### PR TITLE
fix: remove `UseBaseURL` from the go sdk example

### DIFF
--- a/tools/cli/internal/openapi/filter/code_sample_test.go
+++ b/tools/cli/internal/openapi/filter/code_sample_test.go
@@ -94,9 +94,7 @@ func TestCodeSampleFilter(t *testing.T) {
 										"\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n" +
 										"\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n" +
 										"\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n" +
-										"\tclient, err := sdk.NewClient(\n" +
-										"\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n" +
-										"\t\tsdk.UseBaseURL(url))\n\n" +
+										"\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n" +
 										"\tif err != nil {\n" + "\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n" +
 										"\tparams = &sdk.TestOperationIDApiParams{}\n" +
 										"\tsdkResp, httpResp, err := client.TestTagApi.\n" +

--- a/tools/cli/internal/openapi/filter/template/go_sdk_code_sample.go.tmpl
+++ b/tools/cli/internal/openapi/filter/template/go_sdk_code_sample.go.tmpl
@@ -11,9 +11,7 @@ func main() {
   clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
   // See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-  client, err := sdk.NewClient(
-    sdk.UseOAuthAuth(clientID, clientSecret),
-    sdk.UseBaseURL(url))
+  client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
   if err != nil {
 	log.Fatalf("Error: %v", err)

--- a/tools/cli/test/data/split/dev/openapi-v2-2023-01-01.json
+++ b/tools/cli/test/data/split/dev/openapi-v2-2023-01-01.json
@@ -34439,7 +34439,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSystemStatusApiParams{}\n\tsdkResp, httpResp, err := client.RootApi.\n\t\tGetSystemStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSystemStatusApiParams{}\n\tsdkResp, httpResp, err := client.RootApi.\n\t\tGetSystemStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -34506,7 +34506,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationMatchersFieldNamesApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationMatchersFieldNamesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationMatchersFieldNamesApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationMatchersFieldNamesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -34579,7 +34579,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersForAllProjectsApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListClustersForAllProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersForAllProjectsApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListClustersForAllProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -34652,7 +34652,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListEventTypesApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListEventTypesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListEventTypesApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListEventTypesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -34716,7 +34716,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederationAppApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tDeleteFederationAppWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederationAppApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tDeleteFederationAppWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -34792,7 +34792,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListConnectedOrgConfigsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListConnectedOrgConfigsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListConnectedOrgConfigsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListConnectedOrgConfigsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -34875,7 +34875,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveConnectedOrgConfigApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tRemoveConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveConnectedOrgConfigApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tRemoveConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -34956,7 +34956,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -35048,7 +35048,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -35121,7 +35121,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListRoleMappingsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListRoleMappingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListRoleMappingsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListRoleMappingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -35203,7 +35203,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tCreateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tCreateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -35286,7 +35286,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteRoleMappingApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tDeleteRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteRoleMappingApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tDeleteRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -35370,7 +35370,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -35465,7 +35465,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -35573,7 +35573,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIdentityProvidersApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListIdentityProvidersWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIdentityProvidersApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListIdentityProvidersWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -35657,7 +35657,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -35748,7 +35748,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -35819,7 +35819,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderMetadataApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetIdentityProviderMetadataWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderMetadataApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetIdentityProviderMetadataWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -35895,7 +35895,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -35991,7 +35991,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tCreateProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tCreateProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36075,7 +36075,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectByNameApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectByNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectByNameApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectByNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36145,7 +36145,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36213,7 +36213,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36298,7 +36298,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36378,7 +36378,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectIpAccessListsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tListProjectIpAccessListsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectIpAccessListsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tListProjectIpAccessListsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36476,7 +36476,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectIpAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tCreateProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectIpAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tCreateProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36561,7 +36561,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectIpAccessListApiParams{}\n\thttpResp, err := client.ProjectIPAccessListApi.\n\t\tDeleteProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectIpAccessListApiParams{}\n\thttpResp, err := client.ProjectIPAccessListApi.\n\t\tDeleteProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36647,7 +36647,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpListApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tGetProjectIpListWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpListApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tGetProjectIpListWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36734,7 +36734,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpAccessListStatusApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tGetProjectIpAccessListStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpAccessListStatusApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tGetProjectIpAccessListStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36810,7 +36810,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36889,7 +36889,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tCreateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tCreateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36969,7 +36969,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAlertConfigurationApiParams{}\n\thttpResp, err := client.AlertConfigurationsApi.\n\t\tDeleteAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAlertConfigurationApiParams{}\n\thttpResp, err := client.AlertConfigurationsApi.\n\t\tDeleteAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37050,7 +37050,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tGetAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tGetAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37142,7 +37142,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tToggleAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tToggleAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37237,7 +37237,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tUpdateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tUpdateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37329,7 +37329,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsByAlertConfigurationIdApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tListAlertsByAlertConfigurationIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsByAlertConfigurationIdApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tListAlertsByAlertConfigurationIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37421,7 +37421,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tListAlertsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tListAlertsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37503,7 +37503,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tGetAlertWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tGetAlertWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37598,7 +37598,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AcknowledgeAlertApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tAcknowledgeAlertWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AcknowledgeAlertApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tAcknowledgeAlertWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37690,7 +37690,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsByAlertIdApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationsByAlertIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsByAlertIdApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationsByAlertIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37770,7 +37770,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectApiKeysApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListProjectApiKeysWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectApiKeysApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListProjectApiKeysWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37846,7 +37846,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37932,7 +37932,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectApiKeyApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tRemoveProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectApiKeyApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tRemoveProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38032,7 +38032,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyRolesApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyRolesApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38123,7 +38123,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tAddProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tAddProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38190,7 +38190,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AuditingApi.\n\t\tGetAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AuditingApi.\n\t\tGetAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38269,7 +38269,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AuditingApi.\n\t\tUpdateAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AuditingApi.\n\t\tUpdateAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38336,7 +38336,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := client.AWSClustersDNSApi.\n\t\tGetAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := client.AWSClustersDNSApi.\n\t\tGetAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38412,7 +38412,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := client.AWSClustersDNSApi.\n\t\tToggleAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := client.AWSClustersDNSApi.\n\t\tToggleAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38489,7 +38489,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListExportBucketsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListExportBucketsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListExportBucketsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListExportBucketsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38575,7 +38575,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateExportBucketApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateExportBucketWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateExportBucketApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateExportBucketWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38659,7 +38659,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteExportBucketApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteExportBucketWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteExportBucketApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteExportBucketWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38738,7 +38738,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetExportBucketApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetExportBucketWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetExportBucketApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetExportBucketWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38810,7 +38810,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38905,7 +38905,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38973,7 +38973,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderAccessRolesApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tListCloudProviderAccessRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderAccessRolesApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tListCloudProviderAccessRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39053,7 +39053,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tCreateCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tCreateCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39144,7 +39144,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeauthorizeCloudProviderAccessRoleApiParams{}\n\thttpResp, err := client.CloudProviderAccessApi.\n\t\tDeauthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeauthorizeCloudProviderAccessRoleApiParams{}\n\thttpResp, err := client.CloudProviderAccessApi.\n\t\tDeauthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39223,7 +39223,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tGetCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tGetCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39321,7 +39321,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AuthorizeCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tAuthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AuthorizeCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tAuthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39407,7 +39407,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListClustersWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListClustersWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39497,7 +39497,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tCreateClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tCreateClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39593,7 +39593,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderRegionsApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListCloudProviderRegionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderRegionsApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListCloudProviderRegionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39683,7 +39683,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpgradeSharedClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpgradeSharedClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39773,7 +39773,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterToServerlessApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpgradeSharedClusterToServerlessWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterToServerlessApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpgradeSharedClusterToServerlessWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39867,7 +39867,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteClusterApiParams{}\n\thttpResp, err := client.ClustersApi.\n\t\tDeleteClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteClusterApiParams{}\n\thttpResp, err := client.ClustersApi.\n\t\tDeleteClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39952,7 +39952,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40051,7 +40051,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpdateClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpdateClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40140,7 +40140,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupExportJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListBackupExportJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupExportJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListBackupExportJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40234,7 +40234,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40319,7 +40319,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40407,7 +40407,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40504,7 +40504,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40598,7 +40598,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CancelBackupRestoreJobApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tCancelBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CancelBackupRestoreJobApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tCancelBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40687,7 +40687,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40767,7 +40767,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllBackupSchedulesApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteAllBackupSchedulesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllBackupSchedulesApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteAllBackupSchedulesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40846,7 +40846,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40939,7 +40939,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41031,7 +41031,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListReplicaSetBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListReplicaSetBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListReplicaSetBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListReplicaSetBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41122,7 +41122,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TakeSnapshotApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tTakeSnapshotWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TakeSnapshotApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tTakeSnapshotWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41213,7 +41213,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteShardedClusterBackupApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteShardedClusterBackupApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41305,7 +41305,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetShardedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetShardedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41387,7 +41387,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListShardedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListShardedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListShardedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListShardedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41481,7 +41481,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteReplicaSetBackupApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteReplicaSetBackupApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41573,7 +41573,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetReplicaSetBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetReplicaSetBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41676,7 +41676,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateSnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateSnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateSnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateSnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41778,7 +41778,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tDownloadSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tDownloadSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41877,7 +41877,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tCreateSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tCreateSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41959,7 +41959,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tListSharedClusterBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tListSharedClusterBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42053,7 +42053,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tGetSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tGetSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42135,7 +42135,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tListSharedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tListSharedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42229,7 +42229,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tGetSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tGetSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42318,7 +42318,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupCheckpointsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacyBackupCheckpointsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupCheckpointsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacyBackupCheckpointsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42416,7 +42416,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupCheckpointApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacyBackupCheckpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupCheckpointApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacyBackupCheckpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42517,7 +42517,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tCreateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tCreateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42623,7 +42623,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasSearchIndexesDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tListAtlasSearchIndexesDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasSearchIndexesDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tListAtlasSearchIndexesDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42723,7 +42723,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchIndexDeprecatedApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchIndexDeprecatedApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42818,7 +42818,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42930,7 +42930,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43015,7 +43015,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tGetManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tGetManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43100,7 +43100,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllCustomZoneMappingsApiParams{}\n\thttpResp, err := client.GlobalClustersApi.\n\t\tDeleteAllCustomZoneMappingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllCustomZoneMappingsApiParams{}\n\thttpResp, err := client.GlobalClustersApi.\n\t\tDeleteAllCustomZoneMappingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43197,7 +43197,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomZoneMappingApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tCreateCustomZoneMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomZoneMappingApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tCreateCustomZoneMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43301,7 +43301,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteManagedNamespaceApiParams{}\n\thttpResp, err := client.GlobalClustersApi.\n\t\tDeleteManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteManagedNamespaceApiParams{}\n\thttpResp, err := client.GlobalClustersApi.\n\t\tDeleteManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43401,7 +43401,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tCreateManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tCreateManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43587,7 +43587,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRollingIndexApiParams{}\n\tsdkResp, httpResp, err := client.RollingIndexApi.\n\t\tCreateRollingIndexWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRollingIndexApiParams{}\n\tsdkResp, httpResp, err := client.RollingIndexApi.\n\t\tCreateRollingIndexWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43679,7 +43679,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOnlineArchivesApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tListOnlineArchivesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOnlineArchivesApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tListOnlineArchivesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43780,7 +43780,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tCreateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tCreateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43899,7 +43899,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadOnlineArchiveQueryLogsApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tDownloadOnlineArchiveQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadOnlineArchiveQueryLogsApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tDownloadOnlineArchiveQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43997,7 +43997,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOnlineArchiveApiParams{}\n\thttpResp, err := client.OnlineArchiveApi.\n\t\tDeleteOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOnlineArchiveApiParams{}\n\thttpResp, err := client.OnlineArchiveApi.\n\t\tDeleteOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44096,7 +44096,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tGetOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tGetOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44209,7 +44209,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tUpdateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tUpdateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44298,7 +44298,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EndOutageSimulationApiParams{}\n\thttpResp, err := client.ClusterOutageSimulationApi.\n\t\tEndOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EndOutageSimulationApiParams{}\n\thttpResp, err := client.ClusterOutageSimulationApi.\n\t\tEndOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44385,7 +44385,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := client.ClusterOutageSimulationApi.\n\t\tGetOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := client.ClusterOutageSimulationApi.\n\t\tGetOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44480,7 +44480,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.StartOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := client.ClusterOutageSimulationApi.\n\t\tStartOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.StartOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := client.ClusterOutageSimulationApi.\n\t\tStartOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44567,7 +44567,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44668,7 +44668,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpdateClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpdateClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44746,7 +44746,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TestFailoverApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tTestFailoverWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TestFailoverApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tTestFailoverWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44850,7 +44850,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacyBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacyBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44942,7 +44942,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tCreateLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tCreateLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45037,7 +45037,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45120,7 +45120,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchDeploymentApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchDeploymentApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45202,7 +45202,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45298,7 +45298,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45394,7 +45394,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tCreateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tCreateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45475,7 +45475,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45564,7 +45564,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tUpdateLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tUpdateLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45667,7 +45667,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacySnapshotsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacySnapshotsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacySnapshotsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacySnapshotsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45762,7 +45762,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLegacySnapshotApiParams{}\n\thttpResp, err := client.LegacyBackupApi.\n\t\tDeleteLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLegacySnapshotApiParams{}\n\thttpResp, err := client.LegacyBackupApi.\n\t\tDeleteLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45852,7 +45852,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45953,7 +45953,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tUpdateLegacySnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tUpdateLegacySnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46032,7 +46032,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterStatusApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterStatusApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46160,7 +46160,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostLogsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetHostLogsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostLogsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetHostLogsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46255,7 +46255,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainerByCloudProviderApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringContainerByCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainerByCloudProviderApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringContainerByCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46343,7 +46343,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tCreatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tCreatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46419,7 +46419,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainersApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringContainersWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainersApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringContainersWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46508,7 +46508,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringContainerApiParams{}\n\thttpResp, err := client.NetworkPeeringApi.\n\t\tDeletePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringContainerApiParams{}\n\thttpResp, err := client.NetworkPeeringApi.\n\t\tDeletePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46586,7 +46586,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tGetPeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tGetPeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46687,7 +46687,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tUpdatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tUpdatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46757,7 +46757,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCustomDatabaseRolesApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tListCustomDatabaseRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCustomDatabaseRolesApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tListCustomDatabaseRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46845,7 +46845,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tCreateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tCreateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46927,7 +46927,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteCustomDatabaseRoleApiParams{}\n\thttpResp, err := client.CustomDatabaseRolesApi.\n\t\tDeleteCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteCustomDatabaseRoleApiParams{}\n\thttpResp, err := client.CustomDatabaseRolesApi.\n\t\tDeleteCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47004,7 +47004,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tGetCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tGetCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47101,7 +47101,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tUpdateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tUpdateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47184,7 +47184,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListFederatedDatabasesApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tListFederatedDatabasesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListFederatedDatabasesApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tListFederatedDatabasesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47269,7 +47269,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47345,7 +47345,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederatedDatabaseApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederatedDatabaseApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47422,7 +47422,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tGetFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tGetFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47519,7 +47519,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tUpdateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tUpdateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47601,7 +47601,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47689,7 +47689,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOneDataFederationInstanceQueryLimitApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteOneDataFederationInstanceQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOneDataFederationInstanceQueryLimitApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteOneDataFederationInstanceQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47778,7 +47778,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47881,7 +47881,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOneDataFederationQueryLimitApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateOneDataFederationQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOneDataFederationQueryLimitApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateOneDataFederationQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47987,7 +47987,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadFederatedDatabaseQueryLogsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tDownloadFederatedDatabaseQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadFederatedDatabaseQueryLogsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tDownloadFederatedDatabaseQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48063,7 +48063,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUsersApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tListDatabaseUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUsersApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tListDatabaseUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48303,7 +48303,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tCreateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tCreateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48395,7 +48395,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDatabaseUserApiParams{}\n\thttpResp, err := client.DatabaseUsersApi.\n\t\tDeleteDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDatabaseUserApiParams{}\n\thttpResp, err := client.DatabaseUsersApi.\n\t\tDeleteDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48482,7 +48482,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tGetDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tGetDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48589,7 +48589,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tUpdateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tUpdateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48677,7 +48677,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUserCertificatesApiParams{}\n\tsdkResp, httpResp, err := client.X509AuthenticationApi.\n\t\tListDatabaseUserCertificatesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUserCertificatesApiParams{}\n\tsdkResp, httpResp, err := client.X509AuthenticationApi.\n\t\tListDatabaseUserCertificatesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48779,7 +48779,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserCertificateApiParams{}\n\tsdkResp, httpResp, err := client.X509AuthenticationApi.\n\t\tCreateDatabaseUserCertificateWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserCertificateApiParams{}\n\tsdkResp, httpResp, err := client.X509AuthenticationApi.\n\t\tCreateDatabaseUserCertificateWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48912,7 +48912,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByClusterNameApiParams{}\n\tsdkResp, httpResp, err := client.AccessTrackingApi.\n\t\tListAccessLogsByClusterNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByClusterNameApiParams{}\n\tsdkResp, httpResp, err := client.AccessTrackingApi.\n\t\tListAccessLogsByClusterNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49042,7 +49042,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByHostnameApiParams{}\n\tsdkResp, httpResp, err := client.AccessTrackingApi.\n\t\tListAccessLogsByHostnameWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByHostnameApiParams{}\n\tsdkResp, httpResp, err := client.AccessTrackingApi.\n\t\tListAccessLogsByHostnameWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49109,7 +49109,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49194,7 +49194,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tUpdateEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tUpdateEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49273,7 +49273,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointsForCloudProviderApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointsForCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointsForCloudProviderApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointsForCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49361,7 +49361,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tCreateEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tCreateEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49463,7 +49463,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RequestEncryptionAtRestPrivateEndpointDeletionApiParams{}\n\thttpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tRequestEncryptionAtRestPrivateEndpointDeletionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RequestEncryptionAtRestPrivateEndpointDeletionApiParams{}\n\thttpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tRequestEncryptionAtRestPrivateEndpointDeletionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49552,7 +49552,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49695,7 +49695,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectEventsApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListProjectEventsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectEventsApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListProjectEventsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49786,7 +49786,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectEventApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tGetProjectEventWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectEventApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tGetProjectEventWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49856,7 +49856,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListMetricTypesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListMetricTypesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListMetricTypesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListMetricTypesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49972,7 +49972,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50091,7 +50091,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50202,7 +50202,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50284,7 +50284,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListThirdPartyIntegrationsApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tListThirdPartyIntegrationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListThirdPartyIntegrationsApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tListThirdPartyIntegrationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50379,7 +50379,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteThirdPartyIntegrationApiParams{}\n\thttpResp, err := client.Third - PartyIntegrationsApi.\n\t\tDeleteThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteThirdPartyIntegrationApiParams{}\n\thttpResp, err := client.Third - PartyIntegrationsApi.\n\t\tDeleteThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50472,7 +50472,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tGetThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tGetThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50588,7 +50588,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tCreateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tCreateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50701,7 +50701,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tUpdateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tUpdateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50781,7 +50781,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectInvitationsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectInvitationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectInvitationsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectInvitationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50865,7 +50865,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50943,7 +50943,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tCreateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tCreateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51021,7 +51021,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectInvitationApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectInvitationApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51103,7 +51103,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51196,7 +51196,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51267,7 +51267,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnAllIPAddressesApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tReturnAllIPAddressesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnAllIPAddressesApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tReturnAllIPAddressesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51346,7 +51346,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectLimitsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectLimitsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectLimitsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectLimitsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51443,7 +51443,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectLimitApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectLimitApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51541,7 +51541,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51650,7 +51650,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tSetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tSetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51740,7 +51740,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCreatePushMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCreatePushMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51831,7 +51831,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ValidateMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tValidateMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ValidateMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tValidateMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51918,7 +51918,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetValidationStatusApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tGetValidationStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetValidationStatusApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tGetValidationStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51994,7 +51994,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tGetPushMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tGetPushMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52070,7 +52070,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CutoverMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCutoverMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CutoverMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCutoverMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52134,7 +52134,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResetMaintenanceWindowApiParams{}\n\thttpResp, err := client.MaintenanceWindowsApi.\n\t\tResetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResetMaintenanceWindowApiParams{}\n\thttpResp, err := client.MaintenanceWindowsApi.\n\t\tResetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52199,7 +52199,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tGetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tGetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52275,7 +52275,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tUpdateMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tUpdateMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52339,7 +52339,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleMaintenanceAutoDeferApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tToggleMaintenanceAutoDeferWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleMaintenanceAutoDeferApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tToggleMaintenanceAutoDeferWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52403,7 +52403,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeferMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tDeferMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeferMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tDeferMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52470,7 +52470,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedSlowMsApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tGetManagedSlowMsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedSlowMsApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tGetManagedSlowMsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52537,7 +52537,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableSlowOperationThresholdingApiParams{}\n\thttpResp, err := client.PerformanceAdvisorApi.\n\t\tDisableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableSlowOperationThresholdingApiParams{}\n\thttpResp, err := client.PerformanceAdvisorApi.\n\t\tDisableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52604,7 +52604,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EnableSlowOperationThresholdingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tEnableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EnableSlowOperationThresholdingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tEnableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52732,7 +52732,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLTSVersionsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectLTSVersionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLTSVersionsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectLTSVersionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52825,7 +52825,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringConnectionsApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringConnectionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringConnectionsApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringConnectionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52914,7 +52914,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tCreatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tCreatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52996,7 +52996,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringConnectionApiParams{}\n\thttpResp, err := client.NetworkPeeringApi.\n\t\tDeletePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringConnectionApiParams{}\n\thttpResp, err := client.NetworkPeeringApi.\n\t\tDeletePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53076,7 +53076,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tGetPeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tGetPeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53173,7 +53173,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tUpdatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tUpdatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53243,7 +53243,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelinesApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelinesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelinesApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelinesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53322,7 +53322,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tCreatePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tCreatePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53401,7 +53401,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineApiParams{}\n\thttpResp, err := client.DataLakePipelinesApi.\n\t\tDeletePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineApiParams{}\n\thttpResp, err := client.DataLakePipelinesApi.\n\t\tDeletePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53481,7 +53481,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tGetPipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tGetPipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53575,7 +53575,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tUpdatePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tUpdatePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53660,7 +53660,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSchedulesApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineSchedulesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSchedulesApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineSchedulesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53761,7 +53761,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSnapshotsApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineSnapshotsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSnapshotsApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineSnapshotsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53843,7 +53843,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PausePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tPausePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PausePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tPausePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53925,7 +53925,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResumePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tResumePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResumePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tResumePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54026,7 +54026,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineRunsApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineRunsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineRunsApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineRunsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54121,7 +54121,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineRunDatasetApiParams{}\n\thttpResp, err := client.DataLakePipelinesApi.\n\t\tDeletePipelineRunDatasetWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineRunDatasetApiParams{}\n\thttpResp, err := client.DataLakePipelinesApi.\n\t\tDeletePipelineRunDatasetWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54214,7 +54214,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineRunApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tGetPipelineRunWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineRunApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tGetPipelineRunWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54307,7 +54307,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TriggerSnapshotIngestionApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tTriggerSnapshotIngestionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TriggerSnapshotIngestionApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tTriggerSnapshotIngestionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54389,7 +54389,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54459,7 +54459,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54538,7 +54538,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tToggleRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tToggleRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54619,7 +54619,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tListServerlessPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tListServerlessPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54710,7 +54710,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tCreateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tCreateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54800,7 +54800,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessPrivateEndpointApiParams{}\n\thttpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tDeleteServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessPrivateEndpointApiParams{}\n\thttpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tDeleteServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54888,7 +54888,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tGetServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tGetServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54987,7 +54987,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tUpdateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tUpdateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55072,7 +55072,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPrivateEndpointServicesApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tListPrivateEndpointServicesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPrivateEndpointServicesApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tListPrivateEndpointServicesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55166,7 +55166,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointServiceApiParams{}\n\thttpResp, err := client.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointServiceApiParams{}\n\thttpResp, err := client.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55261,7 +55261,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55375,7 +55375,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55479,7 +55479,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointApiParams{}\n\thttpResp, err := client.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointApiParams{}\n\thttpResp, err := client.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55584,7 +55584,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55656,7 +55656,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyConnectViaPeeringOnlyModeForOneProjectApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tVerifyConnectViaPeeringOnlyModeForOneProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyConnectViaPeeringOnlyModeForOneProjectApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tVerifyConnectViaPeeringOnlyModeForOneProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55740,7 +55740,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisablePeeringApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tDisablePeeringWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisablePeeringApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tDisablePeeringWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55822,7 +55822,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDataFederationPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tListDataFederationPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDataFederationPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tListDataFederationPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55901,7 +55901,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55983,7 +55983,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDataFederationPrivateEndpointApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDataFederationPrivateEndpointApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56066,7 +56066,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tGetDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tGetDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56142,7 +56142,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasProcessesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListAtlasProcessesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasProcessesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListAtlasProcessesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56220,7 +56220,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasProcessApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetAtlasProcessWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasProcessApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetAtlasProcessWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56307,7 +56307,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabasesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDatabasesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabasesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDatabasesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56394,7 +56394,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56520,7 +56520,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDatabaseMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDatabaseMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56607,7 +56607,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskPartitionsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDiskPartitionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskPartitionsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDiskPartitionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56691,7 +56691,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56826,7 +56826,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57068,7 +57068,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetHostMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetHostMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57164,7 +57164,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueryNamespacesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSlowQueryNamespacesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueryNamespacesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSlowQueryNamespacesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57284,7 +57284,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueriesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSlowQueriesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueriesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSlowQueriesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57420,7 +57420,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSuggestedIndexesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSuggestedIndexesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSuggestedIndexesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSuggestedIndexesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57493,7 +57493,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePushBasedLogConfigurationApiParams{}\n\thttpResp, err := client.Push - BasedLogExportApi.\n\t\tDeletePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePushBasedLogConfigurationApiParams{}\n\thttpResp, err := client.Push - BasedLogExportApi.\n\t\tDeletePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57564,7 +57564,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tGetPushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tGetPushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57647,7 +57647,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tUpdatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tUpdatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57730,7 +57730,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tCreatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tCreatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57812,7 +57812,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.LoadSampleDatasetApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tLoadSampleDatasetWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.LoadSampleDatasetApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tLoadSampleDatasetWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57888,7 +57888,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSampleDatasetLoadStatusApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetSampleDatasetLoadStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSampleDatasetLoadStatusApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetSampleDatasetLoadStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57964,7 +57964,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessInstancesApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tListServerlessInstancesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessInstancesApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tListServerlessInstancesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58046,7 +58046,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tCreateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tCreateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58137,7 +58137,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListServerlessBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListServerlessBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58234,7 +58234,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58328,7 +58328,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58419,7 +58419,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListServerlessBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListServerlessBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58511,7 +58511,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetServerlessBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetServerlessBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58590,7 +58590,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tGetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tGetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58673,7 +58673,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tSetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tSetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58758,7 +58758,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessInstanceApiParams{}\n\thttpResp, err := client.ServerlessInstancesApi.\n\t\tDeleteServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessInstanceApiParams{}\n\thttpResp, err := client.ServerlessInstancesApi.\n\t\tDeleteServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58841,7 +58841,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tGetServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tGetServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58932,7 +58932,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tUpdateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tUpdateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59005,7 +59005,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59087,7 +59087,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59172,7 +59172,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectTeamsApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListProjectTeamsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectTeamsApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListProjectTeamsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59264,7 +59264,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddAllTeamsToProjectApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tAddAllTeamsToProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddAllTeamsToProjectApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tAddAllTeamsToProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59350,7 +59350,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectTeamApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tRemoveProjectTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectTeamApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tRemoveProjectTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59451,7 +59451,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateTeamRolesApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tUpdateTeamRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateTeamRolesApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tUpdateTeamRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59518,7 +59518,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59597,7 +59597,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SaveLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tSaveLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SaveLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tSaveLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59661,7 +59661,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableCustomerManagedX509ApiParams{}\n\thttpResp, err := client.X509AuthenticationApi.\n\t\tDisableCustomerManagedX509WithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableCustomerManagedX509ApiParams{}\n\thttpResp, err := client.X509AuthenticationApi.\n\t\tDisableCustomerManagedX509WithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59728,7 +59728,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLDAPConfigurationApiParams{}\n\thttpResp, err := client.LDAPConfigurationApi.\n\t\tDeleteLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLDAPConfigurationApiParams{}\n\thttpResp, err := client.LDAPConfigurationApi.\n\t\tDeleteLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59809,7 +59809,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tVerifyLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tVerifyLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59888,7 +59888,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationStatusApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationStatusApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59982,7 +59982,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectUsersApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectUsersApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60064,7 +60064,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectUserApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tRemoveProjectUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectUserApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tRemoveProjectUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60160,7 +60160,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectRolesApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectRolesApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60250,7 +60250,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60335,7 +60335,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60411,7 +60411,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60485,7 +60485,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60570,7 +60570,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tRenameOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tRenameOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60650,7 +60650,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeysApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListApiKeysWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeysApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListApiKeysWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60730,7 +60730,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60813,7 +60813,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60894,7 +60894,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60989,7 +60989,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61081,7 +61081,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeyAccessListsEntriesApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListApiKeyAccessListsEntriesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeyAccessListsEntriesApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListApiKeyAccessListsEntriesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61187,7 +61187,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61287,7 +61287,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyAccessListEntryApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyAccessListEntryWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyAccessListEntryApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyAccessListEntryWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61382,7 +61382,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61460,7 +61460,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcessApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tCreateCostExplorerQueryProcessWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcessApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tCreateCostExplorerQueryProcessWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61551,7 +61551,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcess_1ApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tCreateCostExplorerQueryProcess_1WithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcess_1ApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tCreateCostExplorerQueryProcess_1WithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61666,7 +61666,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationEventsApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListOrganizationEventsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationEventsApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListOrganizationEventsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61757,7 +61757,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationEventApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tGetOrganizationEventWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationEventApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tGetOrganizationEventWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61830,7 +61830,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetFederationSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetFederationSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61920,7 +61920,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationProjectsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationProjectsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62005,7 +62005,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationInvitationsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationInvitationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationInvitationsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationInvitationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62087,7 +62087,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62169,7 +62169,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62251,7 +62251,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationInvitationApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationInvitationApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62331,7 +62331,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62425,7 +62425,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62583,7 +62583,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListInvoicesApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tListInvoicesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListInvoicesApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tListInvoicesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62653,7 +62653,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPendingInvoicesApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tListPendingInvoicesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPendingInvoicesApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tListPendingInvoicesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62741,7 +62741,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetInvoiceApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tGetInvoiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetInvoiceApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tGetInvoiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62822,7 +62822,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadInvoiceCSVApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tDownloadInvoiceCSVWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadInvoiceCSVApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tDownloadInvoiceCSVWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62895,7 +62895,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSourceProjectsApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tListSourceProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSourceProjectsApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tListSourceProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62962,7 +62962,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLinkTokenApiParams{}\n\thttpResp, err := client.CloudMigrationServiceApi.\n\t\tDeleteLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLinkTokenApiParams{}\n\thttpResp, err := client.CloudMigrationServiceApi.\n\t\tDeleteLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63041,7 +63041,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLinkTokenApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCreateLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLinkTokenApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCreateLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63114,7 +63114,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63196,7 +63196,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63282,7 +63282,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationTeamsApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListOrganizationTeamsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationTeamsApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListOrganizationTeamsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63371,7 +63371,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateTeamApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tCreateTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateTeamApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tCreateTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63457,7 +63457,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByNameApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tGetTeamByNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByNameApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tGetTeamByNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63546,7 +63546,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteTeamApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tDeleteTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteTeamApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tDeleteTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63633,7 +63633,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByIdApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tGetTeamByIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByIdApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tGetTeamByIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63734,7 +63734,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameTeamApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tRenameTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameTeamApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tRenameTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63832,7 +63832,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListTeamUsersApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListTeamUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListTeamUsersApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListTeamUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63936,7 +63936,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddTeamUserApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tAddTeamUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddTeamUserApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tAddTeamUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64034,7 +64034,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveTeamUserApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tRemoveTeamUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveTeamUserApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tRemoveTeamUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64116,7 +64116,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationUsersApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationUsersApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64201,7 +64201,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveOrganizationUserApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tRemoveOrganizationUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveOrganizationUserApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tRemoveOrganizationUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64297,7 +64297,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationRolesApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationRolesApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64375,7 +64375,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateUserApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tCreateUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateUserApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tCreateUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64452,7 +64452,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserByUsernameApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tGetUserByUsernameWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserByUsernameApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tGetUserByUsernameWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64531,7 +64531,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tGetUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tGetUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",

--- a/tools/cli/test/data/split/dev/openapi-v2-2023-01-01.yaml
+++ b/tools/cli/test/data/split/dev/openapi-v2-2023-01-01.yaml
@@ -28312,9 +28312,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -28384,9 +28382,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -28457,9 +28453,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -28530,9 +28524,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -28601,9 +28593,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -28677,9 +28667,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -28761,9 +28749,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -28844,9 +28830,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -28934,9 +28918,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -29013,9 +28995,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -29094,9 +29074,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -29181,9 +29159,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -29265,9 +29241,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -29356,9 +29330,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -29458,9 +29430,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -29542,9 +29512,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -29634,9 +29602,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -29713,9 +29679,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -29788,9 +29752,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -29880,9 +29842,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -29957,9 +29917,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30029,9 +29987,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30112,9 +30068,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30193,9 +30147,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30282,9 +30234,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30375,9 +30325,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30460,9 +30408,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30545,9 +30491,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30622,9 +30566,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30704,9 +30646,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30792,9 +30732,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30877,9 +30815,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30971,9 +30907,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31071,9 +31005,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31164,9 +31096,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31252,9 +31182,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31337,9 +31265,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31431,9 +31357,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31524,9 +31448,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31601,9 +31523,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31678,9 +31598,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31767,9 +31685,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31858,9 +31774,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31950,9 +31864,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32025,9 +31937,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32104,9 +32014,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32179,9 +32087,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32256,9 +32162,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32335,9 +32239,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32420,9 +32322,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32509,9 +32409,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32591,9 +32489,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32666,9 +32562,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32757,9 +32651,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32833,9 +32725,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32913,9 +32803,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33005,9 +32893,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33085,9 +32971,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33178,9 +33062,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33263,9 +33145,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33350,9 +33230,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33445,9 +33323,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33530,9 +33406,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33624,9 +33498,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33712,9 +33584,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33803,9 +33673,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33892,9 +33760,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33975,9 +33841,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34070,9 +33934,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34165,9 +34027,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34253,9 +34113,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34335,9 +34193,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34416,9 +34272,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34509,9 +34363,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34599,9 +34451,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34690,9 +34540,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34785,9 +34633,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34875,9 +34721,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34972,9 +34816,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35065,9 +34907,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35155,9 +34995,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35237,9 +35075,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35332,9 +35168,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35429,9 +35263,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35515,9 +35347,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35606,9 +35436,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35688,9 +35516,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35779,9 +35605,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35863,9 +35687,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35957,9 +35779,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36052,9 +35872,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36155,9 +35973,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36251,9 +36067,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36344,9 +36158,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36448,9 +36260,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36537,9 +36347,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36622,9 +36430,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36715,9 +36521,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36816,9 +36620,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36911,9 +36713,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37071,9 +36871,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37161,9 +36959,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37256,9 +37052,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37354,9 +37148,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37449,9 +37241,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37553,9 +37343,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37667,9 +37455,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37754,9 +37540,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37840,9 +37624,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37931,9 +37713,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38021,9 +37801,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38117,9 +37895,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38201,9 +37977,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38303,9 +38077,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38392,9 +38164,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38491,9 +38261,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38574,9 +38342,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38657,9 +38423,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38749,9 +38513,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38845,9 +38607,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38934,9 +38694,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39024,9 +38782,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39122,9 +38878,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39214,9 +38968,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39303,9 +39055,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39399,9 +39149,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39483,9 +39231,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39599,9 +39345,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39686,9 +39430,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39772,9 +39514,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39862,9 +39602,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39953,9 +39691,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40038,9 +39774,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40129,9 +39863,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40209,9 +39941,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40304,9 +40034,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40382,9 +40110,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40455,9 +40181,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40540,9 +40264,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40625,9 +40347,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40703,9 +40423,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40794,9 +40512,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40880,9 +40596,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40963,9 +40677,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41044,9 +40756,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41123,9 +40833,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41214,9 +40922,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41299,9 +41005,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41394,9 +41098,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41489,9 +41191,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41594,9 +41294,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41699,9 +41397,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41773,9 +41469,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41949,9 +41643,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42054,9 +41746,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42152,9 +41842,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42263,9 +41951,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42349,9 +42035,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42449,9 +42133,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42570,9 +42252,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42684,9 +42364,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42758,9 +42436,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42853,9 +42529,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42936,9 +42610,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43021,9 +42693,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43120,9 +42790,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43207,9 +42875,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43335,9 +43001,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43426,9 +43090,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43499,9 +43161,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43602,9 +43262,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43704,9 +43362,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43805,9 +43461,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43883,9 +43537,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43976,9 +43628,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44068,9 +43718,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44172,9 +43820,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44278,9 +43924,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44362,9 +44006,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44445,9 +44087,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44528,9 +44168,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44613,9 +44251,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44696,9 +44332,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44787,9 +44421,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44865,9 +44497,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44944,9 +44574,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45055,9 +44683,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45167,9 +44793,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45289,9 +44913,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45387,9 +45009,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45468,9 +45088,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45544,9 +45162,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45635,9 +45251,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45726,9 +45340,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45796,9 +45408,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45866,9 +45476,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45944,9 +45552,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46018,9 +45624,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46092,9 +45696,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46167,9 +45769,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46238,9 +45838,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46309,9 +45907,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46425,9 +46021,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46511,9 +46105,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46597,9 +46189,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46683,9 +46273,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46764,9 +46352,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46856,9 +46442,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46934,9 +46518,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47014,9 +46596,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47099,9 +46679,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47180,9 +46758,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47271,9 +46847,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47359,9 +46933,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47451,9 +47023,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47533,9 +47103,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47619,9 +47187,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47715,9 +47281,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47807,9 +47371,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47898,9 +47460,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47987,9 +47547,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48075,9 +47633,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48166,9 +47722,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48258,9 +47812,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48362,9 +47914,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48464,9 +48014,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48563,9 +48111,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48644,9 +48190,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48721,9 +48265,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48800,9 +48342,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48886,9 +48426,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48978,9 +48516,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49071,9 +48607,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49159,9 +48693,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49254,9 +48786,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49333,9 +48863,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49416,9 +48944,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49498,9 +49024,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49596,9 +49120,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49682,9 +49204,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49765,9 +49285,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49839,9 +49357,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49918,9 +49434,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50000,9 +49514,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50085,9 +49597,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50196,9 +49706,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50278,9 +49786,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50362,9 +49868,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50489,9 +49993,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50727,9 +50229,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50826,9 +50326,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50942,9 +50440,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51065,9 +50561,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51140,9 +50634,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51214,9 +50706,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51296,9 +50786,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51382,9 +50870,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51469,9 +50955,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51552,9 +51036,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51626,9 +51108,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51707,9 +51187,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51796,9 +51274,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51888,9 +51364,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51983,9 +51457,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52068,9 +51540,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52159,9 +51629,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52239,9 +51707,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52323,9 +51789,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52411,9 +51875,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52494,9 +51956,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52582,9 +52042,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52661,9 +52119,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52742,9 +52198,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52826,9 +52280,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52914,9 +52366,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53004,9 +52454,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53099,9 +52547,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53174,9 +52620,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53256,9 +52700,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53333,9 +52775,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53404,9 +52844,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53484,9 +52922,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53568,9 +53004,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53654,9 +53088,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53736,9 +53168,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53827,9 +53257,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53915,9 +53343,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53999,9 +53425,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54083,9 +53507,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54170,9 +53592,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54246,9 +53666,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54329,9 +53747,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54410,9 +53826,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54490,9 +53904,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54577,9 +53989,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54659,9 +54069,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54750,9 +54158,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54840,9 +54246,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54935,9 +54339,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55034,9 +54436,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55126,9 +54526,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55205,9 +54603,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55298,9 +54694,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55404,9 +54798,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55495,9 +54887,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55570,9 +54960,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55661,9 +55049,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55744,9 +55130,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55825,9 +55209,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55910,9 +55292,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55995,9 +55375,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56077,9 +55455,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56167,9 +55543,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56306,9 +55680,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56394,9 +55766,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56483,9 +55853,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56556,9 +55924,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56631,9 +55997,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56703,9 +56067,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56782,9 +56144,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56861,9 +56221,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56942,9 +56300,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57027,9 +56383,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57113,9 +56467,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57204,9 +56556,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57290,9 +56640,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57385,9 +56733,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57480,9 +56826,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57577,9 +56921,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57675,9 +57017,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57759,9 +57099,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57837,9 +57175,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57922,9 +57258,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58013,9 +57347,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58101,9 +57433,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58186,9 +57516,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58265,9 +57593,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)

--- a/tools/cli/test/data/split/dev/openapi-v2-2023-02-01.json
+++ b/tools/cli/test/data/split/dev/openapi-v2-2023-02-01.json
@@ -34884,7 +34884,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSystemStatusApiParams{}\n\tsdkResp, httpResp, err := client.RootApi.\n\t\tGetSystemStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSystemStatusApiParams{}\n\tsdkResp, httpResp, err := client.RootApi.\n\t\tGetSystemStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -34951,7 +34951,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationMatchersFieldNamesApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationMatchersFieldNamesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationMatchersFieldNamesApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationMatchersFieldNamesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -35024,7 +35024,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersForAllProjectsApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListClustersForAllProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersForAllProjectsApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListClustersForAllProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -35097,7 +35097,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListEventTypesApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListEventTypesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListEventTypesApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListEventTypesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -35161,7 +35161,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederationAppApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tDeleteFederationAppWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederationAppApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tDeleteFederationAppWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -35237,7 +35237,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListConnectedOrgConfigsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListConnectedOrgConfigsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListConnectedOrgConfigsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListConnectedOrgConfigsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -35320,7 +35320,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveConnectedOrgConfigApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tRemoveConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveConnectedOrgConfigApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tRemoveConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -35401,7 +35401,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -35493,7 +35493,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -35566,7 +35566,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListRoleMappingsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListRoleMappingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListRoleMappingsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListRoleMappingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -35648,7 +35648,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tCreateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tCreateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -35731,7 +35731,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteRoleMappingApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tDeleteRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteRoleMappingApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tDeleteRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -35815,7 +35815,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -35910,7 +35910,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36018,7 +36018,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIdentityProvidersApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListIdentityProvidersWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIdentityProvidersApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListIdentityProvidersWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36102,7 +36102,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36193,7 +36193,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36264,7 +36264,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderMetadataApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetIdentityProviderMetadataWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderMetadataApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetIdentityProviderMetadataWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36340,7 +36340,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36436,7 +36436,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tCreateProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tCreateProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36520,7 +36520,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectByNameApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectByNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectByNameApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectByNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36590,7 +36590,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36658,7 +36658,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36743,7 +36743,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36829,7 +36829,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddUserToProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tAddUserToProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddUserToProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tAddUserToProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36909,7 +36909,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectIpAccessListsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tListProjectIpAccessListsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectIpAccessListsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tListProjectIpAccessListsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37007,7 +37007,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectIpAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tCreateProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectIpAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tCreateProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37092,7 +37092,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectIpAccessListApiParams{}\n\thttpResp, err := client.ProjectIPAccessListApi.\n\t\tDeleteProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectIpAccessListApiParams{}\n\thttpResp, err := client.ProjectIPAccessListApi.\n\t\tDeleteProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37178,7 +37178,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpListApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tGetProjectIpListWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpListApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tGetProjectIpListWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37265,7 +37265,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpAccessListStatusApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tGetProjectIpAccessListStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpAccessListStatusApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tGetProjectIpAccessListStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37341,7 +37341,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37420,7 +37420,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tCreateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tCreateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37500,7 +37500,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAlertConfigurationApiParams{}\n\thttpResp, err := client.AlertConfigurationsApi.\n\t\tDeleteAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAlertConfigurationApiParams{}\n\thttpResp, err := client.AlertConfigurationsApi.\n\t\tDeleteAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37581,7 +37581,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tGetAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tGetAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37673,7 +37673,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tToggleAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tToggleAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37768,7 +37768,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tUpdateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tUpdateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37860,7 +37860,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsByAlertConfigurationIdApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tListAlertsByAlertConfigurationIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsByAlertConfigurationIdApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tListAlertsByAlertConfigurationIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37952,7 +37952,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tListAlertsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tListAlertsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38034,7 +38034,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tGetAlertWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tGetAlertWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38129,7 +38129,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AcknowledgeAlertApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tAcknowledgeAlertWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AcknowledgeAlertApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tAcknowledgeAlertWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38221,7 +38221,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsByAlertIdApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationsByAlertIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsByAlertIdApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationsByAlertIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38301,7 +38301,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectApiKeysApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListProjectApiKeysWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectApiKeysApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListProjectApiKeysWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38377,7 +38377,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38463,7 +38463,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectApiKeyApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tRemoveProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectApiKeyApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tRemoveProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38563,7 +38563,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyRolesApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyRolesApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38654,7 +38654,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tAddProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tAddProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38721,7 +38721,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AuditingApi.\n\t\tGetAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AuditingApi.\n\t\tGetAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38800,7 +38800,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AuditingApi.\n\t\tUpdateAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AuditingApi.\n\t\tUpdateAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38867,7 +38867,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := client.AWSClustersDNSApi.\n\t\tGetAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := client.AWSClustersDNSApi.\n\t\tGetAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38943,7 +38943,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := client.AWSClustersDNSApi.\n\t\tToggleAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := client.AWSClustersDNSApi.\n\t\tToggleAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39020,7 +39020,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListExportBucketsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListExportBucketsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListExportBucketsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListExportBucketsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39106,7 +39106,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateExportBucketApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateExportBucketWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateExportBucketApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateExportBucketWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39190,7 +39190,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteExportBucketApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteExportBucketWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteExportBucketApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteExportBucketWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39269,7 +39269,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetExportBucketApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetExportBucketWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetExportBucketApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetExportBucketWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39341,7 +39341,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39436,7 +39436,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39504,7 +39504,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderAccessRolesApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tListCloudProviderAccessRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderAccessRolesApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tListCloudProviderAccessRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39584,7 +39584,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tCreateCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tCreateCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39675,7 +39675,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeauthorizeCloudProviderAccessRoleApiParams{}\n\thttpResp, err := client.CloudProviderAccessApi.\n\t\tDeauthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeauthorizeCloudProviderAccessRoleApiParams{}\n\thttpResp, err := client.CloudProviderAccessApi.\n\t\tDeauthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39754,7 +39754,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tGetCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tGetCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39852,7 +39852,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AuthorizeCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tAuthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AuthorizeCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tAuthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39938,7 +39938,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListClustersWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListClustersWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40028,7 +40028,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tCreateClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tCreateClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40124,7 +40124,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderRegionsApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListCloudProviderRegionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderRegionsApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListCloudProviderRegionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40214,7 +40214,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpgradeSharedClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpgradeSharedClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40304,7 +40304,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterToServerlessApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpgradeSharedClusterToServerlessWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterToServerlessApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpgradeSharedClusterToServerlessWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40397,7 +40397,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteClusterApiParams{}\n\thttpResp, err := client.ClustersApi.\n\t\tDeleteClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteClusterApiParams{}\n\thttpResp, err := client.ClustersApi.\n\t\tDeleteClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40481,7 +40481,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40580,7 +40580,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpdateClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpdateClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40669,7 +40669,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupExportJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListBackupExportJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupExportJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListBackupExportJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40763,7 +40763,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40848,7 +40848,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40936,7 +40936,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41033,7 +41033,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41127,7 +41127,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CancelBackupRestoreJobApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tCancelBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CancelBackupRestoreJobApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tCancelBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41216,7 +41216,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41296,7 +41296,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllBackupSchedulesApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteAllBackupSchedulesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllBackupSchedulesApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteAllBackupSchedulesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41375,7 +41375,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41468,7 +41468,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41560,7 +41560,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListReplicaSetBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListReplicaSetBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListReplicaSetBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListReplicaSetBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41651,7 +41651,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TakeSnapshotApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tTakeSnapshotWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TakeSnapshotApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tTakeSnapshotWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41742,7 +41742,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteShardedClusterBackupApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteShardedClusterBackupApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41834,7 +41834,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetShardedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetShardedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41916,7 +41916,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListShardedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListShardedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListShardedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListShardedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42010,7 +42010,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteReplicaSetBackupApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteReplicaSetBackupApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42102,7 +42102,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetReplicaSetBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetReplicaSetBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42205,7 +42205,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateSnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateSnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateSnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateSnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42307,7 +42307,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tDownloadSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tDownloadSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42406,7 +42406,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tCreateSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tCreateSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42488,7 +42488,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tListSharedClusterBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tListSharedClusterBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42582,7 +42582,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tGetSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tGetSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42664,7 +42664,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tListSharedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tListSharedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42758,7 +42758,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tGetSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tGetSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42847,7 +42847,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupCheckpointsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacyBackupCheckpointsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupCheckpointsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacyBackupCheckpointsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42945,7 +42945,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupCheckpointApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacyBackupCheckpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupCheckpointApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacyBackupCheckpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43046,7 +43046,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tCreateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tCreateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43152,7 +43152,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasSearchIndexesDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tListAtlasSearchIndexesDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasSearchIndexesDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tListAtlasSearchIndexesDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43252,7 +43252,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchIndexDeprecatedApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchIndexDeprecatedApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43347,7 +43347,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43459,7 +43459,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43544,7 +43544,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tGetManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tGetManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43629,7 +43629,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllCustomZoneMappingsApiParams{}\n\thttpResp, err := client.GlobalClustersApi.\n\t\tDeleteAllCustomZoneMappingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllCustomZoneMappingsApiParams{}\n\thttpResp, err := client.GlobalClustersApi.\n\t\tDeleteAllCustomZoneMappingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43726,7 +43726,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomZoneMappingApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tCreateCustomZoneMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomZoneMappingApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tCreateCustomZoneMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43830,7 +43830,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteManagedNamespaceApiParams{}\n\thttpResp, err := client.GlobalClustersApi.\n\t\tDeleteManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteManagedNamespaceApiParams{}\n\thttpResp, err := client.GlobalClustersApi.\n\t\tDeleteManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43930,7 +43930,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tCreateManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tCreateManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44116,7 +44116,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRollingIndexApiParams{}\n\tsdkResp, httpResp, err := client.RollingIndexApi.\n\t\tCreateRollingIndexWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRollingIndexApiParams{}\n\tsdkResp, httpResp, err := client.RollingIndexApi.\n\t\tCreateRollingIndexWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44208,7 +44208,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOnlineArchivesApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tListOnlineArchivesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOnlineArchivesApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tListOnlineArchivesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44309,7 +44309,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tCreateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tCreateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44428,7 +44428,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadOnlineArchiveQueryLogsApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tDownloadOnlineArchiveQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadOnlineArchiveQueryLogsApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tDownloadOnlineArchiveQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44526,7 +44526,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOnlineArchiveApiParams{}\n\thttpResp, err := client.OnlineArchiveApi.\n\t\tDeleteOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOnlineArchiveApiParams{}\n\thttpResp, err := client.OnlineArchiveApi.\n\t\tDeleteOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44625,7 +44625,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tGetOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tGetOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44738,7 +44738,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tUpdateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tUpdateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44827,7 +44827,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EndOutageSimulationApiParams{}\n\thttpResp, err := client.ClusterOutageSimulationApi.\n\t\tEndOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EndOutageSimulationApiParams{}\n\thttpResp, err := client.ClusterOutageSimulationApi.\n\t\tEndOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44914,7 +44914,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := client.ClusterOutageSimulationApi.\n\t\tGetOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := client.ClusterOutageSimulationApi.\n\t\tGetOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45009,7 +45009,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.StartOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := client.ClusterOutageSimulationApi.\n\t\tStartOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.StartOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := client.ClusterOutageSimulationApi.\n\t\tStartOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45096,7 +45096,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45197,7 +45197,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpdateClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpdateClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45274,7 +45274,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TestFailoverApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tTestFailoverWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TestFailoverApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tTestFailoverWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45377,7 +45377,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacyBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacyBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45469,7 +45469,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tCreateLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tCreateLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45564,7 +45564,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45647,7 +45647,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchDeploymentApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchDeploymentApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45729,7 +45729,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45825,7 +45825,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45921,7 +45921,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tCreateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tCreateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46002,7 +46002,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46091,7 +46091,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tUpdateLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tUpdateLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46194,7 +46194,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacySnapshotsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacySnapshotsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacySnapshotsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacySnapshotsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46289,7 +46289,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLegacySnapshotApiParams{}\n\thttpResp, err := client.LegacyBackupApi.\n\t\tDeleteLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLegacySnapshotApiParams{}\n\thttpResp, err := client.LegacyBackupApi.\n\t\tDeleteLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46379,7 +46379,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46480,7 +46480,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tUpdateLegacySnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tUpdateLegacySnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46559,7 +46559,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterStatusApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterStatusApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46686,7 +46686,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostLogsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetHostLogsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostLogsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetHostLogsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46780,7 +46780,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainerByCloudProviderApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringContainerByCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainerByCloudProviderApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringContainerByCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46868,7 +46868,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tCreatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tCreatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46944,7 +46944,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainersApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringContainersWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainersApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringContainersWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47033,7 +47033,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringContainerApiParams{}\n\thttpResp, err := client.NetworkPeeringApi.\n\t\tDeletePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringContainerApiParams{}\n\thttpResp, err := client.NetworkPeeringApi.\n\t\tDeletePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47111,7 +47111,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tGetPeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tGetPeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47212,7 +47212,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tUpdatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tUpdatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47282,7 +47282,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCustomDatabaseRolesApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tListCustomDatabaseRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCustomDatabaseRolesApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tListCustomDatabaseRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47370,7 +47370,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tCreateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tCreateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47452,7 +47452,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteCustomDatabaseRoleApiParams{}\n\thttpResp, err := client.CustomDatabaseRolesApi.\n\t\tDeleteCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteCustomDatabaseRoleApiParams{}\n\thttpResp, err := client.CustomDatabaseRolesApi.\n\t\tDeleteCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47529,7 +47529,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tGetCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tGetCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47626,7 +47626,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tUpdateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tUpdateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47709,7 +47709,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListFederatedDatabasesApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tListFederatedDatabasesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListFederatedDatabasesApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tListFederatedDatabasesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47794,7 +47794,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47870,7 +47870,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederatedDatabaseApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederatedDatabaseApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47947,7 +47947,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tGetFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tGetFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48044,7 +48044,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tUpdateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tUpdateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48126,7 +48126,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48214,7 +48214,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOneDataFederationInstanceQueryLimitApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteOneDataFederationInstanceQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOneDataFederationInstanceQueryLimitApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteOneDataFederationInstanceQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48303,7 +48303,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48406,7 +48406,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOneDataFederationQueryLimitApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateOneDataFederationQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOneDataFederationQueryLimitApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateOneDataFederationQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48512,7 +48512,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadFederatedDatabaseQueryLogsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tDownloadFederatedDatabaseQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadFederatedDatabaseQueryLogsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tDownloadFederatedDatabaseQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48588,7 +48588,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUsersApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tListDatabaseUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUsersApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tListDatabaseUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48828,7 +48828,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tCreateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tCreateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48920,7 +48920,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDatabaseUserApiParams{}\n\thttpResp, err := client.DatabaseUsersApi.\n\t\tDeleteDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDatabaseUserApiParams{}\n\thttpResp, err := client.DatabaseUsersApi.\n\t\tDeleteDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49007,7 +49007,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tGetDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tGetDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49114,7 +49114,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tUpdateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tUpdateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49202,7 +49202,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUserCertificatesApiParams{}\n\tsdkResp, httpResp, err := client.X509AuthenticationApi.\n\t\tListDatabaseUserCertificatesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUserCertificatesApiParams{}\n\tsdkResp, httpResp, err := client.X509AuthenticationApi.\n\t\tListDatabaseUserCertificatesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49304,7 +49304,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserCertificateApiParams{}\n\tsdkResp, httpResp, err := client.X509AuthenticationApi.\n\t\tCreateDatabaseUserCertificateWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserCertificateApiParams{}\n\tsdkResp, httpResp, err := client.X509AuthenticationApi.\n\t\tCreateDatabaseUserCertificateWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49437,7 +49437,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByClusterNameApiParams{}\n\tsdkResp, httpResp, err := client.AccessTrackingApi.\n\t\tListAccessLogsByClusterNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByClusterNameApiParams{}\n\tsdkResp, httpResp, err := client.AccessTrackingApi.\n\t\tListAccessLogsByClusterNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49567,7 +49567,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByHostnameApiParams{}\n\tsdkResp, httpResp, err := client.AccessTrackingApi.\n\t\tListAccessLogsByHostnameWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByHostnameApiParams{}\n\tsdkResp, httpResp, err := client.AccessTrackingApi.\n\t\tListAccessLogsByHostnameWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49634,7 +49634,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49719,7 +49719,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tUpdateEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tUpdateEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49798,7 +49798,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointsForCloudProviderApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointsForCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointsForCloudProviderApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointsForCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49886,7 +49886,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tCreateEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tCreateEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49988,7 +49988,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RequestEncryptionAtRestPrivateEndpointDeletionApiParams{}\n\thttpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tRequestEncryptionAtRestPrivateEndpointDeletionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RequestEncryptionAtRestPrivateEndpointDeletionApiParams{}\n\thttpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tRequestEncryptionAtRestPrivateEndpointDeletionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50077,7 +50077,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50220,7 +50220,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectEventsApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListProjectEventsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectEventsApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListProjectEventsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50311,7 +50311,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectEventApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tGetProjectEventWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectEventApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tGetProjectEventWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50381,7 +50381,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListMetricTypesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListMetricTypesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListMetricTypesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListMetricTypesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50497,7 +50497,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50616,7 +50616,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50727,7 +50727,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50809,7 +50809,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListThirdPartyIntegrationsApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tListThirdPartyIntegrationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListThirdPartyIntegrationsApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tListThirdPartyIntegrationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50904,7 +50904,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteThirdPartyIntegrationApiParams{}\n\thttpResp, err := client.Third - PartyIntegrationsApi.\n\t\tDeleteThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteThirdPartyIntegrationApiParams{}\n\thttpResp, err := client.Third - PartyIntegrationsApi.\n\t\tDeleteThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50997,7 +50997,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tGetThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tGetThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51113,7 +51113,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tCreateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tCreateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51226,7 +51226,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tUpdateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tUpdateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51306,7 +51306,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectInvitationsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectInvitationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectInvitationsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectInvitationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51390,7 +51390,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51468,7 +51468,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tCreateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tCreateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51546,7 +51546,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectInvitationApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectInvitationApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51628,7 +51628,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51721,7 +51721,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51792,7 +51792,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnAllIPAddressesApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tReturnAllIPAddressesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnAllIPAddressesApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tReturnAllIPAddressesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51871,7 +51871,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectLimitsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectLimitsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectLimitsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectLimitsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51968,7 +51968,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectLimitApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectLimitApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52066,7 +52066,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52175,7 +52175,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tSetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tSetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52265,7 +52265,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCreatePushMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCreatePushMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52356,7 +52356,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ValidateMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tValidateMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ValidateMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tValidateMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52443,7 +52443,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetValidationStatusApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tGetValidationStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetValidationStatusApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tGetValidationStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52519,7 +52519,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tGetPushMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tGetPushMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52595,7 +52595,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CutoverMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCutoverMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CutoverMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCutoverMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52659,7 +52659,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResetMaintenanceWindowApiParams{}\n\thttpResp, err := client.MaintenanceWindowsApi.\n\t\tResetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResetMaintenanceWindowApiParams{}\n\thttpResp, err := client.MaintenanceWindowsApi.\n\t\tResetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52724,7 +52724,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tGetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tGetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52800,7 +52800,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tUpdateMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tUpdateMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52864,7 +52864,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleMaintenanceAutoDeferApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tToggleMaintenanceAutoDeferWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleMaintenanceAutoDeferApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tToggleMaintenanceAutoDeferWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52928,7 +52928,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeferMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tDeferMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeferMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tDeferMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52995,7 +52995,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedSlowMsApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tGetManagedSlowMsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedSlowMsApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tGetManagedSlowMsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53062,7 +53062,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableSlowOperationThresholdingApiParams{}\n\thttpResp, err := client.PerformanceAdvisorApi.\n\t\tDisableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableSlowOperationThresholdingApiParams{}\n\thttpResp, err := client.PerformanceAdvisorApi.\n\t\tDisableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53129,7 +53129,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EnableSlowOperationThresholdingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tEnableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EnableSlowOperationThresholdingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tEnableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53257,7 +53257,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLTSVersionsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectLTSVersionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLTSVersionsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectLTSVersionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53350,7 +53350,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringConnectionsApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringConnectionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringConnectionsApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringConnectionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53439,7 +53439,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tCreatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tCreatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53521,7 +53521,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringConnectionApiParams{}\n\thttpResp, err := client.NetworkPeeringApi.\n\t\tDeletePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringConnectionApiParams{}\n\thttpResp, err := client.NetworkPeeringApi.\n\t\tDeletePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53601,7 +53601,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tGetPeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tGetPeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53698,7 +53698,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tUpdatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tUpdatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53768,7 +53768,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelinesApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelinesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelinesApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelinesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53847,7 +53847,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tCreatePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tCreatePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53926,7 +53926,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineApiParams{}\n\thttpResp, err := client.DataLakePipelinesApi.\n\t\tDeletePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineApiParams{}\n\thttpResp, err := client.DataLakePipelinesApi.\n\t\tDeletePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54006,7 +54006,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tGetPipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tGetPipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54100,7 +54100,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tUpdatePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tUpdatePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54185,7 +54185,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSchedulesApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineSchedulesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSchedulesApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineSchedulesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54286,7 +54286,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSnapshotsApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineSnapshotsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSnapshotsApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineSnapshotsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54368,7 +54368,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PausePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tPausePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PausePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tPausePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54450,7 +54450,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResumePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tResumePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResumePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tResumePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54551,7 +54551,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineRunsApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineRunsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineRunsApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineRunsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54646,7 +54646,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineRunDatasetApiParams{}\n\thttpResp, err := client.DataLakePipelinesApi.\n\t\tDeletePipelineRunDatasetWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineRunDatasetApiParams{}\n\thttpResp, err := client.DataLakePipelinesApi.\n\t\tDeletePipelineRunDatasetWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54739,7 +54739,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineRunApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tGetPipelineRunWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineRunApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tGetPipelineRunWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54832,7 +54832,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TriggerSnapshotIngestionApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tTriggerSnapshotIngestionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TriggerSnapshotIngestionApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tTriggerSnapshotIngestionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54914,7 +54914,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54984,7 +54984,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55063,7 +55063,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tToggleRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tToggleRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55144,7 +55144,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tListServerlessPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tListServerlessPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55235,7 +55235,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tCreateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tCreateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55325,7 +55325,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessPrivateEndpointApiParams{}\n\thttpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tDeleteServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessPrivateEndpointApiParams{}\n\thttpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tDeleteServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55413,7 +55413,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tGetServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tGetServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55512,7 +55512,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tUpdateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tUpdateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55597,7 +55597,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPrivateEndpointServicesApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tListPrivateEndpointServicesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPrivateEndpointServicesApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tListPrivateEndpointServicesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55691,7 +55691,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointServiceApiParams{}\n\thttpResp, err := client.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointServiceApiParams{}\n\thttpResp, err := client.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55786,7 +55786,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55900,7 +55900,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56004,7 +56004,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointApiParams{}\n\thttpResp, err := client.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointApiParams{}\n\thttpResp, err := client.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56109,7 +56109,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56181,7 +56181,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyConnectViaPeeringOnlyModeForOneProjectApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tVerifyConnectViaPeeringOnlyModeForOneProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyConnectViaPeeringOnlyModeForOneProjectApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tVerifyConnectViaPeeringOnlyModeForOneProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56265,7 +56265,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisablePeeringApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tDisablePeeringWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisablePeeringApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tDisablePeeringWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56347,7 +56347,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDataFederationPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tListDataFederationPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDataFederationPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tListDataFederationPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56426,7 +56426,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56508,7 +56508,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDataFederationPrivateEndpointApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDataFederationPrivateEndpointApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56591,7 +56591,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tGetDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tGetDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56667,7 +56667,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasProcessesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListAtlasProcessesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasProcessesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListAtlasProcessesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56745,7 +56745,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasProcessApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetAtlasProcessWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasProcessApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetAtlasProcessWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56832,7 +56832,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabasesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDatabasesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabasesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDatabasesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56919,7 +56919,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57045,7 +57045,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDatabaseMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDatabaseMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57132,7 +57132,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskPartitionsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDiskPartitionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskPartitionsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDiskPartitionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57216,7 +57216,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57351,7 +57351,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57593,7 +57593,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetHostMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetHostMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57689,7 +57689,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueryNamespacesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSlowQueryNamespacesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueryNamespacesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSlowQueryNamespacesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57809,7 +57809,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueriesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSlowQueriesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueriesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSlowQueriesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57945,7 +57945,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSuggestedIndexesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSuggestedIndexesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSuggestedIndexesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSuggestedIndexesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58018,7 +58018,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePushBasedLogConfigurationApiParams{}\n\thttpResp, err := client.Push - BasedLogExportApi.\n\t\tDeletePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePushBasedLogConfigurationApiParams{}\n\thttpResp, err := client.Push - BasedLogExportApi.\n\t\tDeletePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58089,7 +58089,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tGetPushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tGetPushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58172,7 +58172,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tUpdatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tUpdatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58255,7 +58255,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tCreatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tCreatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58337,7 +58337,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.LoadSampleDatasetApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tLoadSampleDatasetWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.LoadSampleDatasetApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tLoadSampleDatasetWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58413,7 +58413,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSampleDatasetLoadStatusApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetSampleDatasetLoadStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSampleDatasetLoadStatusApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetSampleDatasetLoadStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58489,7 +58489,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessInstancesApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tListServerlessInstancesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessInstancesApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tListServerlessInstancesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58571,7 +58571,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tCreateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tCreateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58662,7 +58662,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListServerlessBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListServerlessBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58759,7 +58759,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58853,7 +58853,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58944,7 +58944,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListServerlessBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListServerlessBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59036,7 +59036,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetServerlessBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetServerlessBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59115,7 +59115,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tGetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tGetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59198,7 +59198,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tSetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tSetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59283,7 +59283,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessInstanceApiParams{}\n\thttpResp, err := client.ServerlessInstancesApi.\n\t\tDeleteServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessInstanceApiParams{}\n\thttpResp, err := client.ServerlessInstancesApi.\n\t\tDeleteServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59366,7 +59366,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tGetServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tGetServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59457,7 +59457,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tUpdateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tUpdateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59530,7 +59530,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59612,7 +59612,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59685,7 +59685,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamInstancesApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tListStreamInstancesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamInstancesApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tListStreamInstancesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59764,7 +59764,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tCreateStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tCreateStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59846,7 +59846,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamInstanceApiParams{}\n\thttpResp, err := client.StreamsApi.\n\t\tDeleteStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamInstanceApiParams{}\n\thttpResp, err := client.StreamsApi.\n\t\tDeleteStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59931,7 +59931,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tGetStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tGetStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60025,7 +60025,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tUpdateStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tUpdateStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60134,7 +60134,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadStreamTenantAuditLogsApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tDownloadStreamTenantAuditLogsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadStreamTenantAuditLogsApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tDownloadStreamTenantAuditLogsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60219,7 +60219,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamConnectionsApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tListStreamConnectionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamConnectionsApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tListStreamConnectionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60310,7 +60310,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tCreateStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tCreateStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60401,7 +60401,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamConnectionApiParams{}\n\thttpResp, err := client.StreamsApi.\n\t\tDeleteStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamConnectionApiParams{}\n\thttpResp, err := client.StreamsApi.\n\t\tDeleteStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60484,7 +60484,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tGetStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tGetStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60587,7 +60587,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tUpdateStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tUpdateStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60672,7 +60672,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectTeamsApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListProjectTeamsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectTeamsApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListProjectTeamsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60764,7 +60764,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddAllTeamsToProjectApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tAddAllTeamsToProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddAllTeamsToProjectApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tAddAllTeamsToProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60850,7 +60850,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectTeamApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tRemoveProjectTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectTeamApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tRemoveProjectTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60951,7 +60951,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateTeamRolesApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tUpdateTeamRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateTeamRolesApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tUpdateTeamRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61018,7 +61018,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61097,7 +61097,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SaveLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tSaveLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SaveLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tSaveLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61161,7 +61161,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableCustomerManagedX509ApiParams{}\n\thttpResp, err := client.X509AuthenticationApi.\n\t\tDisableCustomerManagedX509WithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableCustomerManagedX509ApiParams{}\n\thttpResp, err := client.X509AuthenticationApi.\n\t\tDisableCustomerManagedX509WithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61228,7 +61228,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLDAPConfigurationApiParams{}\n\thttpResp, err := client.LDAPConfigurationApi.\n\t\tDeleteLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLDAPConfigurationApiParams{}\n\thttpResp, err := client.LDAPConfigurationApi.\n\t\tDeleteLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61309,7 +61309,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tVerifyLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tVerifyLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61388,7 +61388,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationStatusApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationStatusApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61482,7 +61482,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectUsersApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectUsersApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61564,7 +61564,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectUserApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tRemoveProjectUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectUserApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tRemoveProjectUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61660,7 +61660,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectRolesApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectRolesApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61750,7 +61750,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61835,7 +61835,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61911,7 +61911,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61985,7 +61985,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62070,7 +62070,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tRenameOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tRenameOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62150,7 +62150,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeysApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListApiKeysWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeysApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListApiKeysWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62230,7 +62230,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62313,7 +62313,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62394,7 +62394,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62489,7 +62489,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62581,7 +62581,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeyAccessListsEntriesApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListApiKeyAccessListsEntriesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeyAccessListsEntriesApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListApiKeyAccessListsEntriesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62687,7 +62687,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62787,7 +62787,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyAccessListEntryApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyAccessListEntryWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyAccessListEntryApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyAccessListEntryWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62882,7 +62882,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62960,7 +62960,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcessApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tCreateCostExplorerQueryProcessWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcessApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tCreateCostExplorerQueryProcessWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63051,7 +63051,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcess_1ApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tCreateCostExplorerQueryProcess_1WithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcess_1ApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tCreateCostExplorerQueryProcess_1WithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63166,7 +63166,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationEventsApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListOrganizationEventsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationEventsApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListOrganizationEventsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63257,7 +63257,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationEventApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tGetOrganizationEventWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationEventApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tGetOrganizationEventWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63330,7 +63330,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetFederationSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetFederationSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63420,7 +63420,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationProjectsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationProjectsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63505,7 +63505,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationInvitationsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationInvitationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationInvitationsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationInvitationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63587,7 +63587,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63669,7 +63669,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63751,7 +63751,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationInvitationApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationInvitationApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63831,7 +63831,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63925,7 +63925,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64083,7 +64083,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListInvoicesApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tListInvoicesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListInvoicesApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tListInvoicesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64153,7 +64153,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPendingInvoicesApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tListPendingInvoicesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPendingInvoicesApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tListPendingInvoicesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64241,7 +64241,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetInvoiceApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tGetInvoiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetInvoiceApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tGetInvoiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64322,7 +64322,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadInvoiceCSVApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tDownloadInvoiceCSVWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadInvoiceCSVApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tDownloadInvoiceCSVWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64395,7 +64395,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSourceProjectsApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tListSourceProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSourceProjectsApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tListSourceProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64462,7 +64462,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLinkTokenApiParams{}\n\thttpResp, err := client.CloudMigrationServiceApi.\n\t\tDeleteLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLinkTokenApiParams{}\n\thttpResp, err := client.CloudMigrationServiceApi.\n\t\tDeleteLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64541,7 +64541,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLinkTokenApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCreateLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLinkTokenApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCreateLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64614,7 +64614,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64696,7 +64696,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64782,7 +64782,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationTeamsApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListOrganizationTeamsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationTeamsApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListOrganizationTeamsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64871,7 +64871,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateTeamApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tCreateTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateTeamApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tCreateTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64957,7 +64957,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByNameApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tGetTeamByNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByNameApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tGetTeamByNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65046,7 +65046,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteTeamApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tDeleteTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteTeamApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tDeleteTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65133,7 +65133,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByIdApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tGetTeamByIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByIdApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tGetTeamByIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65234,7 +65234,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameTeamApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tRenameTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameTeamApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tRenameTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65332,7 +65332,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListTeamUsersApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListTeamUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListTeamUsersApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListTeamUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65436,7 +65436,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddTeamUserApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tAddTeamUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddTeamUserApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tAddTeamUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65534,7 +65534,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveTeamUserApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tRemoveTeamUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveTeamUserApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tRemoveTeamUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65616,7 +65616,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationUsersApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationUsersApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65701,7 +65701,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveOrganizationUserApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tRemoveOrganizationUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveOrganizationUserApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tRemoveOrganizationUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65797,7 +65797,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationRolesApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationRolesApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65875,7 +65875,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateUserApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tCreateUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateUserApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tCreateUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65952,7 +65952,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserByUsernameApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tGetUserByUsernameWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserByUsernameApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tGetUserByUsernameWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66031,7 +66031,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tGetUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tGetUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",

--- a/tools/cli/test/data/split/dev/openapi-v2-2023-02-01.yaml
+++ b/tools/cli/test/data/split/dev/openapi-v2-2023-02-01.yaml
@@ -28676,9 +28676,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -28748,9 +28746,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -28821,9 +28817,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -28894,9 +28888,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -28965,9 +28957,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -29041,9 +29031,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -29125,9 +29113,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -29208,9 +29194,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -29298,9 +29282,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -29377,9 +29359,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -29458,9 +29438,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -29545,9 +29523,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -29629,9 +29605,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -29720,9 +29694,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -29822,9 +29794,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -29906,9 +29876,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -29998,9 +29966,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30077,9 +30043,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30152,9 +30116,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30244,9 +30206,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30321,9 +30281,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30393,9 +30351,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30476,9 +30432,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30563,9 +30517,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30644,9 +30596,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30733,9 +30683,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30826,9 +30774,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30911,9 +30857,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30996,9 +30940,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31073,9 +31015,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31155,9 +31095,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31243,9 +31181,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31328,9 +31264,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31422,9 +31356,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31522,9 +31454,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31615,9 +31545,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31703,9 +31631,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31788,9 +31714,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31882,9 +31806,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31975,9 +31897,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32052,9 +31972,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32129,9 +32047,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32218,9 +32134,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32309,9 +32223,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32401,9 +32313,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32476,9 +32386,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32555,9 +32463,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32630,9 +32536,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32707,9 +32611,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32786,9 +32688,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32871,9 +32771,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32960,9 +32858,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33042,9 +32938,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33117,9 +33011,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33208,9 +33100,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33284,9 +33174,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33364,9 +33252,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33456,9 +33342,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33536,9 +33420,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33629,9 +33511,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33714,9 +33594,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33801,9 +33679,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33895,9 +33771,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33979,9 +33853,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34073,9 +33945,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34161,9 +34031,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34252,9 +34120,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34341,9 +34207,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34424,9 +34288,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34519,9 +34381,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34614,9 +34474,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34702,9 +34560,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34784,9 +34640,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34865,9 +34719,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34958,9 +34810,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35048,9 +34898,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35139,9 +34987,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35234,9 +35080,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35324,9 +35168,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35421,9 +35263,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35514,9 +35354,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35604,9 +35442,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35686,9 +35522,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35781,9 +35615,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35878,9 +35710,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35964,9 +35794,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36055,9 +35883,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36137,9 +35963,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36228,9 +36052,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36312,9 +36134,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36406,9 +36226,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36501,9 +36319,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36604,9 +36420,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36700,9 +36514,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36793,9 +36605,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36897,9 +36707,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36986,9 +36794,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37071,9 +36877,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37164,9 +36968,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37265,9 +37067,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37360,9 +37160,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37520,9 +37318,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37610,9 +37406,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37705,9 +37499,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37803,9 +37595,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37898,9 +37688,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38002,9 +37790,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38116,9 +37902,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38203,9 +37987,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38289,9 +38071,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38380,9 +38160,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38470,9 +38248,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38566,9 +38342,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38649,9 +38423,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38750,9 +38522,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38839,9 +38609,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38938,9 +38706,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39021,9 +38787,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39104,9 +38868,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39196,9 +38958,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39292,9 +39052,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39381,9 +39139,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39471,9 +39227,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39569,9 +39323,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39661,9 +39413,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39750,9 +39500,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39846,9 +39594,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39930,9 +39676,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40045,9 +39789,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40131,9 +39873,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40217,9 +39957,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40307,9 +40045,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40398,9 +40134,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40483,9 +40217,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40574,9 +40306,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40654,9 +40384,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40749,9 +40477,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40827,9 +40553,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40900,9 +40624,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40985,9 +40707,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41070,9 +40790,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41148,9 +40866,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41239,9 +40955,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41325,9 +41039,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41408,9 +41120,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41489,9 +41199,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41568,9 +41276,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41659,9 +41365,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41744,9 +41448,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41839,9 +41541,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41934,9 +41634,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42039,9 +41737,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42144,9 +41840,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42218,9 +41912,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42394,9 +42086,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42499,9 +42189,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42597,9 +42285,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42708,9 +42394,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42794,9 +42478,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42894,9 +42576,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43015,9 +42695,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43129,9 +42807,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43203,9 +42879,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43298,9 +42972,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43381,9 +43053,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43466,9 +43136,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43565,9 +43233,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43652,9 +43318,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43780,9 +43444,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43871,9 +43533,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43944,9 +43604,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44047,9 +43705,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44149,9 +43805,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44250,9 +43904,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44328,9 +43980,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44421,9 +44071,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44513,9 +44161,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44617,9 +44263,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44723,9 +44367,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44807,9 +44449,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44890,9 +44530,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44973,9 +44611,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45058,9 +44694,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45141,9 +44775,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45232,9 +44864,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45310,9 +44940,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45389,9 +45017,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45500,9 +45126,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45612,9 +45236,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45734,9 +45356,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45832,9 +45452,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45913,9 +45531,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45989,9 +45605,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46080,9 +45694,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46171,9 +45783,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46241,9 +45851,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46311,9 +45919,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46389,9 +45995,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46463,9 +46067,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46537,9 +46139,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46612,9 +46212,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46683,9 +46281,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46754,9 +46350,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46870,9 +46464,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46956,9 +46548,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47042,9 +46632,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47128,9 +46716,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47209,9 +46795,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47301,9 +46885,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47379,9 +46961,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47459,9 +47039,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47544,9 +47122,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47625,9 +47201,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47716,9 +47290,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47804,9 +47376,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47896,9 +47466,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47978,9 +47546,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48064,9 +47630,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48160,9 +47724,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48252,9 +47814,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48343,9 +47903,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48432,9 +47990,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48520,9 +48076,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48611,9 +48165,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48703,9 +48255,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48807,9 +48357,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48909,9 +48457,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49008,9 +48554,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49089,9 +48633,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49166,9 +48708,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49245,9 +48785,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49331,9 +48869,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49423,9 +48959,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49516,9 +49050,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49604,9 +49136,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49699,9 +49229,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49778,9 +49306,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49861,9 +49387,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49943,9 +49467,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50041,9 +49563,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50127,9 +49647,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50210,9 +49728,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50284,9 +49800,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50363,9 +49877,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50445,9 +49957,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50530,9 +50040,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50641,9 +50149,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50723,9 +50229,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50807,9 +50311,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50934,9 +50436,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51172,9 +50672,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51271,9 +50769,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51387,9 +50883,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51510,9 +51004,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51585,9 +51077,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51659,9 +51149,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51741,9 +51229,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51827,9 +51313,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51914,9 +51398,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51997,9 +51479,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52071,9 +51551,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52152,9 +51630,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52241,9 +51717,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52333,9 +51807,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52428,9 +51900,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52513,9 +51983,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52604,9 +52072,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52684,9 +52150,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52768,9 +52232,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52856,9 +52318,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52939,9 +52399,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53027,9 +52485,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53106,9 +52562,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53187,9 +52641,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53264,9 +52716,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53343,9 +52793,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53428,9 +52876,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53512,9 +52958,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53601,9 +53045,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53707,9 +53149,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53788,9 +53228,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53875,9 +53313,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53966,9 +53402,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54049,9 +53483,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54144,9 +53576,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54228,9 +53658,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54316,9 +53744,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54406,9 +53832,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54501,9 +53925,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54576,9 +53998,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54658,9 +54078,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54735,9 +54153,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54806,9 +54222,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54886,9 +54300,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54970,9 +54382,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55056,9 +54466,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55138,9 +54546,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55229,9 +54635,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55317,9 +54721,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55401,9 +54803,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55485,9 +54885,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55572,9 +54970,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55648,9 +55044,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55731,9 +55125,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55812,9 +55204,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55892,9 +55282,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55979,9 +55367,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56061,9 +55447,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56152,9 +55536,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56242,9 +55624,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56337,9 +55717,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56436,9 +55814,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56528,9 +55904,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56607,9 +55981,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56700,9 +56072,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56806,9 +56176,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56897,9 +56265,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56972,9 +56338,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57063,9 +56427,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57146,9 +56508,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57227,9 +56587,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57312,9 +56670,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57397,9 +56753,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57479,9 +56833,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57569,9 +56921,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57708,9 +57058,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57796,9 +57144,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57885,9 +57231,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57958,9 +57302,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58033,9 +57375,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58105,9 +57445,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58184,9 +57522,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58263,9 +57599,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58344,9 +57678,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58429,9 +57761,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58515,9 +57845,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58606,9 +57934,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58692,9 +58018,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58787,9 +58111,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58882,9 +58204,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58979,9 +58299,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59077,9 +58395,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59161,9 +58477,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59239,9 +58553,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59324,9 +58636,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59415,9 +58725,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59503,9 +58811,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59588,9 +58894,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59667,9 +58971,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)

--- a/tools/cli/test/data/split/dev/openapi-v2-2023-10-01.json
+++ b/tools/cli/test/data/split/dev/openapi-v2-2023-10-01.json
@@ -35421,7 +35421,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSystemStatusApiParams{}\n\tsdkResp, httpResp, err := client.RootApi.\n\t\tGetSystemStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSystemStatusApiParams{}\n\tsdkResp, httpResp, err := client.RootApi.\n\t\tGetSystemStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -35488,7 +35488,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationMatchersFieldNamesApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationMatchersFieldNamesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationMatchersFieldNamesApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationMatchersFieldNamesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -35561,7 +35561,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersForAllProjectsApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListClustersForAllProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersForAllProjectsApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListClustersForAllProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -35634,7 +35634,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListEventTypesApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListEventTypesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListEventTypesApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListEventTypesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -35698,7 +35698,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederationAppApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tDeleteFederationAppWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederationAppApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tDeleteFederationAppWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -35774,7 +35774,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListConnectedOrgConfigsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListConnectedOrgConfigsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListConnectedOrgConfigsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListConnectedOrgConfigsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -35857,7 +35857,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveConnectedOrgConfigApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tRemoveConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveConnectedOrgConfigApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tRemoveConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -35938,7 +35938,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36030,7 +36030,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36103,7 +36103,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListRoleMappingsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListRoleMappingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListRoleMappingsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListRoleMappingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36185,7 +36185,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tCreateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tCreateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36268,7 +36268,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteRoleMappingApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tDeleteRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteRoleMappingApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tDeleteRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36352,7 +36352,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36447,7 +36447,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36555,7 +36555,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIdentityProvidersApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListIdentityProvidersWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIdentityProvidersApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListIdentityProvidersWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36639,7 +36639,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36730,7 +36730,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36801,7 +36801,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderMetadataApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetIdentityProviderMetadataWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderMetadataApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetIdentityProviderMetadataWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36877,7 +36877,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36973,7 +36973,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tCreateProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tCreateProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37057,7 +37057,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectByNameApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectByNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectByNameApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectByNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37127,7 +37127,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37195,7 +37195,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37280,7 +37280,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37366,7 +37366,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddUserToProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tAddUserToProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddUserToProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tAddUserToProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37446,7 +37446,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectIpAccessListsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tListProjectIpAccessListsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectIpAccessListsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tListProjectIpAccessListsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37544,7 +37544,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectIpAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tCreateProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectIpAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tCreateProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37629,7 +37629,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectIpAccessListApiParams{}\n\thttpResp, err := client.ProjectIPAccessListApi.\n\t\tDeleteProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectIpAccessListApiParams{}\n\thttpResp, err := client.ProjectIPAccessListApi.\n\t\tDeleteProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37715,7 +37715,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpListApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tGetProjectIpListWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpListApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tGetProjectIpListWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37802,7 +37802,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpAccessListStatusApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tGetProjectIpAccessListStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpAccessListStatusApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tGetProjectIpAccessListStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37878,7 +37878,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37957,7 +37957,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tCreateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tCreateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38037,7 +38037,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAlertConfigurationApiParams{}\n\thttpResp, err := client.AlertConfigurationsApi.\n\t\tDeleteAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAlertConfigurationApiParams{}\n\thttpResp, err := client.AlertConfigurationsApi.\n\t\tDeleteAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38118,7 +38118,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tGetAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tGetAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38210,7 +38210,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tToggleAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tToggleAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38305,7 +38305,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tUpdateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tUpdateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38397,7 +38397,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsByAlertConfigurationIdApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tListAlertsByAlertConfigurationIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsByAlertConfigurationIdApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tListAlertsByAlertConfigurationIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38489,7 +38489,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tListAlertsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tListAlertsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38571,7 +38571,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tGetAlertWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tGetAlertWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38666,7 +38666,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AcknowledgeAlertApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tAcknowledgeAlertWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AcknowledgeAlertApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tAcknowledgeAlertWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38758,7 +38758,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsByAlertIdApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationsByAlertIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsByAlertIdApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationsByAlertIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38838,7 +38838,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectApiKeysApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListProjectApiKeysWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectApiKeysApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListProjectApiKeysWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38914,7 +38914,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39000,7 +39000,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectApiKeyApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tRemoveProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectApiKeyApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tRemoveProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39100,7 +39100,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyRolesApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyRolesApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39191,7 +39191,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tAddProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tAddProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39258,7 +39258,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AuditingApi.\n\t\tGetAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AuditingApi.\n\t\tGetAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39337,7 +39337,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AuditingApi.\n\t\tUpdateAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AuditingApi.\n\t\tUpdateAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39404,7 +39404,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := client.AWSClustersDNSApi.\n\t\tGetAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := client.AWSClustersDNSApi.\n\t\tGetAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39480,7 +39480,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := client.AWSClustersDNSApi.\n\t\tToggleAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := client.AWSClustersDNSApi.\n\t\tToggleAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39557,7 +39557,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListExportBucketsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListExportBucketsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListExportBucketsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListExportBucketsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39643,7 +39643,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateExportBucketApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateExportBucketWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateExportBucketApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateExportBucketWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39727,7 +39727,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteExportBucketApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteExportBucketWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteExportBucketApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteExportBucketWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39806,7 +39806,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetExportBucketApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetExportBucketWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetExportBucketApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetExportBucketWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39877,7 +39877,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39969,7 +39969,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40036,7 +40036,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderAccessRolesApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tListCloudProviderAccessRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderAccessRolesApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tListCloudProviderAccessRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40116,7 +40116,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tCreateCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tCreateCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40207,7 +40207,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeauthorizeCloudProviderAccessRoleApiParams{}\n\thttpResp, err := client.CloudProviderAccessApi.\n\t\tDeauthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeauthorizeCloudProviderAccessRoleApiParams{}\n\thttpResp, err := client.CloudProviderAccessApi.\n\t\tDeauthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40286,7 +40286,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tGetCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tGetCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40384,7 +40384,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AuthorizeCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tAuthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AuthorizeCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tAuthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40470,7 +40470,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListClustersWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListClustersWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40560,7 +40560,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tCreateClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tCreateClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40656,7 +40656,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderRegionsApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListCloudProviderRegionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderRegionsApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListCloudProviderRegionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40746,7 +40746,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpgradeSharedClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpgradeSharedClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40836,7 +40836,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterToServerlessApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpgradeSharedClusterToServerlessWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterToServerlessApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpgradeSharedClusterToServerlessWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40929,7 +40929,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteClusterApiParams{}\n\thttpResp, err := client.ClustersApi.\n\t\tDeleteClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteClusterApiParams{}\n\thttpResp, err := client.ClustersApi.\n\t\tDeleteClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41013,7 +41013,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41112,7 +41112,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpdateClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpdateClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41201,7 +41201,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupExportJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListBackupExportJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupExportJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListBackupExportJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41295,7 +41295,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41380,7 +41380,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41468,7 +41468,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41565,7 +41565,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41659,7 +41659,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CancelBackupRestoreJobApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tCancelBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CancelBackupRestoreJobApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tCancelBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41748,7 +41748,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41828,7 +41828,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllBackupSchedulesApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteAllBackupSchedulesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllBackupSchedulesApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteAllBackupSchedulesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41907,7 +41907,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42000,7 +42000,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42092,7 +42092,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListReplicaSetBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListReplicaSetBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListReplicaSetBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListReplicaSetBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42183,7 +42183,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TakeSnapshotApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tTakeSnapshotWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TakeSnapshotApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tTakeSnapshotWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42274,7 +42274,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteShardedClusterBackupApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteShardedClusterBackupApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42366,7 +42366,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetShardedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetShardedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42448,7 +42448,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListShardedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListShardedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListShardedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListShardedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42542,7 +42542,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteReplicaSetBackupApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteReplicaSetBackupApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42634,7 +42634,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetReplicaSetBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetReplicaSetBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42737,7 +42737,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateSnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateSnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateSnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateSnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42839,7 +42839,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tDownloadSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tDownloadSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42938,7 +42938,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tCreateSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tCreateSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43020,7 +43020,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tListSharedClusterBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tListSharedClusterBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43114,7 +43114,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tGetSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tGetSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43196,7 +43196,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tListSharedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tListSharedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43290,7 +43290,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tGetSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tGetSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43379,7 +43379,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupCheckpointsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacyBackupCheckpointsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupCheckpointsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacyBackupCheckpointsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43477,7 +43477,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupCheckpointApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacyBackupCheckpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupCheckpointApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacyBackupCheckpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43578,7 +43578,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tCreateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tCreateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43684,7 +43684,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasSearchIndexesDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tListAtlasSearchIndexesDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasSearchIndexesDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tListAtlasSearchIndexesDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43784,7 +43784,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchIndexDeprecatedApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchIndexDeprecatedApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43879,7 +43879,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43991,7 +43991,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44076,7 +44076,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tGetManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tGetManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44161,7 +44161,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllCustomZoneMappingsApiParams{}\n\thttpResp, err := client.GlobalClustersApi.\n\t\tDeleteAllCustomZoneMappingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllCustomZoneMappingsApiParams{}\n\thttpResp, err := client.GlobalClustersApi.\n\t\tDeleteAllCustomZoneMappingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44258,7 +44258,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomZoneMappingApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tCreateCustomZoneMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomZoneMappingApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tCreateCustomZoneMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44362,7 +44362,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteManagedNamespaceApiParams{}\n\thttpResp, err := client.GlobalClustersApi.\n\t\tDeleteManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteManagedNamespaceApiParams{}\n\thttpResp, err := client.GlobalClustersApi.\n\t\tDeleteManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44462,7 +44462,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tCreateManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tCreateManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44648,7 +44648,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRollingIndexApiParams{}\n\tsdkResp, httpResp, err := client.RollingIndexApi.\n\t\tCreateRollingIndexWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRollingIndexApiParams{}\n\tsdkResp, httpResp, err := client.RollingIndexApi.\n\t\tCreateRollingIndexWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44740,7 +44740,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOnlineArchivesApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tListOnlineArchivesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOnlineArchivesApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tListOnlineArchivesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44841,7 +44841,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tCreateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tCreateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44960,7 +44960,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadOnlineArchiveQueryLogsApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tDownloadOnlineArchiveQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadOnlineArchiveQueryLogsApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tDownloadOnlineArchiveQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45058,7 +45058,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOnlineArchiveApiParams{}\n\thttpResp, err := client.OnlineArchiveApi.\n\t\tDeleteOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOnlineArchiveApiParams{}\n\thttpResp, err := client.OnlineArchiveApi.\n\t\tDeleteOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45157,7 +45157,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tGetOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tGetOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45270,7 +45270,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tUpdateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tUpdateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45359,7 +45359,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EndOutageSimulationApiParams{}\n\thttpResp, err := client.ClusterOutageSimulationApi.\n\t\tEndOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EndOutageSimulationApiParams{}\n\thttpResp, err := client.ClusterOutageSimulationApi.\n\t\tEndOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45446,7 +45446,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := client.ClusterOutageSimulationApi.\n\t\tGetOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := client.ClusterOutageSimulationApi.\n\t\tGetOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45541,7 +45541,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.StartOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := client.ClusterOutageSimulationApi.\n\t\tStartOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.StartOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := client.ClusterOutageSimulationApi.\n\t\tStartOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45628,7 +45628,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45729,7 +45729,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpdateClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpdateClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45806,7 +45806,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TestFailoverApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tTestFailoverWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TestFailoverApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tTestFailoverWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45909,7 +45909,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacyBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacyBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46001,7 +46001,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tCreateLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tCreateLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46096,7 +46096,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46179,7 +46179,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchDeploymentApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchDeploymentApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46261,7 +46261,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46357,7 +46357,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46453,7 +46453,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tCreateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tCreateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46534,7 +46534,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46623,7 +46623,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tUpdateLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tUpdateLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46726,7 +46726,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacySnapshotsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacySnapshotsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacySnapshotsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacySnapshotsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46821,7 +46821,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLegacySnapshotApiParams{}\n\thttpResp, err := client.LegacyBackupApi.\n\t\tDeleteLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLegacySnapshotApiParams{}\n\thttpResp, err := client.LegacyBackupApi.\n\t\tDeleteLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46911,7 +46911,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47012,7 +47012,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tUpdateLegacySnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tUpdateLegacySnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47091,7 +47091,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterStatusApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterStatusApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47218,7 +47218,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostLogsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetHostLogsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostLogsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetHostLogsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47312,7 +47312,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainerByCloudProviderApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringContainerByCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainerByCloudProviderApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringContainerByCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47400,7 +47400,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tCreatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tCreatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47476,7 +47476,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainersApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringContainersWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainersApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringContainersWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47565,7 +47565,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringContainerApiParams{}\n\thttpResp, err := client.NetworkPeeringApi.\n\t\tDeletePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringContainerApiParams{}\n\thttpResp, err := client.NetworkPeeringApi.\n\t\tDeletePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47643,7 +47643,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tGetPeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tGetPeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47744,7 +47744,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tUpdatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tUpdatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47814,7 +47814,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCustomDatabaseRolesApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tListCustomDatabaseRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCustomDatabaseRolesApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tListCustomDatabaseRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47902,7 +47902,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tCreateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tCreateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47984,7 +47984,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteCustomDatabaseRoleApiParams{}\n\thttpResp, err := client.CustomDatabaseRolesApi.\n\t\tDeleteCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteCustomDatabaseRoleApiParams{}\n\thttpResp, err := client.CustomDatabaseRolesApi.\n\t\tDeleteCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48061,7 +48061,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tGetCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tGetCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48158,7 +48158,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tUpdateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tUpdateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48241,7 +48241,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListFederatedDatabasesApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tListFederatedDatabasesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListFederatedDatabasesApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tListFederatedDatabasesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48326,7 +48326,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48402,7 +48402,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederatedDatabaseApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederatedDatabaseApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48479,7 +48479,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tGetFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tGetFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48576,7 +48576,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tUpdateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tUpdateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48658,7 +48658,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48746,7 +48746,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOneDataFederationInstanceQueryLimitApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteOneDataFederationInstanceQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOneDataFederationInstanceQueryLimitApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteOneDataFederationInstanceQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48835,7 +48835,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48938,7 +48938,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOneDataFederationQueryLimitApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateOneDataFederationQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOneDataFederationQueryLimitApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateOneDataFederationQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49044,7 +49044,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadFederatedDatabaseQueryLogsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tDownloadFederatedDatabaseQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadFederatedDatabaseQueryLogsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tDownloadFederatedDatabaseQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49120,7 +49120,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUsersApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tListDatabaseUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUsersApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tListDatabaseUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49360,7 +49360,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tCreateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tCreateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49452,7 +49452,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDatabaseUserApiParams{}\n\thttpResp, err := client.DatabaseUsersApi.\n\t\tDeleteDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDatabaseUserApiParams{}\n\thttpResp, err := client.DatabaseUsersApi.\n\t\tDeleteDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49539,7 +49539,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tGetDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tGetDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49646,7 +49646,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tUpdateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tUpdateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49734,7 +49734,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUserCertificatesApiParams{}\n\tsdkResp, httpResp, err := client.X509AuthenticationApi.\n\t\tListDatabaseUserCertificatesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUserCertificatesApiParams{}\n\tsdkResp, httpResp, err := client.X509AuthenticationApi.\n\t\tListDatabaseUserCertificatesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49836,7 +49836,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserCertificateApiParams{}\n\tsdkResp, httpResp, err := client.X509AuthenticationApi.\n\t\tCreateDatabaseUserCertificateWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserCertificateApiParams{}\n\tsdkResp, httpResp, err := client.X509AuthenticationApi.\n\t\tCreateDatabaseUserCertificateWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49969,7 +49969,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByClusterNameApiParams{}\n\tsdkResp, httpResp, err := client.AccessTrackingApi.\n\t\tListAccessLogsByClusterNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByClusterNameApiParams{}\n\tsdkResp, httpResp, err := client.AccessTrackingApi.\n\t\tListAccessLogsByClusterNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50099,7 +50099,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByHostnameApiParams{}\n\tsdkResp, httpResp, err := client.AccessTrackingApi.\n\t\tListAccessLogsByHostnameWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByHostnameApiParams{}\n\tsdkResp, httpResp, err := client.AccessTrackingApi.\n\t\tListAccessLogsByHostnameWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50166,7 +50166,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50251,7 +50251,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tUpdateEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tUpdateEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50330,7 +50330,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointsForCloudProviderApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointsForCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointsForCloudProviderApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointsForCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50418,7 +50418,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tCreateEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tCreateEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50520,7 +50520,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RequestEncryptionAtRestPrivateEndpointDeletionApiParams{}\n\thttpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tRequestEncryptionAtRestPrivateEndpointDeletionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RequestEncryptionAtRestPrivateEndpointDeletionApiParams{}\n\thttpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tRequestEncryptionAtRestPrivateEndpointDeletionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50609,7 +50609,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50752,7 +50752,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectEventsApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListProjectEventsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectEventsApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListProjectEventsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50843,7 +50843,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectEventApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tGetProjectEventWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectEventApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tGetProjectEventWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50913,7 +50913,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListMetricTypesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListMetricTypesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListMetricTypesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListMetricTypesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51029,7 +51029,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51148,7 +51148,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51259,7 +51259,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51341,7 +51341,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListThirdPartyIntegrationsApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tListThirdPartyIntegrationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListThirdPartyIntegrationsApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tListThirdPartyIntegrationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51436,7 +51436,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteThirdPartyIntegrationApiParams{}\n\thttpResp, err := client.Third - PartyIntegrationsApi.\n\t\tDeleteThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteThirdPartyIntegrationApiParams{}\n\thttpResp, err := client.Third - PartyIntegrationsApi.\n\t\tDeleteThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51529,7 +51529,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tGetThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tGetThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51645,7 +51645,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tCreateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tCreateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51758,7 +51758,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tUpdateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tUpdateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51838,7 +51838,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectInvitationsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectInvitationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectInvitationsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectInvitationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51922,7 +51922,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52000,7 +52000,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tCreateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tCreateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52078,7 +52078,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectInvitationApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectInvitationApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52160,7 +52160,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52253,7 +52253,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52324,7 +52324,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnAllIPAddressesApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tReturnAllIPAddressesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnAllIPAddressesApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tReturnAllIPAddressesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52403,7 +52403,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectLimitsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectLimitsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectLimitsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectLimitsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52500,7 +52500,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectLimitApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectLimitApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52598,7 +52598,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52707,7 +52707,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tSetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tSetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52797,7 +52797,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCreatePushMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCreatePushMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52888,7 +52888,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ValidateMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tValidateMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ValidateMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tValidateMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52975,7 +52975,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetValidationStatusApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tGetValidationStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetValidationStatusApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tGetValidationStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53051,7 +53051,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tGetPushMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tGetPushMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53127,7 +53127,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CutoverMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCutoverMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CutoverMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCutoverMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53191,7 +53191,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResetMaintenanceWindowApiParams{}\n\thttpResp, err := client.MaintenanceWindowsApi.\n\t\tResetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResetMaintenanceWindowApiParams{}\n\thttpResp, err := client.MaintenanceWindowsApi.\n\t\tResetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53256,7 +53256,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tGetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tGetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53332,7 +53332,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tUpdateMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tUpdateMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53396,7 +53396,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleMaintenanceAutoDeferApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tToggleMaintenanceAutoDeferWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleMaintenanceAutoDeferApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tToggleMaintenanceAutoDeferWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53460,7 +53460,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeferMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tDeferMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeferMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tDeferMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53527,7 +53527,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedSlowMsApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tGetManagedSlowMsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedSlowMsApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tGetManagedSlowMsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53594,7 +53594,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableSlowOperationThresholdingApiParams{}\n\thttpResp, err := client.PerformanceAdvisorApi.\n\t\tDisableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableSlowOperationThresholdingApiParams{}\n\thttpResp, err := client.PerformanceAdvisorApi.\n\t\tDisableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53661,7 +53661,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EnableSlowOperationThresholdingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tEnableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EnableSlowOperationThresholdingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tEnableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53789,7 +53789,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLTSVersionsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectLTSVersionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLTSVersionsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectLTSVersionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53882,7 +53882,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringConnectionsApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringConnectionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringConnectionsApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringConnectionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53971,7 +53971,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tCreatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tCreatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54053,7 +54053,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringConnectionApiParams{}\n\thttpResp, err := client.NetworkPeeringApi.\n\t\tDeletePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringConnectionApiParams{}\n\thttpResp, err := client.NetworkPeeringApi.\n\t\tDeletePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54133,7 +54133,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tGetPeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tGetPeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54230,7 +54230,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tUpdatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tUpdatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54300,7 +54300,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelinesApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelinesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelinesApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelinesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54379,7 +54379,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tCreatePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tCreatePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54458,7 +54458,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineApiParams{}\n\thttpResp, err := client.DataLakePipelinesApi.\n\t\tDeletePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineApiParams{}\n\thttpResp, err := client.DataLakePipelinesApi.\n\t\tDeletePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54538,7 +54538,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tGetPipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tGetPipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54632,7 +54632,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tUpdatePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tUpdatePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54717,7 +54717,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSchedulesApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineSchedulesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSchedulesApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineSchedulesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54818,7 +54818,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSnapshotsApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineSnapshotsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSnapshotsApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineSnapshotsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54900,7 +54900,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PausePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tPausePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PausePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tPausePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54982,7 +54982,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResumePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tResumePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResumePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tResumePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55083,7 +55083,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineRunsApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineRunsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineRunsApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineRunsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55178,7 +55178,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineRunDatasetApiParams{}\n\thttpResp, err := client.DataLakePipelinesApi.\n\t\tDeletePipelineRunDatasetWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineRunDatasetApiParams{}\n\thttpResp, err := client.DataLakePipelinesApi.\n\t\tDeletePipelineRunDatasetWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55271,7 +55271,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineRunApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tGetPipelineRunWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineRunApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tGetPipelineRunWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55364,7 +55364,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TriggerSnapshotIngestionApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tTriggerSnapshotIngestionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TriggerSnapshotIngestionApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tTriggerSnapshotIngestionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55446,7 +55446,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55516,7 +55516,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55595,7 +55595,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tToggleRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tToggleRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55676,7 +55676,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tListServerlessPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tListServerlessPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55767,7 +55767,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tCreateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tCreateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55857,7 +55857,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessPrivateEndpointApiParams{}\n\thttpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tDeleteServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessPrivateEndpointApiParams{}\n\thttpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tDeleteServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55945,7 +55945,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tGetServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tGetServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56044,7 +56044,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tUpdateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tUpdateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56129,7 +56129,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPrivateEndpointServicesApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tListPrivateEndpointServicesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPrivateEndpointServicesApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tListPrivateEndpointServicesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56223,7 +56223,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointServiceApiParams{}\n\thttpResp, err := client.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointServiceApiParams{}\n\thttpResp, err := client.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56318,7 +56318,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56432,7 +56432,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56536,7 +56536,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointApiParams{}\n\thttpResp, err := client.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointApiParams{}\n\thttpResp, err := client.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56641,7 +56641,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56713,7 +56713,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyConnectViaPeeringOnlyModeForOneProjectApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tVerifyConnectViaPeeringOnlyModeForOneProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyConnectViaPeeringOnlyModeForOneProjectApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tVerifyConnectViaPeeringOnlyModeForOneProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56797,7 +56797,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisablePeeringApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tDisablePeeringWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisablePeeringApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tDisablePeeringWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56879,7 +56879,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDataFederationPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tListDataFederationPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDataFederationPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tListDataFederationPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56958,7 +56958,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57040,7 +57040,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDataFederationPrivateEndpointApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDataFederationPrivateEndpointApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57123,7 +57123,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tGetDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tGetDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57199,7 +57199,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasProcessesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListAtlasProcessesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasProcessesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListAtlasProcessesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57277,7 +57277,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasProcessApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetAtlasProcessWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasProcessApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetAtlasProcessWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57364,7 +57364,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabasesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDatabasesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabasesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDatabasesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57451,7 +57451,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57577,7 +57577,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDatabaseMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDatabaseMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57664,7 +57664,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskPartitionsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDiskPartitionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskPartitionsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDiskPartitionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57748,7 +57748,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57883,7 +57883,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58125,7 +58125,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetHostMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetHostMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58221,7 +58221,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueryNamespacesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSlowQueryNamespacesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueryNamespacesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSlowQueryNamespacesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58341,7 +58341,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueriesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSlowQueriesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueriesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSlowQueriesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58477,7 +58477,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSuggestedIndexesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSuggestedIndexesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSuggestedIndexesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSuggestedIndexesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58550,7 +58550,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePushBasedLogConfigurationApiParams{}\n\thttpResp, err := client.Push - BasedLogExportApi.\n\t\tDeletePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePushBasedLogConfigurationApiParams{}\n\thttpResp, err := client.Push - BasedLogExportApi.\n\t\tDeletePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58621,7 +58621,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tGetPushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tGetPushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58704,7 +58704,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tUpdatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tUpdatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58787,7 +58787,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tCreatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tCreatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58869,7 +58869,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.LoadSampleDatasetApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tLoadSampleDatasetWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.LoadSampleDatasetApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tLoadSampleDatasetWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58945,7 +58945,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSampleDatasetLoadStatusApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetSampleDatasetLoadStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSampleDatasetLoadStatusApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetSampleDatasetLoadStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59021,7 +59021,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessInstancesApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tListServerlessInstancesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessInstancesApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tListServerlessInstancesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59103,7 +59103,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tCreateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tCreateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59194,7 +59194,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListServerlessBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListServerlessBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59291,7 +59291,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59385,7 +59385,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59476,7 +59476,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListServerlessBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListServerlessBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59568,7 +59568,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetServerlessBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetServerlessBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59647,7 +59647,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tGetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tGetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59730,7 +59730,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tSetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tSetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59815,7 +59815,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessInstanceApiParams{}\n\thttpResp, err := client.ServerlessInstancesApi.\n\t\tDeleteServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessInstanceApiParams{}\n\thttpResp, err := client.ServerlessInstancesApi.\n\t\tDeleteServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59898,7 +59898,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tGetServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tGetServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59989,7 +59989,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tUpdateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tUpdateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60065,7 +60065,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectServiceAccountsApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tListProjectServiceAccountsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectServiceAccountsApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tListProjectServiceAccountsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60145,7 +60145,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tCreateProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tCreateProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60225,7 +60225,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectServiceAccountApiParams{}\n\thttpResp, err := client.GroupsApi.\n\t\tDeleteProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectServiceAccountApiParams{}\n\thttpResp, err := client.GroupsApi.\n\t\tDeleteProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60302,7 +60302,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tGetProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tGetProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60393,7 +60393,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tUpdateProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tUpdateProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60486,7 +60486,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tAddProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tAddProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60559,7 +60559,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60641,7 +60641,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60714,7 +60714,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamInstancesApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tListStreamInstancesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamInstancesApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tListStreamInstancesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60793,7 +60793,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tCreateStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tCreateStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60875,7 +60875,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamInstanceApiParams{}\n\thttpResp, err := client.StreamsApi.\n\t\tDeleteStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamInstanceApiParams{}\n\thttpResp, err := client.StreamsApi.\n\t\tDeleteStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60960,7 +60960,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tGetStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tGetStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61054,7 +61054,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tUpdateStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tUpdateStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61163,7 +61163,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadStreamTenantAuditLogsApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tDownloadStreamTenantAuditLogsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadStreamTenantAuditLogsApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tDownloadStreamTenantAuditLogsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61248,7 +61248,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamConnectionsApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tListStreamConnectionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamConnectionsApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tListStreamConnectionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61339,7 +61339,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tCreateStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tCreateStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61430,7 +61430,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamConnectionApiParams{}\n\thttpResp, err := client.StreamsApi.\n\t\tDeleteStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamConnectionApiParams{}\n\thttpResp, err := client.StreamsApi.\n\t\tDeleteStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61513,7 +61513,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tGetStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tGetStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61616,7 +61616,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tUpdateStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tUpdateStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61701,7 +61701,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectTeamsApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListProjectTeamsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectTeamsApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListProjectTeamsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61793,7 +61793,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddAllTeamsToProjectApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tAddAllTeamsToProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddAllTeamsToProjectApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tAddAllTeamsToProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61879,7 +61879,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectTeamApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tRemoveProjectTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectTeamApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tRemoveProjectTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61980,7 +61980,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateTeamRolesApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tUpdateTeamRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateTeamRolesApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tUpdateTeamRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62047,7 +62047,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62126,7 +62126,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SaveLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tSaveLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SaveLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tSaveLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62190,7 +62190,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableCustomerManagedX509ApiParams{}\n\thttpResp, err := client.X509AuthenticationApi.\n\t\tDisableCustomerManagedX509WithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableCustomerManagedX509ApiParams{}\n\thttpResp, err := client.X509AuthenticationApi.\n\t\tDisableCustomerManagedX509WithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62257,7 +62257,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLDAPConfigurationApiParams{}\n\thttpResp, err := client.LDAPConfigurationApi.\n\t\tDeleteLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLDAPConfigurationApiParams{}\n\thttpResp, err := client.LDAPConfigurationApi.\n\t\tDeleteLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62338,7 +62338,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tVerifyLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tVerifyLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62417,7 +62417,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationStatusApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationStatusApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62511,7 +62511,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectUsersApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectUsersApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62593,7 +62593,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectUserApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tRemoveProjectUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectUserApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tRemoveProjectUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62689,7 +62689,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectRolesApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectRolesApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62779,7 +62779,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62864,7 +62864,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62940,7 +62940,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63014,7 +63014,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63099,7 +63099,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tRenameOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tRenameOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63179,7 +63179,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeysApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListApiKeysWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeysApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListApiKeysWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63259,7 +63259,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63342,7 +63342,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63423,7 +63423,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63518,7 +63518,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63610,7 +63610,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeyAccessListsEntriesApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListApiKeyAccessListsEntriesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeyAccessListsEntriesApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListApiKeyAccessListsEntriesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63716,7 +63716,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63816,7 +63816,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyAccessListEntryApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyAccessListEntryWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyAccessListEntryApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyAccessListEntryWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63911,7 +63911,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63989,7 +63989,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcessApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tCreateCostExplorerQueryProcessWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcessApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tCreateCostExplorerQueryProcessWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64080,7 +64080,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcess_1ApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tCreateCostExplorerQueryProcess_1WithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcess_1ApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tCreateCostExplorerQueryProcess_1WithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64195,7 +64195,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationEventsApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListOrganizationEventsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationEventsApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListOrganizationEventsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64286,7 +64286,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationEventApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tGetOrganizationEventWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationEventApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tGetOrganizationEventWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64359,7 +64359,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetFederationSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetFederationSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64449,7 +64449,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationProjectsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationProjectsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64534,7 +64534,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationInvitationsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationInvitationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationInvitationsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationInvitationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64616,7 +64616,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64698,7 +64698,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64780,7 +64780,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationInvitationApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationInvitationApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64860,7 +64860,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64954,7 +64954,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65112,7 +65112,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListInvoicesApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tListInvoicesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListInvoicesApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tListInvoicesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65182,7 +65182,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPendingInvoicesApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tListPendingInvoicesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPendingInvoicesApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tListPendingInvoicesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65270,7 +65270,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetInvoiceApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tGetInvoiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetInvoiceApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tGetInvoiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65351,7 +65351,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadInvoiceCSVApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tDownloadInvoiceCSVWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadInvoiceCSVApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tDownloadInvoiceCSVWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65424,7 +65424,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSourceProjectsApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tListSourceProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSourceProjectsApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tListSourceProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65491,7 +65491,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLinkTokenApiParams{}\n\thttpResp, err := client.CloudMigrationServiceApi.\n\t\tDeleteLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLinkTokenApiParams{}\n\thttpResp, err := client.CloudMigrationServiceApi.\n\t\tDeleteLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65570,7 +65570,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLinkTokenApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCreateLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLinkTokenApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCreateLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65646,7 +65646,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServiceAccountsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListServiceAccountsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServiceAccountsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListServiceAccountsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65725,7 +65725,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65801,7 +65801,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServiceAccountApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServiceAccountApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65878,7 +65878,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65969,7 +65969,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66054,7 +66054,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServiceAccountProjectsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListServiceAccountProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServiceAccountProjectsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListServiceAccountProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66144,7 +66144,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServiceAccountSecretApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateServiceAccountSecretWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServiceAccountSecretApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateServiceAccountSecretWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66229,7 +66229,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServiceAccountSecretApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteServiceAccountSecretWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServiceAccountSecretApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteServiceAccountSecretWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66302,7 +66302,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66384,7 +66384,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66470,7 +66470,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationTeamsApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListOrganizationTeamsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationTeamsApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListOrganizationTeamsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66559,7 +66559,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateTeamApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tCreateTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateTeamApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tCreateTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66645,7 +66645,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByNameApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tGetTeamByNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByNameApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tGetTeamByNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66734,7 +66734,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteTeamApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tDeleteTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteTeamApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tDeleteTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66821,7 +66821,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByIdApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tGetTeamByIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByIdApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tGetTeamByIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66922,7 +66922,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameTeamApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tRenameTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameTeamApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tRenameTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67020,7 +67020,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListTeamUsersApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListTeamUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListTeamUsersApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListTeamUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67124,7 +67124,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddTeamUserApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tAddTeamUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddTeamUserApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tAddTeamUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67222,7 +67222,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveTeamUserApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tRemoveTeamUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveTeamUserApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tRemoveTeamUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67304,7 +67304,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationUsersApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationUsersApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67389,7 +67389,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveOrganizationUserApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tRemoveOrganizationUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveOrganizationUserApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tRemoveOrganizationUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67485,7 +67485,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationRolesApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationRolesApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67563,7 +67563,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateUserApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tCreateUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateUserApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tCreateUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67640,7 +67640,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserByUsernameApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tGetUserByUsernameWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserByUsernameApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tGetUserByUsernameWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67719,7 +67719,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tGetUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tGetUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",

--- a/tools/cli/test/data/split/dev/openapi-v2-2023-10-01.yaml
+++ b/tools/cli/test/data/split/dev/openapi-v2-2023-10-01.yaml
@@ -29097,9 +29097,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -29169,9 +29167,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -29242,9 +29238,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -29315,9 +29309,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -29386,9 +29378,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -29462,9 +29452,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -29546,9 +29534,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -29629,9 +29615,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -29719,9 +29703,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -29798,9 +29780,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -29879,9 +29859,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -29966,9 +29944,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30050,9 +30026,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30141,9 +30115,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30243,9 +30215,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30327,9 +30297,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30419,9 +30387,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30498,9 +30464,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30573,9 +30537,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30665,9 +30627,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30742,9 +30702,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30814,9 +30772,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30897,9 +30853,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30984,9 +30938,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31065,9 +31017,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31154,9 +31104,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31247,9 +31195,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31332,9 +31278,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31417,9 +31361,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31494,9 +31436,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31576,9 +31516,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31664,9 +31602,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31749,9 +31685,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31843,9 +31777,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31943,9 +31875,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32036,9 +31966,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32124,9 +32052,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32209,9 +32135,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32303,9 +32227,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32396,9 +32318,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32473,9 +32393,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32550,9 +32468,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32639,9 +32555,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32730,9 +32644,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32822,9 +32734,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32897,9 +32807,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32976,9 +32884,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33051,9 +32957,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33128,9 +33032,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33207,9 +33109,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33292,9 +33192,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33381,9 +33279,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33463,9 +33359,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33537,9 +33431,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33625,9 +33517,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33700,9 +33590,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33780,9 +33668,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33872,9 +33758,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33952,9 +33836,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34045,9 +33927,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34130,9 +34010,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34217,9 +34095,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34311,9 +34187,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34395,9 +34269,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34489,9 +34361,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34577,9 +34447,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34668,9 +34536,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34757,9 +34623,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34840,9 +34704,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34935,9 +34797,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35030,9 +34890,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35118,9 +34976,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35200,9 +35056,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35281,9 +35135,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35374,9 +35226,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35464,9 +35314,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35555,9 +35403,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35650,9 +35496,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35740,9 +35584,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35837,9 +35679,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35930,9 +35770,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36020,9 +35858,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36102,9 +35938,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36197,9 +36031,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36294,9 +36126,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36380,9 +36210,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36471,9 +36299,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36553,9 +36379,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36644,9 +36468,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36728,9 +36550,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36822,9 +36642,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36917,9 +36735,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37020,9 +36836,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37116,9 +36930,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37209,9 +37021,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37313,9 +37123,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37402,9 +37210,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37487,9 +37293,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37580,9 +37384,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37681,9 +37483,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37776,9 +37576,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37936,9 +37734,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38026,9 +37822,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38121,9 +37915,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38219,9 +38011,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38314,9 +38104,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38418,9 +38206,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38532,9 +38318,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38619,9 +38403,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38705,9 +38487,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38796,9 +38576,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38886,9 +38664,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38982,9 +38758,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39065,9 +38839,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39166,9 +38938,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39255,9 +39025,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39354,9 +39122,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39437,9 +39203,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39520,9 +39284,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39612,9 +39374,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39708,9 +39468,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39797,9 +39555,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39887,9 +39643,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39985,9 +39739,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40077,9 +39829,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40166,9 +39916,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40262,9 +40010,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40346,9 +40092,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40461,9 +40205,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40547,9 +40289,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40633,9 +40373,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40723,9 +40461,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40814,9 +40550,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40899,9 +40633,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40990,9 +40722,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41070,9 +40800,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41165,9 +40893,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41243,9 +40969,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41316,9 +41040,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41401,9 +41123,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41486,9 +41206,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41564,9 +41282,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41655,9 +41371,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41741,9 +41455,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41824,9 +41536,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41905,9 +41615,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41984,9 +41692,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42075,9 +41781,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42160,9 +41864,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42255,9 +41957,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42350,9 +42050,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42455,9 +42153,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42560,9 +42256,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42634,9 +42328,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42810,9 +42502,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42915,9 +42605,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43013,9 +42701,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43124,9 +42810,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43210,9 +42894,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43310,9 +42992,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43431,9 +43111,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43545,9 +43223,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43619,9 +43295,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43714,9 +43388,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43797,9 +43469,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43882,9 +43552,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43981,9 +43649,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44068,9 +43734,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44196,9 +43860,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44287,9 +43949,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44360,9 +44020,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44463,9 +44121,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44565,9 +44221,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44666,9 +44320,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44744,9 +44396,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44837,9 +44487,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44929,9 +44577,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45033,9 +44679,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45139,9 +44783,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45223,9 +44865,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45306,9 +44946,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45389,9 +45027,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45474,9 +45110,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45557,9 +45191,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45648,9 +45280,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45726,9 +45356,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45805,9 +45433,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45916,9 +45542,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46028,9 +45652,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46150,9 +45772,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46248,9 +45868,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46329,9 +45947,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46405,9 +46021,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46496,9 +46110,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46587,9 +46199,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46657,9 +46267,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46727,9 +46335,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46805,9 +46411,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46879,9 +46483,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46953,9 +46555,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47028,9 +46628,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47099,9 +46697,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47170,9 +46766,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47286,9 +46880,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47372,9 +46964,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47458,9 +47048,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47544,9 +47132,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47625,9 +47211,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47717,9 +47301,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47795,9 +47377,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47875,9 +47455,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47960,9 +47538,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48041,9 +47617,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48132,9 +47706,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48220,9 +47792,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48312,9 +47882,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48394,9 +47962,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48480,9 +48046,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48576,9 +48140,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48668,9 +48230,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48759,9 +48319,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48848,9 +48406,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48936,9 +48492,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49027,9 +48581,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49119,9 +48671,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49223,9 +48773,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49325,9 +48873,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49424,9 +48970,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49505,9 +49049,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49582,9 +49124,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49661,9 +49201,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49747,9 +49285,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49839,9 +49375,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49932,9 +49466,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50020,9 +49552,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50115,9 +49645,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50194,9 +49722,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50277,9 +49803,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50359,9 +49883,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50457,9 +49979,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50543,9 +50063,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50626,9 +50144,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50700,9 +50216,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50779,9 +50293,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50861,9 +50373,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50946,9 +50456,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51057,9 +50565,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51139,9 +50645,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51223,9 +50727,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51350,9 +50852,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51588,9 +51088,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51687,9 +51185,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51803,9 +51299,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51926,9 +51420,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52001,9 +51493,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52075,9 +51565,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52157,9 +51645,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52243,9 +51729,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52330,9 +51814,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52413,9 +51895,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52487,9 +51967,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52568,9 +52046,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52657,9 +52133,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52749,9 +52223,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52844,9 +52316,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52929,9 +52399,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53020,9 +52488,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53100,9 +52566,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53184,9 +52648,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53272,9 +52734,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53355,9 +52815,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53443,9 +52901,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53522,9 +52978,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53602,9 +53056,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53686,9 +53138,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53764,9 +53214,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53851,9 +53299,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53944,9 +53390,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54023,9 +53467,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54104,9 +53546,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54181,9 +53621,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54260,9 +53698,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54345,9 +53781,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54429,9 +53863,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54518,9 +53950,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54624,9 +54054,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54705,9 +54133,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54792,9 +54218,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54883,9 +54307,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54966,9 +54388,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55061,9 +54481,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55145,9 +54563,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55233,9 +54649,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55323,9 +54737,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55418,9 +54830,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55493,9 +54903,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55575,9 +54983,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55652,9 +55058,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55723,9 +55127,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55803,9 +55205,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55887,9 +55287,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55973,9 +55371,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56055,9 +55451,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56146,9 +55540,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56234,9 +55626,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56318,9 +55708,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56402,9 +55790,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56489,9 +55875,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56565,9 +55949,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56648,9 +56030,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56729,9 +56109,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56809,9 +56187,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56896,9 +56272,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56978,9 +56352,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57069,9 +56441,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57159,9 +56529,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57254,9 +56622,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57353,9 +56719,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57445,9 +56809,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57524,9 +56886,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57617,9 +56977,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57723,9 +57081,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57814,9 +57170,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57889,9 +57243,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57980,9 +57332,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58063,9 +57413,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58144,9 +57492,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58229,9 +57575,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58314,9 +57658,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58396,9 +57738,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58486,9 +57826,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58625,9 +57963,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58713,9 +58049,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58802,9 +58136,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58875,9 +58207,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58950,9 +58280,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59022,9 +58350,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59101,9 +58427,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59180,9 +58504,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59259,9 +58581,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59340,9 +58660,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59418,9 +58736,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59505,9 +58821,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59590,9 +58904,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59676,9 +58988,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59763,9 +59073,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59838,9 +59146,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59919,9 +59225,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60004,9 +59308,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60090,9 +59392,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60181,9 +59481,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60267,9 +59565,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60362,9 +59658,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60457,9 +59751,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60554,9 +59846,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60652,9 +59942,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60736,9 +60024,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60814,9 +60100,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60899,9 +60183,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60990,9 +60272,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -61078,9 +60358,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -61163,9 +60441,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -61242,9 +60518,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)

--- a/tools/cli/test/data/split/dev/openapi-v2-2023-11-15.json
+++ b/tools/cli/test/data/split/dev/openapi-v2-2023-11-15.json
@@ -36110,7 +36110,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSystemStatusApiParams{}\n\tsdkResp, httpResp, err := client.RootApi.\n\t\tGetSystemStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSystemStatusApiParams{}\n\tsdkResp, httpResp, err := client.RootApi.\n\t\tGetSystemStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36177,7 +36177,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationMatchersFieldNamesApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationMatchersFieldNamesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationMatchersFieldNamesApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationMatchersFieldNamesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36250,7 +36250,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersForAllProjectsApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListClustersForAllProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersForAllProjectsApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListClustersForAllProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36323,7 +36323,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListEventTypesApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListEventTypesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListEventTypesApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListEventTypesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36387,7 +36387,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederationAppApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tDeleteFederationAppWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederationAppApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tDeleteFederationAppWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36463,7 +36463,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListConnectedOrgConfigsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListConnectedOrgConfigsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListConnectedOrgConfigsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListConnectedOrgConfigsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36546,7 +36546,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveConnectedOrgConfigApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tRemoveConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveConnectedOrgConfigApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tRemoveConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36627,7 +36627,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36719,7 +36719,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36792,7 +36792,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListRoleMappingsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListRoleMappingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListRoleMappingsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListRoleMappingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36874,7 +36874,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tCreateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tCreateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36957,7 +36957,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteRoleMappingApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tDeleteRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteRoleMappingApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tDeleteRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37041,7 +37041,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37136,7 +37136,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37244,7 +37244,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIdentityProvidersApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListIdentityProvidersWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIdentityProvidersApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListIdentityProvidersWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37326,7 +37326,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tCreateIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tCreateIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37403,7 +37403,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteIdentityProviderApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tDeleteIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteIdentityProviderApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tDeleteIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37484,7 +37484,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37573,7 +37573,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37650,7 +37650,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RevokeJwksFromIdentityProviderApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tRevokeJwksFromIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RevokeJwksFromIdentityProviderApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tRevokeJwksFromIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37720,7 +37720,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderMetadataApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetIdentityProviderMetadataWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderMetadataApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetIdentityProviderMetadataWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37796,7 +37796,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37892,7 +37892,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tCreateProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tCreateProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37976,7 +37976,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectByNameApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectByNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectByNameApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectByNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38046,7 +38046,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38114,7 +38114,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38199,7 +38199,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38285,7 +38285,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddUserToProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tAddUserToProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddUserToProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tAddUserToProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38365,7 +38365,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectIpAccessListsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tListProjectIpAccessListsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectIpAccessListsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tListProjectIpAccessListsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38463,7 +38463,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectIpAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tCreateProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectIpAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tCreateProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38548,7 +38548,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectIpAccessListApiParams{}\n\thttpResp, err := client.ProjectIPAccessListApi.\n\t\tDeleteProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectIpAccessListApiParams{}\n\thttpResp, err := client.ProjectIPAccessListApi.\n\t\tDeleteProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38634,7 +38634,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpListApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tGetProjectIpListWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpListApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tGetProjectIpListWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38721,7 +38721,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpAccessListStatusApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tGetProjectIpAccessListStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpAccessListStatusApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tGetProjectIpAccessListStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38797,7 +38797,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38876,7 +38876,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tCreateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tCreateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38956,7 +38956,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAlertConfigurationApiParams{}\n\thttpResp, err := client.AlertConfigurationsApi.\n\t\tDeleteAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAlertConfigurationApiParams{}\n\thttpResp, err := client.AlertConfigurationsApi.\n\t\tDeleteAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39037,7 +39037,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tGetAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tGetAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39129,7 +39129,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tToggleAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tToggleAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39224,7 +39224,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tUpdateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tUpdateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39316,7 +39316,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsByAlertConfigurationIdApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tListAlertsByAlertConfigurationIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsByAlertConfigurationIdApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tListAlertsByAlertConfigurationIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39408,7 +39408,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tListAlertsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tListAlertsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39490,7 +39490,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tGetAlertWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tGetAlertWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39585,7 +39585,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AcknowledgeAlertApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tAcknowledgeAlertWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AcknowledgeAlertApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tAcknowledgeAlertWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39677,7 +39677,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsByAlertIdApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationsByAlertIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsByAlertIdApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationsByAlertIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39757,7 +39757,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectApiKeysApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListProjectApiKeysWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectApiKeysApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListProjectApiKeysWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39833,7 +39833,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39919,7 +39919,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectApiKeyApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tRemoveProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectApiKeyApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tRemoveProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40019,7 +40019,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyRolesApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyRolesApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40110,7 +40110,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tAddProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tAddProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40177,7 +40177,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AuditingApi.\n\t\tGetAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AuditingApi.\n\t\tGetAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40256,7 +40256,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AuditingApi.\n\t\tUpdateAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AuditingApi.\n\t\tUpdateAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40323,7 +40323,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := client.AWSClustersDNSApi.\n\t\tGetAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := client.AWSClustersDNSApi.\n\t\tGetAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40399,7 +40399,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := client.AWSClustersDNSApi.\n\t\tToggleAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := client.AWSClustersDNSApi.\n\t\tToggleAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40476,7 +40476,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListExportBucketsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListExportBucketsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListExportBucketsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListExportBucketsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40562,7 +40562,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateExportBucketApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateExportBucketWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateExportBucketApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateExportBucketWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40646,7 +40646,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteExportBucketApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteExportBucketWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteExportBucketApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteExportBucketWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40725,7 +40725,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetExportBucketApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetExportBucketWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetExportBucketApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetExportBucketWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40796,7 +40796,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40888,7 +40888,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40955,7 +40955,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderAccessRolesApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tListCloudProviderAccessRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderAccessRolesApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tListCloudProviderAccessRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41035,7 +41035,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tCreateCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tCreateCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41126,7 +41126,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeauthorizeCloudProviderAccessRoleApiParams{}\n\thttpResp, err := client.CloudProviderAccessApi.\n\t\tDeauthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeauthorizeCloudProviderAccessRoleApiParams{}\n\thttpResp, err := client.CloudProviderAccessApi.\n\t\tDeauthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41205,7 +41205,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tGetCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tGetCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41303,7 +41303,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AuthorizeCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tAuthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AuthorizeCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tAuthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41389,7 +41389,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListClustersWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListClustersWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41479,7 +41479,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tCreateClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tCreateClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41575,7 +41575,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderRegionsApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListCloudProviderRegionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderRegionsApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListCloudProviderRegionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41665,7 +41665,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpgradeSharedClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpgradeSharedClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41755,7 +41755,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterToServerlessApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpgradeSharedClusterToServerlessWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterToServerlessApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpgradeSharedClusterToServerlessWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41848,7 +41848,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteClusterApiParams{}\n\thttpResp, err := client.ClustersApi.\n\t\tDeleteClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteClusterApiParams{}\n\thttpResp, err := client.ClustersApi.\n\t\tDeleteClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41932,7 +41932,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42031,7 +42031,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpdateClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpdateClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42120,7 +42120,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupExportJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListBackupExportJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupExportJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListBackupExportJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42214,7 +42214,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42299,7 +42299,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42387,7 +42387,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42484,7 +42484,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42578,7 +42578,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CancelBackupRestoreJobApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tCancelBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CancelBackupRestoreJobApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tCancelBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42667,7 +42667,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42747,7 +42747,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllBackupSchedulesApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteAllBackupSchedulesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllBackupSchedulesApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteAllBackupSchedulesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42826,7 +42826,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42919,7 +42919,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43011,7 +43011,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListReplicaSetBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListReplicaSetBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListReplicaSetBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListReplicaSetBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43102,7 +43102,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TakeSnapshotApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tTakeSnapshotWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TakeSnapshotApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tTakeSnapshotWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43193,7 +43193,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteShardedClusterBackupApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteShardedClusterBackupApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43285,7 +43285,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetShardedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetShardedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43367,7 +43367,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListShardedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListShardedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListShardedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListShardedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43461,7 +43461,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteReplicaSetBackupApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteReplicaSetBackupApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43553,7 +43553,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetReplicaSetBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetReplicaSetBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43656,7 +43656,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateSnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateSnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateSnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateSnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43758,7 +43758,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tDownloadSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tDownloadSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43857,7 +43857,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tCreateSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tCreateSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43939,7 +43939,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tListSharedClusterBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tListSharedClusterBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44033,7 +44033,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tGetSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tGetSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44115,7 +44115,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tListSharedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tListSharedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44209,7 +44209,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tGetSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tGetSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44298,7 +44298,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupCheckpointsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacyBackupCheckpointsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupCheckpointsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacyBackupCheckpointsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44396,7 +44396,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupCheckpointApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacyBackupCheckpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupCheckpointApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacyBackupCheckpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44478,7 +44478,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPinnedNamespacesApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetPinnedNamespacesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPinnedNamespacesApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetPinnedNamespacesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44580,7 +44580,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PinNamespacesPatchApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tPinNamespacesPatchWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PinNamespacesPatchApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tPinNamespacesPatchWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44682,7 +44682,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PinNamespacesPutApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tPinNamespacesPutWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PinNamespacesPutApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tPinNamespacesPutWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44775,7 +44775,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UnpinNamespacesApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tUnpinNamespacesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UnpinNamespacesApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tUnpinNamespacesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44876,7 +44876,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tCreateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tCreateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44982,7 +44982,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasSearchIndexesDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tListAtlasSearchIndexesDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasSearchIndexesDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tListAtlasSearchIndexesDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45082,7 +45082,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchIndexDeprecatedApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchIndexDeprecatedApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45177,7 +45177,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45289,7 +45289,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45374,7 +45374,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tGetManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tGetManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45459,7 +45459,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllCustomZoneMappingsApiParams{}\n\thttpResp, err := client.GlobalClustersApi.\n\t\tDeleteAllCustomZoneMappingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllCustomZoneMappingsApiParams{}\n\thttpResp, err := client.GlobalClustersApi.\n\t\tDeleteAllCustomZoneMappingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45556,7 +45556,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomZoneMappingApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tCreateCustomZoneMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomZoneMappingApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tCreateCustomZoneMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45660,7 +45660,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteManagedNamespaceApiParams{}\n\thttpResp, err := client.GlobalClustersApi.\n\t\tDeleteManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteManagedNamespaceApiParams{}\n\thttpResp, err := client.GlobalClustersApi.\n\t\tDeleteManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45760,7 +45760,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tCreateManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tCreateManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45946,7 +45946,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRollingIndexApiParams{}\n\tsdkResp, httpResp, err := client.RollingIndexApi.\n\t\tCreateRollingIndexWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRollingIndexApiParams{}\n\tsdkResp, httpResp, err := client.RollingIndexApi.\n\t\tCreateRollingIndexWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46038,7 +46038,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOnlineArchivesApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tListOnlineArchivesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOnlineArchivesApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tListOnlineArchivesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46139,7 +46139,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tCreateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tCreateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46258,7 +46258,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadOnlineArchiveQueryLogsApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tDownloadOnlineArchiveQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadOnlineArchiveQueryLogsApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tDownloadOnlineArchiveQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46356,7 +46356,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOnlineArchiveApiParams{}\n\thttpResp, err := client.OnlineArchiveApi.\n\t\tDeleteOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOnlineArchiveApiParams{}\n\thttpResp, err := client.OnlineArchiveApi.\n\t\tDeleteOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46455,7 +46455,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tGetOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tGetOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46568,7 +46568,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tUpdateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tUpdateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46657,7 +46657,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EndOutageSimulationApiParams{}\n\thttpResp, err := client.ClusterOutageSimulationApi.\n\t\tEndOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EndOutageSimulationApiParams{}\n\thttpResp, err := client.ClusterOutageSimulationApi.\n\t\tEndOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46744,7 +46744,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := client.ClusterOutageSimulationApi.\n\t\tGetOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := client.ClusterOutageSimulationApi.\n\t\tGetOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46839,7 +46839,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.StartOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := client.ClusterOutageSimulationApi.\n\t\tStartOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.StartOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := client.ClusterOutageSimulationApi.\n\t\tStartOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46926,7 +46926,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47027,7 +47027,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpdateClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpdateClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47104,7 +47104,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TestFailoverApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tTestFailoverWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TestFailoverApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tTestFailoverWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47207,7 +47207,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacyBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacyBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47299,7 +47299,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tCreateLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tCreateLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47394,7 +47394,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47477,7 +47477,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchDeploymentApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchDeploymentApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47559,7 +47559,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47655,7 +47655,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47751,7 +47751,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tCreateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tCreateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47832,7 +47832,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47921,7 +47921,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tUpdateLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tUpdateLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48024,7 +48024,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacySnapshotsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacySnapshotsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacySnapshotsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacySnapshotsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48119,7 +48119,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLegacySnapshotApiParams{}\n\thttpResp, err := client.LegacyBackupApi.\n\t\tDeleteLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLegacySnapshotApiParams{}\n\thttpResp, err := client.LegacyBackupApi.\n\t\tDeleteLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48209,7 +48209,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48310,7 +48310,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tUpdateLegacySnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tUpdateLegacySnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48389,7 +48389,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterStatusApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterStatusApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48488,7 +48488,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespacesForClusterApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespacesForClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespacesForClusterApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespacesForClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48640,7 +48640,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespaceClusterMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespaceClusterMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespaceClusterMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespaceClusterMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48767,7 +48767,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostLogsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetHostLogsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostLogsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetHostLogsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48837,7 +48837,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespaceMetricsApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespaceMetricsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespaceMetricsApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespaceMetricsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48931,7 +48931,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainerByCloudProviderApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringContainerByCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainerByCloudProviderApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringContainerByCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49019,7 +49019,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tCreatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tCreatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49095,7 +49095,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainersApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringContainersWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainersApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringContainersWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49184,7 +49184,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringContainerApiParams{}\n\thttpResp, err := client.NetworkPeeringApi.\n\t\tDeletePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringContainerApiParams{}\n\thttpResp, err := client.NetworkPeeringApi.\n\t\tDeletePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49262,7 +49262,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tGetPeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tGetPeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49363,7 +49363,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tUpdatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tUpdatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49433,7 +49433,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCustomDatabaseRolesApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tListCustomDatabaseRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCustomDatabaseRolesApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tListCustomDatabaseRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49521,7 +49521,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tCreateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tCreateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49603,7 +49603,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteCustomDatabaseRoleApiParams{}\n\thttpResp, err := client.CustomDatabaseRolesApi.\n\t\tDeleteCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteCustomDatabaseRoleApiParams{}\n\thttpResp, err := client.CustomDatabaseRolesApi.\n\t\tDeleteCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49680,7 +49680,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tGetCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tGetCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49777,7 +49777,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tUpdateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tUpdateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49860,7 +49860,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListFederatedDatabasesApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tListFederatedDatabasesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListFederatedDatabasesApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tListFederatedDatabasesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49945,7 +49945,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50021,7 +50021,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederatedDatabaseApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederatedDatabaseApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50098,7 +50098,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tGetFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tGetFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50195,7 +50195,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tUpdateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tUpdateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50277,7 +50277,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50365,7 +50365,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOneDataFederationInstanceQueryLimitApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteOneDataFederationInstanceQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOneDataFederationInstanceQueryLimitApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteOneDataFederationInstanceQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50454,7 +50454,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50557,7 +50557,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOneDataFederationQueryLimitApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateOneDataFederationQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOneDataFederationQueryLimitApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateOneDataFederationQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50663,7 +50663,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadFederatedDatabaseQueryLogsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tDownloadFederatedDatabaseQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadFederatedDatabaseQueryLogsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tDownloadFederatedDatabaseQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50739,7 +50739,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUsersApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tListDatabaseUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUsersApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tListDatabaseUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50979,7 +50979,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tCreateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tCreateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51071,7 +51071,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDatabaseUserApiParams{}\n\thttpResp, err := client.DatabaseUsersApi.\n\t\tDeleteDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDatabaseUserApiParams{}\n\thttpResp, err := client.DatabaseUsersApi.\n\t\tDeleteDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51158,7 +51158,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tGetDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tGetDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51265,7 +51265,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tUpdateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tUpdateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51353,7 +51353,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUserCertificatesApiParams{}\n\tsdkResp, httpResp, err := client.X509AuthenticationApi.\n\t\tListDatabaseUserCertificatesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUserCertificatesApiParams{}\n\tsdkResp, httpResp, err := client.X509AuthenticationApi.\n\t\tListDatabaseUserCertificatesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51455,7 +51455,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserCertificateApiParams{}\n\tsdkResp, httpResp, err := client.X509AuthenticationApi.\n\t\tCreateDatabaseUserCertificateWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserCertificateApiParams{}\n\tsdkResp, httpResp, err := client.X509AuthenticationApi.\n\t\tCreateDatabaseUserCertificateWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51588,7 +51588,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByClusterNameApiParams{}\n\tsdkResp, httpResp, err := client.AccessTrackingApi.\n\t\tListAccessLogsByClusterNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByClusterNameApiParams{}\n\tsdkResp, httpResp, err := client.AccessTrackingApi.\n\t\tListAccessLogsByClusterNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51718,7 +51718,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByHostnameApiParams{}\n\tsdkResp, httpResp, err := client.AccessTrackingApi.\n\t\tListAccessLogsByHostnameWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByHostnameApiParams{}\n\tsdkResp, httpResp, err := client.AccessTrackingApi.\n\t\tListAccessLogsByHostnameWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51785,7 +51785,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51870,7 +51870,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tUpdateEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tUpdateEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51949,7 +51949,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointsForCloudProviderApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointsForCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointsForCloudProviderApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointsForCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52037,7 +52037,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tCreateEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tCreateEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52139,7 +52139,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RequestEncryptionAtRestPrivateEndpointDeletionApiParams{}\n\thttpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tRequestEncryptionAtRestPrivateEndpointDeletionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RequestEncryptionAtRestPrivateEndpointDeletionApiParams{}\n\thttpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tRequestEncryptionAtRestPrivateEndpointDeletionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52228,7 +52228,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52371,7 +52371,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectEventsApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListProjectEventsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectEventsApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListProjectEventsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52462,7 +52462,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectEventApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tGetProjectEventWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectEventApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tGetProjectEventWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52532,7 +52532,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListMetricTypesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListMetricTypesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListMetricTypesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListMetricTypesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52648,7 +52648,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52767,7 +52767,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52878,7 +52878,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52960,7 +52960,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListThirdPartyIntegrationsApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tListThirdPartyIntegrationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListThirdPartyIntegrationsApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tListThirdPartyIntegrationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53055,7 +53055,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteThirdPartyIntegrationApiParams{}\n\thttpResp, err := client.Third - PartyIntegrationsApi.\n\t\tDeleteThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteThirdPartyIntegrationApiParams{}\n\thttpResp, err := client.Third - PartyIntegrationsApi.\n\t\tDeleteThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53148,7 +53148,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tGetThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tGetThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53264,7 +53264,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tCreateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tCreateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53377,7 +53377,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tUpdateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tUpdateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53457,7 +53457,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectInvitationsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectInvitationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectInvitationsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectInvitationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53541,7 +53541,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53619,7 +53619,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tCreateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tCreateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53697,7 +53697,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectInvitationApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectInvitationApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53779,7 +53779,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53872,7 +53872,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53943,7 +53943,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnAllIPAddressesApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tReturnAllIPAddressesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnAllIPAddressesApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tReturnAllIPAddressesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54022,7 +54022,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectLimitsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectLimitsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectLimitsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectLimitsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54119,7 +54119,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectLimitApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectLimitApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54217,7 +54217,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54326,7 +54326,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tSetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tSetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54416,7 +54416,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCreatePushMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCreatePushMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54507,7 +54507,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ValidateMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tValidateMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ValidateMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tValidateMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54594,7 +54594,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetValidationStatusApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tGetValidationStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetValidationStatusApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tGetValidationStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54670,7 +54670,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tGetPushMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tGetPushMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54746,7 +54746,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CutoverMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCutoverMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CutoverMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCutoverMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54810,7 +54810,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResetMaintenanceWindowApiParams{}\n\thttpResp, err := client.MaintenanceWindowsApi.\n\t\tResetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResetMaintenanceWindowApiParams{}\n\thttpResp, err := client.MaintenanceWindowsApi.\n\t\tResetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54875,7 +54875,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tGetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tGetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54951,7 +54951,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tUpdateMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tUpdateMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55015,7 +55015,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleMaintenanceAutoDeferApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tToggleMaintenanceAutoDeferWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleMaintenanceAutoDeferApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tToggleMaintenanceAutoDeferWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55079,7 +55079,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeferMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tDeferMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeferMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tDeferMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55146,7 +55146,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedSlowMsApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tGetManagedSlowMsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedSlowMsApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tGetManagedSlowMsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55213,7 +55213,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableSlowOperationThresholdingApiParams{}\n\thttpResp, err := client.PerformanceAdvisorApi.\n\t\tDisableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableSlowOperationThresholdingApiParams{}\n\thttpResp, err := client.PerformanceAdvisorApi.\n\t\tDisableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55280,7 +55280,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EnableSlowOperationThresholdingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tEnableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EnableSlowOperationThresholdingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tEnableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55408,7 +55408,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLTSVersionsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectLTSVersionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLTSVersionsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectLTSVersionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55501,7 +55501,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringConnectionsApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringConnectionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringConnectionsApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringConnectionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55590,7 +55590,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tCreatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tCreatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55672,7 +55672,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringConnectionApiParams{}\n\thttpResp, err := client.NetworkPeeringApi.\n\t\tDeletePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringConnectionApiParams{}\n\thttpResp, err := client.NetworkPeeringApi.\n\t\tDeletePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55752,7 +55752,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tGetPeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tGetPeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55849,7 +55849,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tUpdatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tUpdatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55919,7 +55919,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelinesApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelinesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelinesApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelinesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55998,7 +55998,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tCreatePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tCreatePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56077,7 +56077,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineApiParams{}\n\thttpResp, err := client.DataLakePipelinesApi.\n\t\tDeletePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineApiParams{}\n\thttpResp, err := client.DataLakePipelinesApi.\n\t\tDeletePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56157,7 +56157,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tGetPipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tGetPipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56251,7 +56251,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tUpdatePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tUpdatePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56336,7 +56336,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSchedulesApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineSchedulesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSchedulesApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineSchedulesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56437,7 +56437,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSnapshotsApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineSnapshotsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSnapshotsApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineSnapshotsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56519,7 +56519,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PausePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tPausePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PausePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tPausePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56601,7 +56601,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResumePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tResumePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResumePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tResumePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56702,7 +56702,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineRunsApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineRunsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineRunsApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineRunsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56797,7 +56797,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineRunDatasetApiParams{}\n\thttpResp, err := client.DataLakePipelinesApi.\n\t\tDeletePipelineRunDatasetWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineRunDatasetApiParams{}\n\thttpResp, err := client.DataLakePipelinesApi.\n\t\tDeletePipelineRunDatasetWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56890,7 +56890,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineRunApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tGetPipelineRunWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineRunApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tGetPipelineRunWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56983,7 +56983,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TriggerSnapshotIngestionApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tTriggerSnapshotIngestionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TriggerSnapshotIngestionApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tTriggerSnapshotIngestionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57065,7 +57065,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57135,7 +57135,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57214,7 +57214,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tToggleRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tToggleRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57295,7 +57295,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tListServerlessPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tListServerlessPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57386,7 +57386,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tCreateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tCreateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57476,7 +57476,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessPrivateEndpointApiParams{}\n\thttpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tDeleteServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessPrivateEndpointApiParams{}\n\thttpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tDeleteServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57564,7 +57564,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tGetServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tGetServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57663,7 +57663,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tUpdateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tUpdateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57748,7 +57748,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPrivateEndpointServicesApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tListPrivateEndpointServicesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPrivateEndpointServicesApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tListPrivateEndpointServicesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57842,7 +57842,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointServiceApiParams{}\n\thttpResp, err := client.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointServiceApiParams{}\n\thttpResp, err := client.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57937,7 +57937,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58051,7 +58051,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58155,7 +58155,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointApiParams{}\n\thttpResp, err := client.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointApiParams{}\n\thttpResp, err := client.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58260,7 +58260,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58332,7 +58332,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyConnectViaPeeringOnlyModeForOneProjectApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tVerifyConnectViaPeeringOnlyModeForOneProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyConnectViaPeeringOnlyModeForOneProjectApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tVerifyConnectViaPeeringOnlyModeForOneProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58416,7 +58416,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisablePeeringApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tDisablePeeringWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisablePeeringApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tDisablePeeringWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58498,7 +58498,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDataFederationPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tListDataFederationPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDataFederationPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tListDataFederationPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58577,7 +58577,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58659,7 +58659,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDataFederationPrivateEndpointApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDataFederationPrivateEndpointApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58742,7 +58742,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tGetDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tGetDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58818,7 +58818,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasProcessesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListAtlasProcessesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasProcessesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListAtlasProcessesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58896,7 +58896,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasProcessApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetAtlasProcessWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasProcessApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetAtlasProcessWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58972,7 +58972,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespacesForHostApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespacesForHostWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespacesForHostApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespacesForHostWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59059,7 +59059,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabasesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDatabasesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabasesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDatabasesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59146,7 +59146,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59272,7 +59272,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDatabaseMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDatabaseMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59359,7 +59359,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskPartitionsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDiskPartitionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskPartitionsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDiskPartitionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59443,7 +59443,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59578,7 +59578,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59820,7 +59820,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetHostMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetHostMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59916,7 +59916,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueryNamespacesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSlowQueryNamespacesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueryNamespacesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSlowQueryNamespacesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60036,7 +60036,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueriesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSlowQueriesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueriesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSlowQueriesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60172,7 +60172,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSuggestedIndexesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSuggestedIndexesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSuggestedIndexesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSuggestedIndexesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60299,7 +60299,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespaceHostMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespaceHostMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespaceHostMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespaceHostMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60372,7 +60372,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePushBasedLogConfigurationApiParams{}\n\thttpResp, err := client.Push - BasedLogExportApi.\n\t\tDeletePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePushBasedLogConfigurationApiParams{}\n\thttpResp, err := client.Push - BasedLogExportApi.\n\t\tDeletePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60443,7 +60443,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tGetPushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tGetPushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60526,7 +60526,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tUpdatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tUpdatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60609,7 +60609,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tCreatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tCreatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60691,7 +60691,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.LoadSampleDatasetApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tLoadSampleDatasetWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.LoadSampleDatasetApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tLoadSampleDatasetWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60767,7 +60767,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSampleDatasetLoadStatusApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetSampleDatasetLoadStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSampleDatasetLoadStatusApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetSampleDatasetLoadStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60843,7 +60843,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessInstancesApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tListServerlessInstancesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessInstancesApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tListServerlessInstancesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60925,7 +60925,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tCreateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tCreateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61016,7 +61016,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListServerlessBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListServerlessBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61113,7 +61113,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61207,7 +61207,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61298,7 +61298,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListServerlessBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListServerlessBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61390,7 +61390,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetServerlessBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetServerlessBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61469,7 +61469,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tGetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tGetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61552,7 +61552,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tSetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tSetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61637,7 +61637,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessInstanceApiParams{}\n\thttpResp, err := client.ServerlessInstancesApi.\n\t\tDeleteServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessInstanceApiParams{}\n\thttpResp, err := client.ServerlessInstancesApi.\n\t\tDeleteServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61720,7 +61720,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tGetServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tGetServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61811,7 +61811,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tUpdateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tUpdateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61887,7 +61887,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectServiceAccountsApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tListProjectServiceAccountsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectServiceAccountsApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tListProjectServiceAccountsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61967,7 +61967,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tCreateProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tCreateProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62047,7 +62047,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectServiceAccountApiParams{}\n\thttpResp, err := client.GroupsApi.\n\t\tDeleteProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectServiceAccountApiParams{}\n\thttpResp, err := client.GroupsApi.\n\t\tDeleteProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62124,7 +62124,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tGetProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tGetProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62215,7 +62215,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tUpdateProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tUpdateProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62308,7 +62308,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tAddProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tAddProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62381,7 +62381,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62463,7 +62463,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62536,7 +62536,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamInstancesApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tListStreamInstancesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamInstancesApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tListStreamInstancesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62615,7 +62615,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tCreateStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tCreateStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62697,7 +62697,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamInstanceApiParams{}\n\thttpResp, err := client.StreamsApi.\n\t\tDeleteStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamInstanceApiParams{}\n\thttpResp, err := client.StreamsApi.\n\t\tDeleteStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62782,7 +62782,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tGetStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tGetStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62876,7 +62876,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tUpdateStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tUpdateStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62985,7 +62985,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadStreamTenantAuditLogsApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tDownloadStreamTenantAuditLogsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadStreamTenantAuditLogsApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tDownloadStreamTenantAuditLogsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63070,7 +63070,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamConnectionsApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tListStreamConnectionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamConnectionsApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tListStreamConnectionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63161,7 +63161,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tCreateStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tCreateStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63252,7 +63252,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamConnectionApiParams{}\n\thttpResp, err := client.StreamsApi.\n\t\tDeleteStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamConnectionApiParams{}\n\thttpResp, err := client.StreamsApi.\n\t\tDeleteStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63335,7 +63335,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tGetStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tGetStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63438,7 +63438,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tUpdateStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tUpdateStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63523,7 +63523,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectTeamsApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListProjectTeamsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectTeamsApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListProjectTeamsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63615,7 +63615,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddAllTeamsToProjectApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tAddAllTeamsToProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddAllTeamsToProjectApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tAddAllTeamsToProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63701,7 +63701,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectTeamApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tRemoveProjectTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectTeamApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tRemoveProjectTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63802,7 +63802,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateTeamRolesApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tUpdateTeamRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateTeamRolesApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tUpdateTeamRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63869,7 +63869,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63948,7 +63948,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SaveLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tSaveLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SaveLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tSaveLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64012,7 +64012,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableCustomerManagedX509ApiParams{}\n\thttpResp, err := client.X509AuthenticationApi.\n\t\tDisableCustomerManagedX509WithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableCustomerManagedX509ApiParams{}\n\thttpResp, err := client.X509AuthenticationApi.\n\t\tDisableCustomerManagedX509WithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64079,7 +64079,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLDAPConfigurationApiParams{}\n\thttpResp, err := client.LDAPConfigurationApi.\n\t\tDeleteLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLDAPConfigurationApiParams{}\n\thttpResp, err := client.LDAPConfigurationApi.\n\t\tDeleteLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64160,7 +64160,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tVerifyLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tVerifyLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64239,7 +64239,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationStatusApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationStatusApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64333,7 +64333,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectUsersApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectUsersApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64415,7 +64415,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectUserApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tRemoveProjectUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectUserApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tRemoveProjectUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64511,7 +64511,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectRolesApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectRolesApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64601,7 +64601,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64686,7 +64686,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64762,7 +64762,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64836,7 +64836,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64921,7 +64921,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tRenameOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tRenameOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65001,7 +65001,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeysApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListApiKeysWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeysApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListApiKeysWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65081,7 +65081,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65164,7 +65164,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65245,7 +65245,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65340,7 +65340,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65432,7 +65432,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeyAccessListsEntriesApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListApiKeyAccessListsEntriesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeyAccessListsEntriesApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListApiKeyAccessListsEntriesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65538,7 +65538,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65638,7 +65638,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyAccessListEntryApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyAccessListEntryWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyAccessListEntryApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyAccessListEntryWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65733,7 +65733,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65811,7 +65811,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcessApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tCreateCostExplorerQueryProcessWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcessApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tCreateCostExplorerQueryProcessWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65902,7 +65902,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcess_1ApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tCreateCostExplorerQueryProcess_1WithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcess_1ApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tCreateCostExplorerQueryProcess_1WithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66017,7 +66017,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationEventsApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListOrganizationEventsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationEventsApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListOrganizationEventsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66108,7 +66108,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationEventApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tGetOrganizationEventWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationEventApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tGetOrganizationEventWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66181,7 +66181,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetFederationSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetFederationSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66271,7 +66271,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationProjectsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationProjectsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66356,7 +66356,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationInvitationsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationInvitationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationInvitationsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationInvitationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66438,7 +66438,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66520,7 +66520,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66602,7 +66602,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationInvitationApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationInvitationApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66682,7 +66682,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66776,7 +66776,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66934,7 +66934,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListInvoicesApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tListInvoicesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListInvoicesApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tListInvoicesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67004,7 +67004,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPendingInvoicesApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tListPendingInvoicesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPendingInvoicesApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tListPendingInvoicesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67092,7 +67092,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetInvoiceApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tGetInvoiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetInvoiceApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tGetInvoiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67173,7 +67173,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadInvoiceCSVApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tDownloadInvoiceCSVWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadInvoiceCSVApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tDownloadInvoiceCSVWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67246,7 +67246,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSourceProjectsApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tListSourceProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSourceProjectsApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tListSourceProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67313,7 +67313,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLinkTokenApiParams{}\n\thttpResp, err := client.CloudMigrationServiceApi.\n\t\tDeleteLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLinkTokenApiParams{}\n\thttpResp, err := client.CloudMigrationServiceApi.\n\t\tDeleteLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67392,7 +67392,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLinkTokenApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCreateLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLinkTokenApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCreateLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67468,7 +67468,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServiceAccountsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListServiceAccountsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServiceAccountsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListServiceAccountsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67547,7 +67547,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67623,7 +67623,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServiceAccountApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServiceAccountApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67700,7 +67700,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67791,7 +67791,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67876,7 +67876,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServiceAccountProjectsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListServiceAccountProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServiceAccountProjectsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListServiceAccountProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67966,7 +67966,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServiceAccountSecretApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateServiceAccountSecretWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServiceAccountSecretApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateServiceAccountSecretWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -68051,7 +68051,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServiceAccountSecretApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteServiceAccountSecretWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServiceAccountSecretApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteServiceAccountSecretWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -68124,7 +68124,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -68206,7 +68206,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -68292,7 +68292,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationTeamsApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListOrganizationTeamsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationTeamsApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListOrganizationTeamsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -68381,7 +68381,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateTeamApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tCreateTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateTeamApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tCreateTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -68467,7 +68467,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByNameApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tGetTeamByNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByNameApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tGetTeamByNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -68556,7 +68556,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteTeamApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tDeleteTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteTeamApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tDeleteTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -68643,7 +68643,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByIdApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tGetTeamByIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByIdApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tGetTeamByIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -68744,7 +68744,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameTeamApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tRenameTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameTeamApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tRenameTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -68842,7 +68842,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListTeamUsersApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListTeamUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListTeamUsersApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListTeamUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -68946,7 +68946,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddTeamUserApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tAddTeamUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddTeamUserApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tAddTeamUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -69044,7 +69044,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveTeamUserApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tRemoveTeamUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveTeamUserApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tRemoveTeamUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -69126,7 +69126,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationUsersApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationUsersApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -69211,7 +69211,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveOrganizationUserApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tRemoveOrganizationUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveOrganizationUserApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tRemoveOrganizationUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -69307,7 +69307,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationRolesApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationRolesApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -69360,7 +69360,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnAllControlPlaneIPAddressesApiParams{}\n\tsdkResp, httpResp, err := client.RootApi.\n\t\tReturnAllControlPlaneIPAddressesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnAllControlPlaneIPAddressesApiParams{}\n\tsdkResp, httpResp, err := client.RootApi.\n\t\tReturnAllControlPlaneIPAddressesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -69438,7 +69438,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateUserApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tCreateUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateUserApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tCreateUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -69515,7 +69515,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserByUsernameApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tGetUserByUsernameWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserByUsernameApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tGetUserByUsernameWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -69594,7 +69594,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tGetUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tGetUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",

--- a/tools/cli/test/data/split/dev/openapi-v2-2023-11-15.yaml
+++ b/tools/cli/test/data/split/dev/openapi-v2-2023-11-15.yaml
@@ -29618,9 +29618,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -29690,9 +29688,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -29763,9 +29759,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -29836,9 +29830,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -29907,9 +29899,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -29983,9 +29973,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30067,9 +30055,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30150,9 +30136,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30240,9 +30224,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30319,9 +30301,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30400,9 +30380,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30487,9 +30465,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30571,9 +30547,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30662,9 +30636,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30764,9 +30736,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30849,9 +30819,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30932,9 +30900,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31014,9 +30980,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31104,9 +31068,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31187,9 +31149,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31261,9 +31221,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31336,9 +31294,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31428,9 +31384,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31505,9 +31459,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31577,9 +31529,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31660,9 +31610,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31747,9 +31695,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31828,9 +31774,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31917,9 +31861,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32010,9 +31952,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32095,9 +32035,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32180,9 +32118,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32257,9 +32193,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32339,9 +32273,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32427,9 +32359,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32512,9 +32442,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32606,9 +32534,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32706,9 +32632,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32799,9 +32723,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32887,9 +32809,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32972,9 +32892,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33066,9 +32984,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33159,9 +33075,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33236,9 +33150,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33313,9 +33225,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33402,9 +33312,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33493,9 +33401,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33585,9 +33491,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33660,9 +33564,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33739,9 +33641,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33814,9 +33714,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33891,9 +33789,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33970,9 +33866,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34055,9 +33949,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34144,9 +34036,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34226,9 +34116,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34300,9 +34188,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34388,9 +34274,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34463,9 +34347,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34543,9 +34425,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34635,9 +34515,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34715,9 +34593,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34808,9 +34684,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34893,9 +34767,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34980,9 +34852,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35074,9 +34944,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35158,9 +35026,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35252,9 +35118,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35391,9 +35255,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35483,9 +35345,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35566,9 +35426,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35657,9 +35515,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35746,9 +35602,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35829,9 +35683,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35924,9 +35776,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36019,9 +35869,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36107,9 +35955,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36189,9 +36035,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36270,9 +36114,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36363,9 +36205,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36453,9 +36293,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36544,9 +36382,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36639,9 +36475,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36729,9 +36563,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36826,9 +36658,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36919,9 +36749,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37009,9 +36837,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37091,9 +36917,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37186,9 +37010,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37283,9 +37105,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37369,9 +37189,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37460,9 +37278,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37542,9 +37358,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37633,9 +37447,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37717,9 +37529,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37811,9 +37621,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37894,9 +37702,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37990,9 +37796,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38090,9 +37894,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38184,9 +37986,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38283,9 +38083,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38386,9 +38184,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38482,9 +38278,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38575,9 +38369,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38679,9 +38471,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38768,9 +38558,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38853,9 +38641,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38946,9 +38732,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39047,9 +38831,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39142,9 +38924,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39302,9 +39082,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39392,9 +39170,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39487,9 +39263,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39585,9 +39359,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39680,9 +39452,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39784,9 +39554,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39898,9 +39666,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39985,9 +39751,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40071,9 +39835,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40162,9 +39924,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40252,9 +40012,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40348,9 +40106,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40431,9 +40187,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40532,9 +40286,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40621,9 +40373,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40720,9 +40470,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40803,9 +40551,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40886,9 +40632,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40978,9 +40722,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41074,9 +40816,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41163,9 +40903,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41253,9 +40991,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41351,9 +41087,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41443,9 +41177,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41532,9 +41264,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41628,9 +41358,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41712,9 +41440,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41827,9 +41553,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41913,9 +41637,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41999,9 +41721,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42089,9 +41809,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42167,9 +41885,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42254,9 +41970,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42339,9 +42053,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42430,9 +42142,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42510,9 +42220,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42605,9 +42313,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42683,9 +42389,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42756,9 +42460,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42841,9 +42543,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42926,9 +42626,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43004,9 +42702,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43095,9 +42791,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43181,9 +42875,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43264,9 +42956,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43345,9 +43035,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43424,9 +43112,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43515,9 +43201,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43600,9 +43284,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43695,9 +43377,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43790,9 +43470,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43895,9 +43573,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44000,9 +43676,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44074,9 +43748,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44250,9 +43922,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44355,9 +44025,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44453,9 +44121,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44564,9 +44230,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44650,9 +44314,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44750,9 +44412,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44871,9 +44531,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44985,9 +44643,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45059,9 +44715,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45154,9 +44808,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45237,9 +44889,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45322,9 +44972,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45421,9 +45069,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45508,9 +45154,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45636,9 +45280,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45727,9 +45369,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45800,9 +45440,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45903,9 +45541,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46005,9 +45641,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46106,9 +45740,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46184,9 +45816,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46277,9 +45907,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46369,9 +45997,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46473,9 +46099,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46579,9 +46203,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46663,9 +46285,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46746,9 +46366,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46829,9 +46447,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46914,9 +46530,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46997,9 +46611,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47088,9 +46700,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47166,9 +46776,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47245,9 +46853,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47356,9 +46962,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47468,9 +47072,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47590,9 +47192,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47688,9 +47288,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47769,9 +47367,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47845,9 +47441,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47936,9 +47530,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48027,9 +47619,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48097,9 +47687,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48167,9 +47755,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48245,9 +47831,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48319,9 +47903,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48393,9 +47975,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48468,9 +48048,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48539,9 +48117,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48610,9 +48186,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48726,9 +48300,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48812,9 +48384,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48898,9 +48468,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48984,9 +48552,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49065,9 +48631,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49157,9 +48721,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49235,9 +48797,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49315,9 +48875,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49400,9 +48958,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49481,9 +49037,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49572,9 +49126,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49660,9 +49212,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49752,9 +49302,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49834,9 +49382,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49920,9 +49466,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50016,9 +49560,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50108,9 +49650,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50199,9 +49739,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50288,9 +49826,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50376,9 +49912,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50467,9 +50001,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50559,9 +50091,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50663,9 +50193,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50765,9 +50293,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50864,9 +50390,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50945,9 +50469,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51022,9 +50544,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51101,9 +50621,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51187,9 +50705,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51279,9 +50795,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51372,9 +50886,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51460,9 +50972,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51555,9 +51065,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51634,9 +51142,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51717,9 +51223,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51799,9 +51303,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51897,9 +51399,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51983,9 +51483,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52066,9 +51564,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52140,9 +51636,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52219,9 +51713,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52333,9 +51825,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52407,9 +51897,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52489,9 +51977,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52574,9 +52060,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52685,9 +52169,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52767,9 +52249,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52851,9 +52331,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52978,9 +52456,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53216,9 +52692,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53315,9 +52789,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53431,9 +52903,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53554,9 +53024,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53629,9 +53097,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53703,9 +53169,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53785,9 +53249,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53871,9 +53333,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53958,9 +53418,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54041,9 +53499,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54115,9 +53571,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54196,9 +53650,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54285,9 +53737,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54377,9 +53827,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54472,9 +53920,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54557,9 +54003,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54648,9 +54092,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54728,9 +54170,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54812,9 +54252,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54900,9 +54338,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54983,9 +54419,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55071,9 +54505,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55150,9 +54582,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55230,9 +54660,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55314,9 +54742,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55392,9 +54818,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55479,9 +54903,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55572,9 +54994,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55651,9 +55071,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55732,9 +55150,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55809,9 +55225,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55888,9 +55302,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55973,9 +55385,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56057,9 +55467,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56146,9 +55554,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56252,9 +55658,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56333,9 +55737,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56420,9 +55822,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56511,9 +55911,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56594,9 +55992,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56689,9 +56085,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56773,9 +56167,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56861,9 +56253,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56951,9 +56341,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57046,9 +56434,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57121,9 +56507,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57203,9 +56587,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57280,9 +56662,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57351,9 +56731,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57431,9 +56809,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57515,9 +56891,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57601,9 +56975,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57683,9 +57055,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57774,9 +57144,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57862,9 +57230,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57946,9 +57312,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58030,9 +57394,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58117,9 +57479,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58193,9 +57553,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58276,9 +57634,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58357,9 +57713,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58437,9 +57791,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58524,9 +57876,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58606,9 +57956,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58697,9 +58045,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58787,9 +58133,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58882,9 +58226,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58981,9 +58323,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59073,9 +58413,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59152,9 +58490,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59245,9 +58581,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59351,9 +58685,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59442,9 +58774,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59517,9 +58847,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59608,9 +58936,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59691,9 +59017,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59772,9 +59096,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59857,9 +59179,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59942,9 +59262,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60024,9 +59342,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60114,9 +59430,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60253,9 +59567,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60341,9 +59653,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60430,9 +59740,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60503,9 +59811,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60578,9 +59884,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60650,9 +59954,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60729,9 +60031,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60808,9 +60108,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60887,9 +60185,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60968,9 +60264,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -61046,9 +60340,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -61133,9 +60425,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -61218,9 +60508,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -61304,9 +60592,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -61391,9 +60677,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -61466,9 +60750,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -61547,9 +60829,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -61632,9 +60912,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -61718,9 +60996,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -61809,9 +61085,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -61895,9 +61169,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -61990,9 +61262,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -62085,9 +61355,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -62182,9 +61450,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -62280,9 +61546,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -62364,9 +61628,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -62442,9 +61704,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -62527,9 +61787,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -62618,9 +61876,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -62687,9 +61943,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -62771,9 +62025,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -62856,9 +62108,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -62935,9 +62185,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)

--- a/tools/cli/test/data/split/dev/openapi-v2-2024-05-30.json
+++ b/tools/cli/test/data/split/dev/openapi-v2-2024-05-30.json
@@ -36465,7 +36465,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSystemStatusApiParams{}\n\tsdkResp, httpResp, err := client.RootApi.\n\t\tGetSystemStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSystemStatusApiParams{}\n\tsdkResp, httpResp, err := client.RootApi.\n\t\tGetSystemStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36532,7 +36532,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationMatchersFieldNamesApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationMatchersFieldNamesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationMatchersFieldNamesApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationMatchersFieldNamesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36605,7 +36605,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersForAllProjectsApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListClustersForAllProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersForAllProjectsApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListClustersForAllProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36678,7 +36678,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListEventTypesApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListEventTypesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListEventTypesApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListEventTypesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36742,7 +36742,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederationAppApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tDeleteFederationAppWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederationAppApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tDeleteFederationAppWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36818,7 +36818,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListConnectedOrgConfigsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListConnectedOrgConfigsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListConnectedOrgConfigsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListConnectedOrgConfigsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36901,7 +36901,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveConnectedOrgConfigApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tRemoveConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveConnectedOrgConfigApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tRemoveConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36982,7 +36982,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37074,7 +37074,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37147,7 +37147,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListRoleMappingsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListRoleMappingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListRoleMappingsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListRoleMappingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37229,7 +37229,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tCreateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tCreateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37312,7 +37312,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteRoleMappingApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tDeleteRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteRoleMappingApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tDeleteRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37396,7 +37396,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37491,7 +37491,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37599,7 +37599,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIdentityProvidersApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListIdentityProvidersWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIdentityProvidersApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListIdentityProvidersWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37681,7 +37681,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tCreateIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tCreateIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37758,7 +37758,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteIdentityProviderApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tDeleteIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteIdentityProviderApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tDeleteIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37839,7 +37839,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37928,7 +37928,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38005,7 +38005,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RevokeJwksFromIdentityProviderApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tRevokeJwksFromIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RevokeJwksFromIdentityProviderApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tRevokeJwksFromIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38075,7 +38075,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderMetadataApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetIdentityProviderMetadataWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderMetadataApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetIdentityProviderMetadataWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38151,7 +38151,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38247,7 +38247,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tCreateProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tCreateProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38331,7 +38331,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectByNameApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectByNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectByNameApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectByNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38401,7 +38401,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38469,7 +38469,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38554,7 +38554,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38640,7 +38640,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddUserToProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tAddUserToProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddUserToProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tAddUserToProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38720,7 +38720,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectIpAccessListsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tListProjectIpAccessListsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectIpAccessListsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tListProjectIpAccessListsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38818,7 +38818,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectIpAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tCreateProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectIpAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tCreateProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38903,7 +38903,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectIpAccessListApiParams{}\n\thttpResp, err := client.ProjectIPAccessListApi.\n\t\tDeleteProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectIpAccessListApiParams{}\n\thttpResp, err := client.ProjectIPAccessListApi.\n\t\tDeleteProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38989,7 +38989,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpListApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tGetProjectIpListWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpListApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tGetProjectIpListWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39076,7 +39076,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpAccessListStatusApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tGetProjectIpAccessListStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpAccessListStatusApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tGetProjectIpAccessListStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39152,7 +39152,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39231,7 +39231,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tCreateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tCreateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39311,7 +39311,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAlertConfigurationApiParams{}\n\thttpResp, err := client.AlertConfigurationsApi.\n\t\tDeleteAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAlertConfigurationApiParams{}\n\thttpResp, err := client.AlertConfigurationsApi.\n\t\tDeleteAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39392,7 +39392,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tGetAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tGetAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39484,7 +39484,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tToggleAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tToggleAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39579,7 +39579,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tUpdateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tUpdateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39671,7 +39671,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsByAlertConfigurationIdApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tListAlertsByAlertConfigurationIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsByAlertConfigurationIdApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tListAlertsByAlertConfigurationIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39763,7 +39763,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tListAlertsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tListAlertsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39845,7 +39845,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tGetAlertWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tGetAlertWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39939,7 +39939,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AcknowledgeAlertApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tAcknowledgeAlertWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AcknowledgeAlertApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tAcknowledgeAlertWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40030,7 +40030,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsByAlertIdApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationsByAlertIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsByAlertIdApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationsByAlertIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40110,7 +40110,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectApiKeysApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListProjectApiKeysWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectApiKeysApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListProjectApiKeysWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40186,7 +40186,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40272,7 +40272,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectApiKeyApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tRemoveProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectApiKeyApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tRemoveProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40372,7 +40372,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyRolesApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyRolesApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40463,7 +40463,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tAddProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tAddProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40530,7 +40530,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AuditingApi.\n\t\tGetAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AuditingApi.\n\t\tGetAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40609,7 +40609,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AuditingApi.\n\t\tUpdateAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AuditingApi.\n\t\tUpdateAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40676,7 +40676,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := client.AWSClustersDNSApi.\n\t\tGetAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := client.AWSClustersDNSApi.\n\t\tGetAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40752,7 +40752,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := client.AWSClustersDNSApi.\n\t\tToggleAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := client.AWSClustersDNSApi.\n\t\tToggleAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40828,7 +40828,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListExportBucketsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListExportBucketsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListExportBucketsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListExportBucketsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40965,7 +40965,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateExportBucketApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateExportBucketWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateExportBucketApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateExportBucketWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41048,7 +41048,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteExportBucketApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteExportBucketWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteExportBucketApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteExportBucketWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41160,7 +41160,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetExportBucketApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetExportBucketWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetExportBucketApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetExportBucketWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41230,7 +41230,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41322,7 +41322,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41389,7 +41389,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderAccessRolesApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tListCloudProviderAccessRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderAccessRolesApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tListCloudProviderAccessRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41469,7 +41469,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tCreateCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tCreateCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41560,7 +41560,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeauthorizeCloudProviderAccessRoleApiParams{}\n\thttpResp, err := client.CloudProviderAccessApi.\n\t\tDeauthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeauthorizeCloudProviderAccessRoleApiParams{}\n\thttpResp, err := client.CloudProviderAccessApi.\n\t\tDeauthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41639,7 +41639,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tGetCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tGetCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41737,7 +41737,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AuthorizeCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tAuthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AuthorizeCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tAuthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41823,7 +41823,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListClustersWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListClustersWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41913,7 +41913,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tCreateClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tCreateClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42009,7 +42009,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderRegionsApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListCloudProviderRegionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderRegionsApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListCloudProviderRegionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42099,7 +42099,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpgradeSharedClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpgradeSharedClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42189,7 +42189,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterToServerlessApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpgradeSharedClusterToServerlessWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterToServerlessApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpgradeSharedClusterToServerlessWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42282,7 +42282,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteClusterApiParams{}\n\thttpResp, err := client.ClustersApi.\n\t\tDeleteClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteClusterApiParams{}\n\thttpResp, err := client.ClustersApi.\n\t\tDeleteClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42366,7 +42366,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42465,7 +42465,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpdateClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpdateClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42554,7 +42554,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupExportJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListBackupExportJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupExportJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListBackupExportJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42648,7 +42648,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42733,7 +42733,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42821,7 +42821,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42918,7 +42918,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43012,7 +43012,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CancelBackupRestoreJobApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tCancelBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CancelBackupRestoreJobApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tCancelBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43101,7 +43101,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43181,7 +43181,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllBackupSchedulesApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteAllBackupSchedulesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllBackupSchedulesApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteAllBackupSchedulesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43260,7 +43260,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43353,7 +43353,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43445,7 +43445,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListReplicaSetBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListReplicaSetBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListReplicaSetBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListReplicaSetBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43536,7 +43536,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TakeSnapshotApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tTakeSnapshotWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TakeSnapshotApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tTakeSnapshotWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43627,7 +43627,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteShardedClusterBackupApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteShardedClusterBackupApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43719,7 +43719,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetShardedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetShardedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43801,7 +43801,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListShardedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListShardedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListShardedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListShardedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43895,7 +43895,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteReplicaSetBackupApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteReplicaSetBackupApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43987,7 +43987,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetReplicaSetBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetReplicaSetBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44090,7 +44090,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateSnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateSnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateSnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateSnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44192,7 +44192,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tDownloadSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tDownloadSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44291,7 +44291,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tCreateSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tCreateSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44373,7 +44373,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tListSharedClusterBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tListSharedClusterBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44467,7 +44467,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tGetSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tGetSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44549,7 +44549,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tListSharedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tListSharedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44643,7 +44643,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tGetSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tGetSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44732,7 +44732,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupCheckpointsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacyBackupCheckpointsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupCheckpointsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacyBackupCheckpointsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44830,7 +44830,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupCheckpointApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacyBackupCheckpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupCheckpointApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacyBackupCheckpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44912,7 +44912,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPinnedNamespacesApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetPinnedNamespacesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPinnedNamespacesApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetPinnedNamespacesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45014,7 +45014,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PinNamespacesPatchApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tPinNamespacesPatchWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PinNamespacesPatchApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tPinNamespacesPatchWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45116,7 +45116,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PinNamespacesPutApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tPinNamespacesPutWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PinNamespacesPutApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tPinNamespacesPutWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45209,7 +45209,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UnpinNamespacesApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tUnpinNamespacesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UnpinNamespacesApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tUnpinNamespacesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45310,7 +45310,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tCreateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tCreateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45416,7 +45416,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasSearchIndexesDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tListAtlasSearchIndexesDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasSearchIndexesDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tListAtlasSearchIndexesDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45516,7 +45516,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchIndexDeprecatedApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchIndexDeprecatedApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45611,7 +45611,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45723,7 +45723,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45808,7 +45808,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tGetManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tGetManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45893,7 +45893,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllCustomZoneMappingsApiParams{}\n\thttpResp, err := client.GlobalClustersApi.\n\t\tDeleteAllCustomZoneMappingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllCustomZoneMappingsApiParams{}\n\thttpResp, err := client.GlobalClustersApi.\n\t\tDeleteAllCustomZoneMappingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45990,7 +45990,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomZoneMappingApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tCreateCustomZoneMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomZoneMappingApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tCreateCustomZoneMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46094,7 +46094,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteManagedNamespaceApiParams{}\n\thttpResp, err := client.GlobalClustersApi.\n\t\tDeleteManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteManagedNamespaceApiParams{}\n\thttpResp, err := client.GlobalClustersApi.\n\t\tDeleteManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46194,7 +46194,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tCreateManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tCreateManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46380,7 +46380,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRollingIndexApiParams{}\n\tsdkResp, httpResp, err := client.RollingIndexApi.\n\t\tCreateRollingIndexWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRollingIndexApiParams{}\n\tsdkResp, httpResp, err := client.RollingIndexApi.\n\t\tCreateRollingIndexWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46472,7 +46472,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOnlineArchivesApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tListOnlineArchivesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOnlineArchivesApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tListOnlineArchivesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46573,7 +46573,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tCreateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tCreateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46692,7 +46692,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadOnlineArchiveQueryLogsApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tDownloadOnlineArchiveQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadOnlineArchiveQueryLogsApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tDownloadOnlineArchiveQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46790,7 +46790,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOnlineArchiveApiParams{}\n\thttpResp, err := client.OnlineArchiveApi.\n\t\tDeleteOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOnlineArchiveApiParams{}\n\thttpResp, err := client.OnlineArchiveApi.\n\t\tDeleteOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46889,7 +46889,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tGetOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tGetOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47002,7 +47002,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tUpdateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tUpdateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47091,7 +47091,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EndOutageSimulationApiParams{}\n\thttpResp, err := client.ClusterOutageSimulationApi.\n\t\tEndOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EndOutageSimulationApiParams{}\n\thttpResp, err := client.ClusterOutageSimulationApi.\n\t\tEndOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47178,7 +47178,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := client.ClusterOutageSimulationApi.\n\t\tGetOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := client.ClusterOutageSimulationApi.\n\t\tGetOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47273,7 +47273,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.StartOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := client.ClusterOutageSimulationApi.\n\t\tStartOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.StartOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := client.ClusterOutageSimulationApi.\n\t\tStartOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47360,7 +47360,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47461,7 +47461,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpdateClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpdateClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47538,7 +47538,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TestFailoverApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tTestFailoverWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TestFailoverApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tTestFailoverWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47641,7 +47641,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacyBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacyBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47733,7 +47733,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tCreateLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tCreateLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47828,7 +47828,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47913,7 +47913,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchDeploymentApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchDeploymentApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47993,7 +47993,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48087,7 +48087,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48181,7 +48181,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tCreateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tCreateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48280,7 +48280,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasSearchIndexesClusterApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tListAtlasSearchIndexesClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasSearchIndexesClusterApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tListAtlasSearchIndexesClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48378,7 +48378,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchIndexApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tCreateAtlasSearchIndexWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchIndexApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tCreateAtlasSearchIndexWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48495,7 +48495,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasSearchIndexesApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tListAtlasSearchIndexesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasSearchIndexesApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tListAtlasSearchIndexesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48608,7 +48608,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchIndexByNameApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchIndexByNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchIndexByNameApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchIndexByNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48719,7 +48719,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchIndexByNameApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchIndexByNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchIndexByNameApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchIndexByNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48844,7 +48844,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchIndexByNameApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchIndexByNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchIndexByNameApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchIndexByNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48942,7 +48942,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchIndexApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchIndexWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchIndexApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchIndexWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49048,7 +49048,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchIndexApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchIndexWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchIndexApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchIndexWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49158,7 +49158,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchIndexApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchIndexWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchIndexApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchIndexWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49238,7 +49238,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49327,7 +49327,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tUpdateLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tUpdateLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49430,7 +49430,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacySnapshotsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacySnapshotsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacySnapshotsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacySnapshotsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49525,7 +49525,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLegacySnapshotApiParams{}\n\thttpResp, err := client.LegacyBackupApi.\n\t\tDeleteLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLegacySnapshotApiParams{}\n\thttpResp, err := client.LegacyBackupApi.\n\t\tDeleteLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49615,7 +49615,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49716,7 +49716,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tUpdateLegacySnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tUpdateLegacySnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49795,7 +49795,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterStatusApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterStatusApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49894,7 +49894,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespacesForClusterApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespacesForClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespacesForClusterApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespacesForClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50046,7 +50046,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespaceClusterMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespaceClusterMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespaceClusterMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespaceClusterMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50145,7 +50145,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PinFeatureCompatibilityVersionApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tPinFeatureCompatibilityVersionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PinFeatureCompatibilityVersionApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tPinFeatureCompatibilityVersionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50236,7 +50236,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UnpinFeatureCompatibilityVersionApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUnpinFeatureCompatibilityVersionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UnpinFeatureCompatibilityVersionApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUnpinFeatureCompatibilityVersionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50363,7 +50363,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostLogsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetHostLogsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostLogsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetHostLogsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50433,7 +50433,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespaceMetricsApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespaceMetricsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespaceMetricsApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespaceMetricsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50527,7 +50527,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainerByCloudProviderApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringContainerByCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainerByCloudProviderApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringContainerByCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50615,7 +50615,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tCreatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tCreatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50691,7 +50691,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainersApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringContainersWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainersApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringContainersWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50780,7 +50780,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringContainerApiParams{}\n\thttpResp, err := client.NetworkPeeringApi.\n\t\tDeletePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringContainerApiParams{}\n\thttpResp, err := client.NetworkPeeringApi.\n\t\tDeletePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50858,7 +50858,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tGetPeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tGetPeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50959,7 +50959,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tUpdatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tUpdatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51029,7 +51029,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCustomDatabaseRolesApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tListCustomDatabaseRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCustomDatabaseRolesApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tListCustomDatabaseRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51117,7 +51117,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tCreateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tCreateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51199,7 +51199,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteCustomDatabaseRoleApiParams{}\n\thttpResp, err := client.CustomDatabaseRolesApi.\n\t\tDeleteCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteCustomDatabaseRoleApiParams{}\n\thttpResp, err := client.CustomDatabaseRolesApi.\n\t\tDeleteCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51276,7 +51276,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tGetCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tGetCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51373,7 +51373,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tUpdateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tUpdateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51456,7 +51456,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListFederatedDatabasesApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tListFederatedDatabasesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListFederatedDatabasesApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tListFederatedDatabasesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51541,7 +51541,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51617,7 +51617,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederatedDatabaseApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederatedDatabaseApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51694,7 +51694,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tGetFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tGetFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51791,7 +51791,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tUpdateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tUpdateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51873,7 +51873,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51961,7 +51961,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOneDataFederationInstanceQueryLimitApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteOneDataFederationInstanceQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOneDataFederationInstanceQueryLimitApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteOneDataFederationInstanceQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52050,7 +52050,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52153,7 +52153,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOneDataFederationQueryLimitApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateOneDataFederationQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOneDataFederationQueryLimitApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateOneDataFederationQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52259,7 +52259,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadFederatedDatabaseQueryLogsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tDownloadFederatedDatabaseQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadFederatedDatabaseQueryLogsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tDownloadFederatedDatabaseQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52335,7 +52335,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUsersApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tListDatabaseUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUsersApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tListDatabaseUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52575,7 +52575,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tCreateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tCreateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52667,7 +52667,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDatabaseUserApiParams{}\n\thttpResp, err := client.DatabaseUsersApi.\n\t\tDeleteDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDatabaseUserApiParams{}\n\thttpResp, err := client.DatabaseUsersApi.\n\t\tDeleteDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52754,7 +52754,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tGetDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tGetDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52861,7 +52861,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tUpdateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tUpdateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52949,7 +52949,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUserCertificatesApiParams{}\n\tsdkResp, httpResp, err := client.X509AuthenticationApi.\n\t\tListDatabaseUserCertificatesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUserCertificatesApiParams{}\n\tsdkResp, httpResp, err := client.X509AuthenticationApi.\n\t\tListDatabaseUserCertificatesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53051,7 +53051,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserCertificateApiParams{}\n\tsdkResp, httpResp, err := client.X509AuthenticationApi.\n\t\tCreateDatabaseUserCertificateWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserCertificateApiParams{}\n\tsdkResp, httpResp, err := client.X509AuthenticationApi.\n\t\tCreateDatabaseUserCertificateWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53184,7 +53184,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByClusterNameApiParams{}\n\tsdkResp, httpResp, err := client.AccessTrackingApi.\n\t\tListAccessLogsByClusterNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByClusterNameApiParams{}\n\tsdkResp, httpResp, err := client.AccessTrackingApi.\n\t\tListAccessLogsByClusterNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53314,7 +53314,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByHostnameApiParams{}\n\tsdkResp, httpResp, err := client.AccessTrackingApi.\n\t\tListAccessLogsByHostnameWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByHostnameApiParams{}\n\tsdkResp, httpResp, err := client.AccessTrackingApi.\n\t\tListAccessLogsByHostnameWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53381,7 +53381,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53466,7 +53466,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tUpdateEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tUpdateEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53545,7 +53545,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointsForCloudProviderApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointsForCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointsForCloudProviderApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointsForCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53633,7 +53633,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tCreateEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tCreateEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53735,7 +53735,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RequestEncryptionAtRestPrivateEndpointDeletionApiParams{}\n\thttpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tRequestEncryptionAtRestPrivateEndpointDeletionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RequestEncryptionAtRestPrivateEndpointDeletionApiParams{}\n\thttpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tRequestEncryptionAtRestPrivateEndpointDeletionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53824,7 +53824,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53967,7 +53967,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectEventsApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListProjectEventsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectEventsApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListProjectEventsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54058,7 +54058,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectEventApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tGetProjectEventWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectEventApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tGetProjectEventWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54128,7 +54128,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListMetricTypesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListMetricTypesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListMetricTypesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListMetricTypesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54244,7 +54244,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54363,7 +54363,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54474,7 +54474,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54556,7 +54556,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListThirdPartyIntegrationsApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tListThirdPartyIntegrationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListThirdPartyIntegrationsApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tListThirdPartyIntegrationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54651,7 +54651,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteThirdPartyIntegrationApiParams{}\n\thttpResp, err := client.Third - PartyIntegrationsApi.\n\t\tDeleteThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteThirdPartyIntegrationApiParams{}\n\thttpResp, err := client.Third - PartyIntegrationsApi.\n\t\tDeleteThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54744,7 +54744,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tGetThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tGetThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54860,7 +54860,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tCreateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tCreateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54973,7 +54973,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tUpdateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tUpdateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55053,7 +55053,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectInvitationsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectInvitationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectInvitationsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectInvitationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55137,7 +55137,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55215,7 +55215,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tCreateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tCreateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55293,7 +55293,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectInvitationApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectInvitationApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55375,7 +55375,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55468,7 +55468,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55539,7 +55539,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnAllIPAddressesApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tReturnAllIPAddressesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnAllIPAddressesApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tReturnAllIPAddressesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55618,7 +55618,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectLimitsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectLimitsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectLimitsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectLimitsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55715,7 +55715,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectLimitApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectLimitApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55813,7 +55813,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55922,7 +55922,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tSetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tSetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56010,7 +56010,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCreatePushMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCreatePushMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56098,7 +56098,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ValidateMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tValidateMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ValidateMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tValidateMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56184,7 +56184,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetValidationStatusApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tGetValidationStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetValidationStatusApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tGetValidationStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56260,7 +56260,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tGetPushMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tGetPushMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56336,7 +56336,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CutoverMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCutoverMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CutoverMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCutoverMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56400,7 +56400,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResetMaintenanceWindowApiParams{}\n\thttpResp, err := client.MaintenanceWindowsApi.\n\t\tResetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResetMaintenanceWindowApiParams{}\n\thttpResp, err := client.MaintenanceWindowsApi.\n\t\tResetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56465,7 +56465,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tGetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tGetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56541,7 +56541,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tUpdateMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tUpdateMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56605,7 +56605,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleMaintenanceAutoDeferApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tToggleMaintenanceAutoDeferWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleMaintenanceAutoDeferApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tToggleMaintenanceAutoDeferWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56669,7 +56669,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeferMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tDeferMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeferMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tDeferMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56736,7 +56736,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedSlowMsApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tGetManagedSlowMsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedSlowMsApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tGetManagedSlowMsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56803,7 +56803,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableSlowOperationThresholdingApiParams{}\n\thttpResp, err := client.PerformanceAdvisorApi.\n\t\tDisableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableSlowOperationThresholdingApiParams{}\n\thttpResp, err := client.PerformanceAdvisorApi.\n\t\tDisableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56870,7 +56870,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EnableSlowOperationThresholdingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tEnableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EnableSlowOperationThresholdingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tEnableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56998,7 +56998,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLTSVersionsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectLTSVersionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLTSVersionsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectLTSVersionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57091,7 +57091,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringConnectionsApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringConnectionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringConnectionsApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringConnectionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57180,7 +57180,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tCreatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tCreatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57262,7 +57262,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringConnectionApiParams{}\n\thttpResp, err := client.NetworkPeeringApi.\n\t\tDeletePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringConnectionApiParams{}\n\thttpResp, err := client.NetworkPeeringApi.\n\t\tDeletePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57342,7 +57342,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tGetPeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tGetPeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57439,7 +57439,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tUpdatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tUpdatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57509,7 +57509,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelinesApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelinesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelinesApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelinesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57588,7 +57588,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tCreatePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tCreatePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57667,7 +57667,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineApiParams{}\n\thttpResp, err := client.DataLakePipelinesApi.\n\t\tDeletePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineApiParams{}\n\thttpResp, err := client.DataLakePipelinesApi.\n\t\tDeletePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57747,7 +57747,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tGetPipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tGetPipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57841,7 +57841,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tUpdatePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tUpdatePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57926,7 +57926,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSchedulesApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineSchedulesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSchedulesApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineSchedulesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58027,7 +58027,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSnapshotsApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineSnapshotsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSnapshotsApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineSnapshotsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58109,7 +58109,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PausePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tPausePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PausePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tPausePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58191,7 +58191,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResumePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tResumePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResumePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tResumePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58292,7 +58292,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineRunsApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineRunsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineRunsApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineRunsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58387,7 +58387,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineRunDatasetApiParams{}\n\thttpResp, err := client.DataLakePipelinesApi.\n\t\tDeletePipelineRunDatasetWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineRunDatasetApiParams{}\n\thttpResp, err := client.DataLakePipelinesApi.\n\t\tDeletePipelineRunDatasetWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58480,7 +58480,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineRunApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tGetPipelineRunWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineRunApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tGetPipelineRunWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58573,7 +58573,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TriggerSnapshotIngestionApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tTriggerSnapshotIngestionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TriggerSnapshotIngestionApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tTriggerSnapshotIngestionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58655,7 +58655,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58725,7 +58725,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58804,7 +58804,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tToggleRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tToggleRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58885,7 +58885,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tListServerlessPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tListServerlessPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58976,7 +58976,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tCreateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tCreateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59066,7 +59066,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessPrivateEndpointApiParams{}\n\thttpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tDeleteServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessPrivateEndpointApiParams{}\n\thttpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tDeleteServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59154,7 +59154,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tGetServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tGetServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59253,7 +59253,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tUpdateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tUpdateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59338,7 +59338,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPrivateEndpointServicesApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tListPrivateEndpointServicesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPrivateEndpointServicesApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tListPrivateEndpointServicesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59432,7 +59432,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointServiceApiParams{}\n\thttpResp, err := client.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointServiceApiParams{}\n\thttpResp, err := client.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59527,7 +59527,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59641,7 +59641,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59745,7 +59745,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointApiParams{}\n\thttpResp, err := client.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointApiParams{}\n\thttpResp, err := client.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59850,7 +59850,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59922,7 +59922,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyConnectViaPeeringOnlyModeForOneProjectApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tVerifyConnectViaPeeringOnlyModeForOneProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyConnectViaPeeringOnlyModeForOneProjectApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tVerifyConnectViaPeeringOnlyModeForOneProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60006,7 +60006,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisablePeeringApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tDisablePeeringWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisablePeeringApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tDisablePeeringWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60088,7 +60088,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDataFederationPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tListDataFederationPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDataFederationPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tListDataFederationPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60167,7 +60167,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60249,7 +60249,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDataFederationPrivateEndpointApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDataFederationPrivateEndpointApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60332,7 +60332,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tGetDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tGetDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60408,7 +60408,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasProcessesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListAtlasProcessesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasProcessesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListAtlasProcessesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60486,7 +60486,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasProcessApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetAtlasProcessWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasProcessApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetAtlasProcessWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60562,7 +60562,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespacesForHostApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespacesForHostWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespacesForHostApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespacesForHostWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60649,7 +60649,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabasesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDatabasesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabasesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDatabasesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60736,7 +60736,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60862,7 +60862,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDatabaseMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDatabaseMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60949,7 +60949,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskPartitionsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDiskPartitionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskPartitionsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDiskPartitionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61033,7 +61033,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61168,7 +61168,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61410,7 +61410,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetHostMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetHostMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61506,7 +61506,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueryNamespacesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSlowQueryNamespacesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueryNamespacesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSlowQueryNamespacesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61626,7 +61626,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueriesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSlowQueriesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueriesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSlowQueriesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61762,7 +61762,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSuggestedIndexesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSuggestedIndexesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSuggestedIndexesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSuggestedIndexesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61889,7 +61889,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespaceHostMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespaceHostMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespaceHostMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespaceHostMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61962,7 +61962,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePushBasedLogConfigurationApiParams{}\n\thttpResp, err := client.Push - BasedLogExportApi.\n\t\tDeletePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePushBasedLogConfigurationApiParams{}\n\thttpResp, err := client.Push - BasedLogExportApi.\n\t\tDeletePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62033,7 +62033,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tGetPushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tGetPushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62116,7 +62116,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tUpdatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tUpdatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62199,7 +62199,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tCreatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tCreatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62281,7 +62281,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.LoadSampleDatasetApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tLoadSampleDatasetWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.LoadSampleDatasetApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tLoadSampleDatasetWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62357,7 +62357,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSampleDatasetLoadStatusApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetSampleDatasetLoadStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSampleDatasetLoadStatusApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetSampleDatasetLoadStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62433,7 +62433,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessInstancesApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tListServerlessInstancesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessInstancesApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tListServerlessInstancesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62515,7 +62515,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tCreateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tCreateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62606,7 +62606,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListServerlessBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListServerlessBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62703,7 +62703,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62797,7 +62797,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62888,7 +62888,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListServerlessBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListServerlessBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62980,7 +62980,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetServerlessBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetServerlessBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63059,7 +63059,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tGetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tGetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63142,7 +63142,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tSetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tSetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63227,7 +63227,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessInstanceApiParams{}\n\thttpResp, err := client.ServerlessInstancesApi.\n\t\tDeleteServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessInstanceApiParams{}\n\thttpResp, err := client.ServerlessInstancesApi.\n\t\tDeleteServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63310,7 +63310,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tGetServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tGetServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63401,7 +63401,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tUpdateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tUpdateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63477,7 +63477,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectServiceAccountsApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tListProjectServiceAccountsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectServiceAccountsApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tListProjectServiceAccountsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63557,7 +63557,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tCreateProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tCreateProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63637,7 +63637,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectServiceAccountApiParams{}\n\thttpResp, err := client.GroupsApi.\n\t\tDeleteProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectServiceAccountApiParams{}\n\thttpResp, err := client.GroupsApi.\n\t\tDeleteProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63714,7 +63714,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tGetProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tGetProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63805,7 +63805,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tUpdateProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tUpdateProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63898,7 +63898,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tAddProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tAddProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63971,7 +63971,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64053,7 +64053,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64126,7 +64126,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamInstancesApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tListStreamInstancesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamInstancesApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tListStreamInstancesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64205,7 +64205,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tCreateStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tCreateStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64287,7 +64287,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamInstanceApiParams{}\n\thttpResp, err := client.StreamsApi.\n\t\tDeleteStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamInstanceApiParams{}\n\thttpResp, err := client.StreamsApi.\n\t\tDeleteStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64372,7 +64372,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tGetStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tGetStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64466,7 +64466,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tUpdateStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tUpdateStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64575,7 +64575,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadStreamTenantAuditLogsApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tDownloadStreamTenantAuditLogsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadStreamTenantAuditLogsApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tDownloadStreamTenantAuditLogsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64660,7 +64660,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamConnectionsApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tListStreamConnectionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamConnectionsApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tListStreamConnectionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64751,7 +64751,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tCreateStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tCreateStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64842,7 +64842,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamConnectionApiParams{}\n\thttpResp, err := client.StreamsApi.\n\t\tDeleteStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamConnectionApiParams{}\n\thttpResp, err := client.StreamsApi.\n\t\tDeleteStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64925,7 +64925,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tGetStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tGetStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65028,7 +65028,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tUpdateStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tUpdateStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65121,7 +65121,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamProcessorApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tCreateStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamProcessorApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tCreateStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65209,7 +65209,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamProcessorApiParams{}\n\thttpResp, err := client.StreamsApi.\n\t\tDeleteStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamProcessorApiParams{}\n\thttpResp, err := client.StreamsApi.\n\t\tDeleteStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65298,7 +65298,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamProcessorApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tGetStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamProcessorApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tGetStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65389,7 +65389,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.StartStreamProcessorApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tStartStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.StartStreamProcessorApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tStartStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65480,7 +65480,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.StopStreamProcessorApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tStopStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.StopStreamProcessorApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tStopStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65571,7 +65571,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamProcessorsApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tListStreamProcessorsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamProcessorsApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tListStreamProcessorsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65656,7 +65656,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectTeamsApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListProjectTeamsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectTeamsApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListProjectTeamsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65748,7 +65748,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddAllTeamsToProjectApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tAddAllTeamsToProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddAllTeamsToProjectApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tAddAllTeamsToProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65834,7 +65834,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectTeamApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tRemoveProjectTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectTeamApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tRemoveProjectTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65935,7 +65935,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateTeamRolesApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tUpdateTeamRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateTeamRolesApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tUpdateTeamRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66002,7 +66002,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66081,7 +66081,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SaveLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tSaveLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SaveLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tSaveLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66145,7 +66145,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableCustomerManagedX509ApiParams{}\n\thttpResp, err := client.X509AuthenticationApi.\n\t\tDisableCustomerManagedX509WithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableCustomerManagedX509ApiParams{}\n\thttpResp, err := client.X509AuthenticationApi.\n\t\tDisableCustomerManagedX509WithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66212,7 +66212,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLDAPConfigurationApiParams{}\n\thttpResp, err := client.LDAPConfigurationApi.\n\t\tDeleteLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLDAPConfigurationApiParams{}\n\thttpResp, err := client.LDAPConfigurationApi.\n\t\tDeleteLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66293,7 +66293,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tVerifyLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tVerifyLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66372,7 +66372,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationStatusApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationStatusApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66466,7 +66466,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectUsersApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectUsersApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66548,7 +66548,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectUserApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tRemoveProjectUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectUserApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tRemoveProjectUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66644,7 +66644,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectRolesApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectRolesApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66719,7 +66719,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.MigrateProjectToAnotherOrgApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tMigrateProjectToAnotherOrgWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.MigrateProjectToAnotherOrgApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tMigrateProjectToAnotherOrgWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66809,7 +66809,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66894,7 +66894,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66970,7 +66970,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67044,7 +67044,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67129,7 +67129,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tRenameOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tRenameOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67209,7 +67209,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeysApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListApiKeysWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeysApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListApiKeysWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67289,7 +67289,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67372,7 +67372,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67453,7 +67453,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67548,7 +67548,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67640,7 +67640,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeyAccessListsEntriesApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListApiKeyAccessListsEntriesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeyAccessListsEntriesApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListApiKeyAccessListsEntriesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67746,7 +67746,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67846,7 +67846,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyAccessListEntryApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyAccessListEntryWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyAccessListEntryApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyAccessListEntryWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67941,7 +67941,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -68019,7 +68019,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcessApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tCreateCostExplorerQueryProcessWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcessApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tCreateCostExplorerQueryProcessWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -68110,7 +68110,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcess_1ApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tCreateCostExplorerQueryProcess_1WithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcess_1ApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tCreateCostExplorerQueryProcess_1WithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -68225,7 +68225,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationEventsApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListOrganizationEventsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationEventsApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListOrganizationEventsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -68316,7 +68316,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationEventApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tGetOrganizationEventWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationEventApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tGetOrganizationEventWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -68389,7 +68389,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetFederationSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetFederationSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -68479,7 +68479,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationProjectsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationProjectsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -68564,7 +68564,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationInvitationsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationInvitationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationInvitationsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationInvitationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -68646,7 +68646,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -68728,7 +68728,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -68810,7 +68810,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationInvitationApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationInvitationApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -68890,7 +68890,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -68984,7 +68984,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -69142,7 +69142,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListInvoicesApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tListInvoicesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListInvoicesApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tListInvoicesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -69212,7 +69212,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPendingInvoicesApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tListPendingInvoicesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPendingInvoicesApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tListPendingInvoicesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -69300,7 +69300,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetInvoiceApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tGetInvoiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetInvoiceApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tGetInvoiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -69381,7 +69381,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadInvoiceCSVApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tDownloadInvoiceCSVWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadInvoiceCSVApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tDownloadInvoiceCSVWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -69454,7 +69454,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSourceProjectsApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tListSourceProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSourceProjectsApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tListSourceProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -69521,7 +69521,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLinkTokenApiParams{}\n\thttpResp, err := client.CloudMigrationServiceApi.\n\t\tDeleteLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLinkTokenApiParams{}\n\thttpResp, err := client.CloudMigrationServiceApi.\n\t\tDeleteLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -69600,7 +69600,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLinkTokenApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCreateLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLinkTokenApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCreateLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -69676,7 +69676,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServiceAccountsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListServiceAccountsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServiceAccountsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListServiceAccountsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -69755,7 +69755,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -69831,7 +69831,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServiceAccountApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServiceAccountApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -69908,7 +69908,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -69999,7 +69999,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -70084,7 +70084,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServiceAccountProjectsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListServiceAccountProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServiceAccountProjectsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListServiceAccountProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -70174,7 +70174,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServiceAccountSecretApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateServiceAccountSecretWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServiceAccountSecretApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateServiceAccountSecretWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -70259,7 +70259,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServiceAccountSecretApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteServiceAccountSecretWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServiceAccountSecretApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteServiceAccountSecretWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -70332,7 +70332,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -70414,7 +70414,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -70500,7 +70500,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationTeamsApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListOrganizationTeamsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationTeamsApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListOrganizationTeamsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -70589,7 +70589,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateTeamApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tCreateTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateTeamApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tCreateTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -70675,7 +70675,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByNameApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tGetTeamByNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByNameApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tGetTeamByNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -70764,7 +70764,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteTeamApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tDeleteTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteTeamApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tDeleteTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -70851,7 +70851,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByIdApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tGetTeamByIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByIdApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tGetTeamByIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -70952,7 +70952,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameTeamApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tRenameTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameTeamApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tRenameTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -71050,7 +71050,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListTeamUsersApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListTeamUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListTeamUsersApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListTeamUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -71154,7 +71154,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddTeamUserApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tAddTeamUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddTeamUserApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tAddTeamUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -71252,7 +71252,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveTeamUserApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tRemoveTeamUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveTeamUserApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tRemoveTeamUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -71334,7 +71334,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationUsersApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationUsersApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -71419,7 +71419,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveOrganizationUserApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tRemoveOrganizationUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveOrganizationUserApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tRemoveOrganizationUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -71515,7 +71515,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationRolesApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationRolesApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -71568,7 +71568,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnAllControlPlaneIPAddressesApiParams{}\n\tsdkResp, httpResp, err := client.RootApi.\n\t\tReturnAllControlPlaneIPAddressesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnAllControlPlaneIPAddressesApiParams{}\n\tsdkResp, httpResp, err := client.RootApi.\n\t\tReturnAllControlPlaneIPAddressesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -71646,7 +71646,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateUserApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tCreateUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateUserApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tCreateUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -71723,7 +71723,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserByUsernameApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tGetUserByUsernameWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserByUsernameApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tGetUserByUsernameWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -71802,7 +71802,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tGetUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tGetUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",

--- a/tools/cli/test/data/split/dev/openapi-v2-2024-05-30.yaml
+++ b/tools/cli/test/data/split/dev/openapi-v2-2024-05-30.yaml
@@ -29885,9 +29885,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -29957,9 +29955,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30030,9 +30026,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30103,9 +30097,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30174,9 +30166,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30250,9 +30240,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30334,9 +30322,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30417,9 +30403,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30507,9 +30491,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30586,9 +30568,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30667,9 +30647,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30754,9 +30732,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30838,9 +30814,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30929,9 +30903,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31031,9 +31003,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31116,9 +31086,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31199,9 +31167,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31281,9 +31247,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31371,9 +31335,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31454,9 +31416,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31528,9 +31488,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31603,9 +31561,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31695,9 +31651,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31772,9 +31726,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31844,9 +31796,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31927,9 +31877,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32014,9 +31962,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32095,9 +32041,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32184,9 +32128,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32277,9 +32219,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32362,9 +32302,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32447,9 +32385,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32524,9 +32460,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32606,9 +32540,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32694,9 +32626,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32779,9 +32709,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32873,9 +32801,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32973,9 +32899,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33066,9 +32990,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33154,9 +33076,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33239,9 +33159,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33332,9 +33250,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33424,9 +33340,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33501,9 +33415,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33578,9 +33490,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33667,9 +33577,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33758,9 +33666,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33850,9 +33756,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33925,9 +33829,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34004,9 +33906,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34079,9 +33979,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34156,9 +34054,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34234,9 +34130,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34354,9 +34248,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34442,9 +34334,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34546,9 +34436,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34619,9 +34507,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34707,9 +34593,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34782,9 +34666,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34862,9 +34744,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34954,9 +34834,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35034,9 +34912,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35127,9 +35003,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35212,9 +35086,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35299,9 +35171,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35393,9 +35263,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35477,9 +35345,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35571,9 +35437,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35710,9 +35574,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35802,9 +35664,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35885,9 +35745,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35976,9 +35834,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36065,9 +35921,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36148,9 +36002,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36243,9 +36095,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36338,9 +36188,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36426,9 +36274,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36508,9 +36354,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36589,9 +36433,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36682,9 +36524,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36772,9 +36612,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36863,9 +36701,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36958,9 +36794,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37048,9 +36882,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37145,9 +36977,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37238,9 +37068,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37328,9 +37156,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37410,9 +37236,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37505,9 +37329,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37602,9 +37424,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37688,9 +37508,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37779,9 +37597,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37861,9 +37677,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37952,9 +37766,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38036,9 +37848,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38130,9 +37940,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38213,9 +38021,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38309,9 +38115,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38409,9 +38213,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38503,9 +38305,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38602,9 +38402,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38705,9 +38503,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38801,9 +38597,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38894,9 +38688,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38998,9 +38790,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39087,9 +38877,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39172,9 +38960,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39265,9 +39051,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39366,9 +39150,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39461,9 +39243,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39621,9 +39401,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39711,9 +39489,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39806,9 +39582,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39904,9 +39678,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39999,9 +39771,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40103,9 +39873,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40217,9 +39985,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40304,9 +40070,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40390,9 +40154,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40481,9 +40243,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40571,9 +40331,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40667,9 +40425,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40750,9 +40506,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40851,9 +40605,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40940,9 +40692,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41039,9 +40789,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41123,9 +40871,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41204,9 +40950,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41294,9 +41038,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41388,9 +41130,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41485,9 +41225,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41578,9 +41316,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41687,9 +41423,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41790,9 +41524,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41892,9 +41624,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42003,9 +41733,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42101,9 +41829,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42200,9 +41926,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42302,9 +42026,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42390,9 +42112,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42480,9 +42200,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42578,9 +42296,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42670,9 +42386,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42759,9 +42473,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42855,9 +42567,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42939,9 +42649,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43032,9 +42740,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43124,9 +42830,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43243,9 +42947,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43329,9 +43031,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43415,9 +43115,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43505,9 +43203,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43583,9 +43279,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43670,9 +43364,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43755,9 +43447,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43846,9 +43536,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43926,9 +43614,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44021,9 +43707,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44099,9 +43783,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44172,9 +43854,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44257,9 +43937,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44342,9 +44020,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44420,9 +44096,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44511,9 +44185,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44597,9 +44269,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44680,9 +44350,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44761,9 +44429,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44840,9 +44506,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44931,9 +44595,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45016,9 +44678,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45111,9 +44771,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45206,9 +44864,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45311,9 +44967,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45416,9 +45070,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45490,9 +45142,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45666,9 +45316,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45771,9 +45419,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45869,9 +45515,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45980,9 +45624,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46066,9 +45708,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46166,9 +45806,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46287,9 +45925,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46401,9 +46037,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46475,9 +46109,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46570,9 +46202,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46653,9 +46283,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46738,9 +46366,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46837,9 +46463,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46924,9 +46548,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47052,9 +46674,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47143,9 +46763,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47216,9 +46834,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47319,9 +46935,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47421,9 +47035,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47522,9 +47134,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47600,9 +47210,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47693,9 +47301,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47785,9 +47391,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47889,9 +47493,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47995,9 +47597,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48079,9 +47679,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48162,9 +47760,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48245,9 +47841,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48330,9 +47924,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48413,9 +48005,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48504,9 +48094,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48582,9 +48170,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48661,9 +48247,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48772,9 +48356,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48884,9 +48466,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49006,9 +48586,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49102,9 +48680,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49182,9 +48758,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49258,9 +48832,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49347,9 +48919,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49437,9 +49007,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49507,9 +49075,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49577,9 +49143,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49655,9 +49219,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49729,9 +49291,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49803,9 +49363,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49878,9 +49436,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49949,9 +49505,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50020,9 +49574,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50136,9 +49688,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50222,9 +49772,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50308,9 +49856,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50394,9 +49940,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50475,9 +50019,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50567,9 +50109,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50645,9 +50185,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50725,9 +50263,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50810,9 +50346,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50891,9 +50425,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50982,9 +50514,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51070,9 +50600,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51162,9 +50690,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51244,9 +50770,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51330,9 +50854,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51426,9 +50948,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51518,9 +51038,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51609,9 +51127,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51698,9 +51214,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51786,9 +51300,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51877,9 +51389,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51969,9 +51479,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52073,9 +51581,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52175,9 +51681,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52274,9 +51778,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52355,9 +51857,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52432,9 +51932,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52511,9 +52009,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52597,9 +52093,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52689,9 +52183,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52782,9 +52274,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52870,9 +52360,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52965,9 +52453,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53044,9 +52530,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53127,9 +52611,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53209,9 +52691,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53307,9 +52787,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53393,9 +52871,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53476,9 +52952,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53550,9 +53024,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53629,9 +53101,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53743,9 +53213,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53817,9 +53285,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53899,9 +53365,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53984,9 +53448,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54095,9 +53557,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54177,9 +53637,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54261,9 +53719,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54388,9 +53844,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54626,9 +54080,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54725,9 +54177,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54841,9 +54291,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54964,9 +54412,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55039,9 +54485,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55113,9 +54557,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55195,9 +54637,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55281,9 +54721,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55368,9 +54806,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55451,9 +54887,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55525,9 +54959,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55606,9 +55038,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55695,9 +55125,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55787,9 +55215,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55882,9 +55308,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55967,9 +55391,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56058,9 +55480,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56138,9 +55558,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56222,9 +55640,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56310,9 +55726,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56393,9 +55807,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56481,9 +55893,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56560,9 +55970,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56640,9 +56048,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56724,9 +56130,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56802,9 +56206,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56889,9 +56291,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56982,9 +56382,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57061,9 +56459,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57142,9 +56538,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57219,9 +56613,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57298,9 +56690,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57383,9 +56773,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57467,9 +56855,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57556,9 +56942,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57662,9 +57046,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57743,9 +57125,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57830,9 +57210,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57921,9 +57299,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58004,9 +57380,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58099,9 +57473,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58191,9 +57563,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58280,9 +57650,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58366,9 +57734,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58453,9 +57819,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58544,9 +57908,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58632,9 +57994,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58712,9 +58072,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58800,9 +58158,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58890,9 +58246,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58985,9 +58339,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59060,9 +58412,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59142,9 +58492,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59219,9 +58567,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59290,9 +58636,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59370,9 +58714,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59454,9 +58796,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59540,9 +58880,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59622,9 +58960,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59713,9 +59049,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59794,9 +59128,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59882,9 +59214,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59966,9 +59296,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60050,9 +59378,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60137,9 +59463,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60213,9 +59537,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60296,9 +59618,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60377,9 +59697,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60457,9 +59775,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60544,9 +59860,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60626,9 +59940,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60717,9 +60029,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60807,9 +60117,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60902,9 +60210,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -61001,9 +60307,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -61093,9 +60397,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -61172,9 +60474,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -61265,9 +60565,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -61371,9 +60669,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -61462,9 +60758,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -61537,9 +60831,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -61628,9 +60920,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -61711,9 +61001,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -61792,9 +61080,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -61877,9 +61163,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -61962,9 +61246,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -62044,9 +61326,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -62134,9 +61414,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -62273,9 +61551,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -62361,9 +61637,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -62450,9 +61724,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -62523,9 +61795,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -62598,9 +61868,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -62670,9 +61938,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -62749,9 +62015,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -62828,9 +62092,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -62907,9 +62169,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -62988,9 +62248,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -63066,9 +62324,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -63153,9 +62409,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -63238,9 +62492,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -63324,9 +62576,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -63411,9 +62661,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -63486,9 +62734,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -63567,9 +62813,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -63652,9 +62896,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -63738,9 +62980,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -63829,9 +63069,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -63915,9 +63153,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -64010,9 +63246,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -64105,9 +63339,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -64202,9 +63434,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -64300,9 +63530,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -64384,9 +63612,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -64462,9 +63688,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -64547,9 +63771,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -64638,9 +63860,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -64707,9 +63927,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -64791,9 +64009,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -64876,9 +64092,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -64955,9 +64169,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)

--- a/tools/cli/test/data/split/dev/openapi-v2-2024-08-05.json
+++ b/tools/cli/test/data/split/dev/openapi-v2-2024-08-05.json
@@ -36806,7 +36806,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSystemStatusApiParams{}\n\tsdkResp, httpResp, err := client.RootApi.\n\t\tGetSystemStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSystemStatusApiParams{}\n\tsdkResp, httpResp, err := client.RootApi.\n\t\tGetSystemStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36873,7 +36873,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationMatchersFieldNamesApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationMatchersFieldNamesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationMatchersFieldNamesApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationMatchersFieldNamesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -36946,7 +36946,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersForAllProjectsApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListClustersForAllProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersForAllProjectsApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListClustersForAllProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37019,7 +37019,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListEventTypesApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListEventTypesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListEventTypesApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListEventTypesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37083,7 +37083,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederationAppApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tDeleteFederationAppWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederationAppApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tDeleteFederationAppWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37159,7 +37159,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListConnectedOrgConfigsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListConnectedOrgConfigsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListConnectedOrgConfigsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListConnectedOrgConfigsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37242,7 +37242,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveConnectedOrgConfigApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tRemoveConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveConnectedOrgConfigApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tRemoveConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37323,7 +37323,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37415,7 +37415,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37488,7 +37488,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListRoleMappingsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListRoleMappingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListRoleMappingsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListRoleMappingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37570,7 +37570,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tCreateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tCreateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37653,7 +37653,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteRoleMappingApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tDeleteRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteRoleMappingApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tDeleteRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37737,7 +37737,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37832,7 +37832,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37940,7 +37940,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIdentityProvidersApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListIdentityProvidersWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIdentityProvidersApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListIdentityProvidersWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38022,7 +38022,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tCreateIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tCreateIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38099,7 +38099,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteIdentityProviderApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tDeleteIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteIdentityProviderApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tDeleteIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38180,7 +38180,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38269,7 +38269,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38346,7 +38346,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RevokeJwksFromIdentityProviderApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tRevokeJwksFromIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RevokeJwksFromIdentityProviderApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tRevokeJwksFromIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38416,7 +38416,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderMetadataApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetIdentityProviderMetadataWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderMetadataApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetIdentityProviderMetadataWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38492,7 +38492,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38588,7 +38588,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tCreateProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tCreateProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38672,7 +38672,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectByNameApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectByNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectByNameApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectByNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38742,7 +38742,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38810,7 +38810,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38895,7 +38895,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38981,7 +38981,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddUserToProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tAddUserToProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddUserToProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tAddUserToProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39061,7 +39061,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectIpAccessListsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tListProjectIpAccessListsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectIpAccessListsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tListProjectIpAccessListsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39159,7 +39159,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectIpAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tCreateProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectIpAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tCreateProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39244,7 +39244,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectIpAccessListApiParams{}\n\thttpResp, err := client.ProjectIPAccessListApi.\n\t\tDeleteProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectIpAccessListApiParams{}\n\thttpResp, err := client.ProjectIPAccessListApi.\n\t\tDeleteProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39330,7 +39330,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpListApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tGetProjectIpListWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpListApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tGetProjectIpListWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39417,7 +39417,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpAccessListStatusApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tGetProjectIpAccessListStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpAccessListStatusApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tGetProjectIpAccessListStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39493,7 +39493,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39572,7 +39572,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tCreateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tCreateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39652,7 +39652,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAlertConfigurationApiParams{}\n\thttpResp, err := client.AlertConfigurationsApi.\n\t\tDeleteAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAlertConfigurationApiParams{}\n\thttpResp, err := client.AlertConfigurationsApi.\n\t\tDeleteAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39733,7 +39733,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tGetAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tGetAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39825,7 +39825,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tToggleAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tToggleAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39920,7 +39920,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tUpdateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tUpdateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40012,7 +40012,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsByAlertConfigurationIdApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tListAlertsByAlertConfigurationIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsByAlertConfigurationIdApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tListAlertsByAlertConfigurationIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40104,7 +40104,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tListAlertsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tListAlertsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40186,7 +40186,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tGetAlertWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tGetAlertWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40280,7 +40280,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AcknowledgeAlertApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tAcknowledgeAlertWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AcknowledgeAlertApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tAcknowledgeAlertWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40371,7 +40371,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsByAlertIdApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationsByAlertIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsByAlertIdApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationsByAlertIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40451,7 +40451,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectApiKeysApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListProjectApiKeysWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectApiKeysApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListProjectApiKeysWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40527,7 +40527,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40613,7 +40613,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectApiKeyApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tRemoveProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectApiKeyApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tRemoveProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40713,7 +40713,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyRolesApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyRolesApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40804,7 +40804,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tAddProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tAddProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40871,7 +40871,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AuditingApi.\n\t\tGetAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AuditingApi.\n\t\tGetAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40950,7 +40950,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AuditingApi.\n\t\tUpdateAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AuditingApi.\n\t\tUpdateAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41017,7 +41017,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := client.AWSClustersDNSApi.\n\t\tGetAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := client.AWSClustersDNSApi.\n\t\tGetAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41093,7 +41093,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := client.AWSClustersDNSApi.\n\t\tToggleAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := client.AWSClustersDNSApi.\n\t\tToggleAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41169,7 +41169,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListExportBucketsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListExportBucketsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListExportBucketsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListExportBucketsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41306,7 +41306,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateExportBucketApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateExportBucketWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateExportBucketApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateExportBucketWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41389,7 +41389,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteExportBucketApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteExportBucketWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteExportBucketApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteExportBucketWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41501,7 +41501,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetExportBucketApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetExportBucketWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetExportBucketApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetExportBucketWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41571,7 +41571,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41663,7 +41663,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41730,7 +41730,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderAccessRolesApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tListCloudProviderAccessRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderAccessRolesApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tListCloudProviderAccessRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41810,7 +41810,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tCreateCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tCreateCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41901,7 +41901,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeauthorizeCloudProviderAccessRoleApiParams{}\n\thttpResp, err := client.CloudProviderAccessApi.\n\t\tDeauthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeauthorizeCloudProviderAccessRoleApiParams{}\n\thttpResp, err := client.CloudProviderAccessApi.\n\t\tDeauthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41980,7 +41980,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tGetCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tGetCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42078,7 +42078,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AuthorizeCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tAuthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AuthorizeCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tAuthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42163,7 +42163,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListClustersWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListClustersWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42258,7 +42258,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tCreateClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tCreateClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42353,7 +42353,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderRegionsApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListCloudProviderRegionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderRegionsApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListCloudProviderRegionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42443,7 +42443,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpgradeSharedClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpgradeSharedClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42533,7 +42533,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterToServerlessApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpgradeSharedClusterToServerlessWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterToServerlessApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpgradeSharedClusterToServerlessWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42626,7 +42626,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteClusterApiParams{}\n\thttpResp, err := client.ClustersApi.\n\t\tDeleteClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteClusterApiParams{}\n\thttpResp, err := client.ClustersApi.\n\t\tDeleteClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42709,7 +42709,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42807,7 +42807,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpdateClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpdateClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42895,7 +42895,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupExportJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListBackupExportJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupExportJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListBackupExportJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42989,7 +42989,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43074,7 +43074,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43162,7 +43162,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43259,7 +43259,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43353,7 +43353,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CancelBackupRestoreJobApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tCancelBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CancelBackupRestoreJobApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tCancelBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43442,7 +43442,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43521,7 +43521,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllBackupSchedulesApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteAllBackupSchedulesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllBackupSchedulesApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteAllBackupSchedulesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43598,7 +43598,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43689,7 +43689,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43780,7 +43780,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListReplicaSetBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListReplicaSetBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListReplicaSetBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListReplicaSetBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43871,7 +43871,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TakeSnapshotApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tTakeSnapshotWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TakeSnapshotApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tTakeSnapshotWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43962,7 +43962,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteShardedClusterBackupApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteShardedClusterBackupApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44054,7 +44054,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetShardedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetShardedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44136,7 +44136,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListShardedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListShardedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListShardedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListShardedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44230,7 +44230,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteReplicaSetBackupApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteReplicaSetBackupApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44322,7 +44322,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetReplicaSetBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetReplicaSetBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44425,7 +44425,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateSnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateSnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateSnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateSnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44527,7 +44527,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tDownloadSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tDownloadSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44626,7 +44626,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tCreateSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tCreateSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44708,7 +44708,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tListSharedClusterBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tListSharedClusterBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44802,7 +44802,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tGetSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tGetSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44884,7 +44884,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tListSharedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tListSharedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44978,7 +44978,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tGetSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tGetSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45067,7 +45067,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupCheckpointsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacyBackupCheckpointsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupCheckpointsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacyBackupCheckpointsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45165,7 +45165,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupCheckpointApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacyBackupCheckpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupCheckpointApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacyBackupCheckpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45247,7 +45247,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPinnedNamespacesApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetPinnedNamespacesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPinnedNamespacesApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetPinnedNamespacesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45349,7 +45349,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PinNamespacesPatchApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tPinNamespacesPatchWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PinNamespacesPatchApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tPinNamespacesPatchWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45451,7 +45451,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PinNamespacesPutApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tPinNamespacesPutWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PinNamespacesPutApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tPinNamespacesPutWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45544,7 +45544,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UnpinNamespacesApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tUnpinNamespacesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UnpinNamespacesApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tUnpinNamespacesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45645,7 +45645,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tCreateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tCreateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45751,7 +45751,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasSearchIndexesDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tListAtlasSearchIndexesDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasSearchIndexesDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tListAtlasSearchIndexesDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45851,7 +45851,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchIndexDeprecatedApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchIndexDeprecatedApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45946,7 +45946,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46058,7 +46058,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46142,7 +46142,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tGetManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tGetManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46225,7 +46225,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllCustomZoneMappingsApiParams{}\n\thttpResp, err := client.GlobalClustersApi.\n\t\tDeleteAllCustomZoneMappingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllCustomZoneMappingsApiParams{}\n\thttpResp, err := client.GlobalClustersApi.\n\t\tDeleteAllCustomZoneMappingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46321,7 +46321,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomZoneMappingApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tCreateCustomZoneMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomZoneMappingApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tCreateCustomZoneMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46423,7 +46423,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteManagedNamespaceApiParams{}\n\thttpResp, err := client.GlobalClustersApi.\n\t\tDeleteManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteManagedNamespaceApiParams{}\n\thttpResp, err := client.GlobalClustersApi.\n\t\tDeleteManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46522,7 +46522,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tCreateManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tCreateManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46707,7 +46707,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRollingIndexApiParams{}\n\tsdkResp, httpResp, err := client.RollingIndexApi.\n\t\tCreateRollingIndexWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRollingIndexApiParams{}\n\tsdkResp, httpResp, err := client.RollingIndexApi.\n\t\tCreateRollingIndexWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46799,7 +46799,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOnlineArchivesApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tListOnlineArchivesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOnlineArchivesApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tListOnlineArchivesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46900,7 +46900,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tCreateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tCreateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47019,7 +47019,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadOnlineArchiveQueryLogsApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tDownloadOnlineArchiveQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadOnlineArchiveQueryLogsApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tDownloadOnlineArchiveQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47117,7 +47117,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOnlineArchiveApiParams{}\n\thttpResp, err := client.OnlineArchiveApi.\n\t\tDeleteOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOnlineArchiveApiParams{}\n\thttpResp, err := client.OnlineArchiveApi.\n\t\tDeleteOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47216,7 +47216,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tGetOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tGetOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47329,7 +47329,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tUpdateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tUpdateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47418,7 +47418,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EndOutageSimulationApiParams{}\n\thttpResp, err := client.ClusterOutageSimulationApi.\n\t\tEndOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EndOutageSimulationApiParams{}\n\thttpResp, err := client.ClusterOutageSimulationApi.\n\t\tEndOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47505,7 +47505,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := client.ClusterOutageSimulationApi.\n\t\tGetOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := client.ClusterOutageSimulationApi.\n\t\tGetOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47600,7 +47600,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.StartOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := client.ClusterOutageSimulationApi.\n\t\tStartOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.StartOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := client.ClusterOutageSimulationApi.\n\t\tStartOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47686,7 +47686,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47785,7 +47785,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpdateClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpdateClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47861,7 +47861,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TestFailoverApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tTestFailoverWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TestFailoverApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tTestFailoverWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47964,7 +47964,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacyBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacyBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48056,7 +48056,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tCreateLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tCreateLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48151,7 +48151,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48236,7 +48236,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchDeploymentApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchDeploymentApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48316,7 +48316,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48410,7 +48410,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48504,7 +48504,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tCreateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tCreateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48603,7 +48603,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasSearchIndexesClusterApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tListAtlasSearchIndexesClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasSearchIndexesClusterApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tListAtlasSearchIndexesClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48701,7 +48701,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchIndexApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tCreateAtlasSearchIndexWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchIndexApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tCreateAtlasSearchIndexWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48818,7 +48818,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasSearchIndexesApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tListAtlasSearchIndexesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasSearchIndexesApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tListAtlasSearchIndexesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48931,7 +48931,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchIndexByNameApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchIndexByNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchIndexByNameApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchIndexByNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49042,7 +49042,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchIndexByNameApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchIndexByNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchIndexByNameApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchIndexByNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49167,7 +49167,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchIndexByNameApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchIndexByNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchIndexByNameApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchIndexByNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49265,7 +49265,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchIndexApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchIndexWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchIndexApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchIndexWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49371,7 +49371,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchIndexApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchIndexWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchIndexApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchIndexWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49481,7 +49481,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchIndexApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchIndexWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchIndexApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchIndexWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49561,7 +49561,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49650,7 +49650,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tUpdateLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tUpdateLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49753,7 +49753,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacySnapshotsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacySnapshotsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacySnapshotsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacySnapshotsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49848,7 +49848,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLegacySnapshotApiParams{}\n\thttpResp, err := client.LegacyBackupApi.\n\t\tDeleteLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLegacySnapshotApiParams{}\n\thttpResp, err := client.LegacyBackupApi.\n\t\tDeleteLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49938,7 +49938,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50039,7 +50039,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tUpdateLegacySnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tUpdateLegacySnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50118,7 +50118,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterStatusApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterStatusApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50217,7 +50217,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespacesForClusterApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespacesForClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespacesForClusterApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespacesForClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50369,7 +50369,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespaceClusterMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespaceClusterMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespaceClusterMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespaceClusterMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50468,7 +50468,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PinFeatureCompatibilityVersionApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tPinFeatureCompatibilityVersionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PinFeatureCompatibilityVersionApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tPinFeatureCompatibilityVersionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50559,7 +50559,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UnpinFeatureCompatibilityVersionApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUnpinFeatureCompatibilityVersionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UnpinFeatureCompatibilityVersionApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUnpinFeatureCompatibilityVersionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50686,7 +50686,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostLogsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetHostLogsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostLogsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetHostLogsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50756,7 +50756,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespaceMetricsApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespaceMetricsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespaceMetricsApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespaceMetricsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50850,7 +50850,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainerByCloudProviderApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringContainerByCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainerByCloudProviderApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringContainerByCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50938,7 +50938,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tCreatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tCreatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51014,7 +51014,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainersApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringContainersWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainersApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringContainersWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51103,7 +51103,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringContainerApiParams{}\n\thttpResp, err := client.NetworkPeeringApi.\n\t\tDeletePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringContainerApiParams{}\n\thttpResp, err := client.NetworkPeeringApi.\n\t\tDeletePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51181,7 +51181,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tGetPeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tGetPeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51282,7 +51282,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tUpdatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tUpdatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51352,7 +51352,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCustomDatabaseRolesApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tListCustomDatabaseRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCustomDatabaseRolesApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tListCustomDatabaseRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51440,7 +51440,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tCreateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tCreateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51522,7 +51522,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteCustomDatabaseRoleApiParams{}\n\thttpResp, err := client.CustomDatabaseRolesApi.\n\t\tDeleteCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteCustomDatabaseRoleApiParams{}\n\thttpResp, err := client.CustomDatabaseRolesApi.\n\t\tDeleteCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51599,7 +51599,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tGetCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tGetCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51696,7 +51696,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tUpdateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tUpdateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51779,7 +51779,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListFederatedDatabasesApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tListFederatedDatabasesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListFederatedDatabasesApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tListFederatedDatabasesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51864,7 +51864,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51940,7 +51940,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederatedDatabaseApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederatedDatabaseApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52017,7 +52017,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tGetFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tGetFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52114,7 +52114,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tUpdateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tUpdateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52196,7 +52196,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52284,7 +52284,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOneDataFederationInstanceQueryLimitApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteOneDataFederationInstanceQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOneDataFederationInstanceQueryLimitApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteOneDataFederationInstanceQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52373,7 +52373,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52476,7 +52476,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOneDataFederationQueryLimitApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateOneDataFederationQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOneDataFederationQueryLimitApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateOneDataFederationQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52582,7 +52582,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadFederatedDatabaseQueryLogsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tDownloadFederatedDatabaseQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadFederatedDatabaseQueryLogsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tDownloadFederatedDatabaseQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52658,7 +52658,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUsersApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tListDatabaseUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUsersApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tListDatabaseUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52898,7 +52898,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tCreateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tCreateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52990,7 +52990,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDatabaseUserApiParams{}\n\thttpResp, err := client.DatabaseUsersApi.\n\t\tDeleteDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDatabaseUserApiParams{}\n\thttpResp, err := client.DatabaseUsersApi.\n\t\tDeleteDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53077,7 +53077,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tGetDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tGetDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53184,7 +53184,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tUpdateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tUpdateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53272,7 +53272,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUserCertificatesApiParams{}\n\tsdkResp, httpResp, err := client.X509AuthenticationApi.\n\t\tListDatabaseUserCertificatesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUserCertificatesApiParams{}\n\tsdkResp, httpResp, err := client.X509AuthenticationApi.\n\t\tListDatabaseUserCertificatesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53374,7 +53374,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserCertificateApiParams{}\n\tsdkResp, httpResp, err := client.X509AuthenticationApi.\n\t\tCreateDatabaseUserCertificateWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserCertificateApiParams{}\n\tsdkResp, httpResp, err := client.X509AuthenticationApi.\n\t\tCreateDatabaseUserCertificateWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53507,7 +53507,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByClusterNameApiParams{}\n\tsdkResp, httpResp, err := client.AccessTrackingApi.\n\t\tListAccessLogsByClusterNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByClusterNameApiParams{}\n\tsdkResp, httpResp, err := client.AccessTrackingApi.\n\t\tListAccessLogsByClusterNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53637,7 +53637,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByHostnameApiParams{}\n\tsdkResp, httpResp, err := client.AccessTrackingApi.\n\t\tListAccessLogsByHostnameWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByHostnameApiParams{}\n\tsdkResp, httpResp, err := client.AccessTrackingApi.\n\t\tListAccessLogsByHostnameWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53704,7 +53704,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53789,7 +53789,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tUpdateEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tUpdateEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53868,7 +53868,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointsForCloudProviderApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointsForCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointsForCloudProviderApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointsForCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53956,7 +53956,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tCreateEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tCreateEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54058,7 +54058,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RequestEncryptionAtRestPrivateEndpointDeletionApiParams{}\n\thttpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tRequestEncryptionAtRestPrivateEndpointDeletionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RequestEncryptionAtRestPrivateEndpointDeletionApiParams{}\n\thttpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tRequestEncryptionAtRestPrivateEndpointDeletionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54147,7 +54147,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54290,7 +54290,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectEventsApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListProjectEventsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectEventsApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListProjectEventsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54381,7 +54381,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectEventApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tGetProjectEventWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectEventApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tGetProjectEventWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54451,7 +54451,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListMetricTypesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListMetricTypesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListMetricTypesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListMetricTypesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54567,7 +54567,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54686,7 +54686,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54797,7 +54797,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54879,7 +54879,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListThirdPartyIntegrationsApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tListThirdPartyIntegrationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListThirdPartyIntegrationsApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tListThirdPartyIntegrationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54974,7 +54974,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteThirdPartyIntegrationApiParams{}\n\thttpResp, err := client.Third - PartyIntegrationsApi.\n\t\tDeleteThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteThirdPartyIntegrationApiParams{}\n\thttpResp, err := client.Third - PartyIntegrationsApi.\n\t\tDeleteThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55067,7 +55067,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tGetThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tGetThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55183,7 +55183,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tCreateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tCreateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55296,7 +55296,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tUpdateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tUpdateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55376,7 +55376,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectInvitationsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectInvitationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectInvitationsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectInvitationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55460,7 +55460,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55538,7 +55538,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tCreateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tCreateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55616,7 +55616,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectInvitationApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectInvitationApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55698,7 +55698,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55791,7 +55791,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55862,7 +55862,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnAllIPAddressesApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tReturnAllIPAddressesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnAllIPAddressesApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tReturnAllIPAddressesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55941,7 +55941,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectLimitsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectLimitsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectLimitsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectLimitsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56038,7 +56038,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectLimitApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectLimitApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56136,7 +56136,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56245,7 +56245,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tSetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tSetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56333,7 +56333,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCreatePushMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCreatePushMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56421,7 +56421,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ValidateMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tValidateMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ValidateMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tValidateMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56507,7 +56507,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetValidationStatusApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tGetValidationStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetValidationStatusApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tGetValidationStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56583,7 +56583,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tGetPushMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tGetPushMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56659,7 +56659,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CutoverMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCutoverMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CutoverMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCutoverMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56723,7 +56723,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResetMaintenanceWindowApiParams{}\n\thttpResp, err := client.MaintenanceWindowsApi.\n\t\tResetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResetMaintenanceWindowApiParams{}\n\thttpResp, err := client.MaintenanceWindowsApi.\n\t\tResetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56788,7 +56788,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tGetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tGetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56864,7 +56864,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tUpdateMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tUpdateMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56928,7 +56928,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleMaintenanceAutoDeferApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tToggleMaintenanceAutoDeferWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleMaintenanceAutoDeferApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tToggleMaintenanceAutoDeferWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56992,7 +56992,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeferMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tDeferMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeferMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tDeferMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57059,7 +57059,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedSlowMsApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tGetManagedSlowMsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedSlowMsApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tGetManagedSlowMsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57126,7 +57126,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableSlowOperationThresholdingApiParams{}\n\thttpResp, err := client.PerformanceAdvisorApi.\n\t\tDisableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableSlowOperationThresholdingApiParams{}\n\thttpResp, err := client.PerformanceAdvisorApi.\n\t\tDisableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57193,7 +57193,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EnableSlowOperationThresholdingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tEnableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EnableSlowOperationThresholdingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tEnableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57321,7 +57321,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLTSVersionsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectLTSVersionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLTSVersionsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectLTSVersionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57414,7 +57414,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringConnectionsApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringConnectionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringConnectionsApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringConnectionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57503,7 +57503,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tCreatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tCreatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57585,7 +57585,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringConnectionApiParams{}\n\thttpResp, err := client.NetworkPeeringApi.\n\t\tDeletePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringConnectionApiParams{}\n\thttpResp, err := client.NetworkPeeringApi.\n\t\tDeletePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57665,7 +57665,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tGetPeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tGetPeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57762,7 +57762,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tUpdatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tUpdatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57832,7 +57832,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelinesApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelinesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelinesApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelinesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57911,7 +57911,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tCreatePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tCreatePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57990,7 +57990,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineApiParams{}\n\thttpResp, err := client.DataLakePipelinesApi.\n\t\tDeletePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineApiParams{}\n\thttpResp, err := client.DataLakePipelinesApi.\n\t\tDeletePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58070,7 +58070,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tGetPipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tGetPipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58164,7 +58164,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tUpdatePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tUpdatePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58249,7 +58249,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSchedulesApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineSchedulesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSchedulesApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineSchedulesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58350,7 +58350,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSnapshotsApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineSnapshotsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSnapshotsApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineSnapshotsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58432,7 +58432,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PausePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tPausePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PausePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tPausePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58514,7 +58514,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResumePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tResumePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResumePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tResumePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58615,7 +58615,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineRunsApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineRunsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineRunsApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineRunsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58710,7 +58710,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineRunDatasetApiParams{}\n\thttpResp, err := client.DataLakePipelinesApi.\n\t\tDeletePipelineRunDatasetWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineRunDatasetApiParams{}\n\thttpResp, err := client.DataLakePipelinesApi.\n\t\tDeletePipelineRunDatasetWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58803,7 +58803,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineRunApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tGetPipelineRunWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineRunApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tGetPipelineRunWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58896,7 +58896,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TriggerSnapshotIngestionApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tTriggerSnapshotIngestionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TriggerSnapshotIngestionApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tTriggerSnapshotIngestionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58978,7 +58978,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59048,7 +59048,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59127,7 +59127,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tToggleRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tToggleRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59208,7 +59208,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tListServerlessPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tListServerlessPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59299,7 +59299,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tCreateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tCreateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59389,7 +59389,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessPrivateEndpointApiParams{}\n\thttpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tDeleteServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessPrivateEndpointApiParams{}\n\thttpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tDeleteServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59477,7 +59477,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tGetServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tGetServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59576,7 +59576,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tUpdateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tUpdateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59661,7 +59661,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPrivateEndpointServicesApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tListPrivateEndpointServicesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPrivateEndpointServicesApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tListPrivateEndpointServicesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59755,7 +59755,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointServiceApiParams{}\n\thttpResp, err := client.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointServiceApiParams{}\n\thttpResp, err := client.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59850,7 +59850,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59964,7 +59964,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60068,7 +60068,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointApiParams{}\n\thttpResp, err := client.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointApiParams{}\n\thttpResp, err := client.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60173,7 +60173,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60245,7 +60245,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyConnectViaPeeringOnlyModeForOneProjectApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tVerifyConnectViaPeeringOnlyModeForOneProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyConnectViaPeeringOnlyModeForOneProjectApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tVerifyConnectViaPeeringOnlyModeForOneProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60329,7 +60329,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisablePeeringApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tDisablePeeringWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisablePeeringApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tDisablePeeringWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60411,7 +60411,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDataFederationPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tListDataFederationPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDataFederationPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tListDataFederationPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60490,7 +60490,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60572,7 +60572,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDataFederationPrivateEndpointApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDataFederationPrivateEndpointApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60655,7 +60655,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tGetDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tGetDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60731,7 +60731,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasProcessesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListAtlasProcessesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasProcessesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListAtlasProcessesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60809,7 +60809,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasProcessApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetAtlasProcessWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasProcessApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetAtlasProcessWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60885,7 +60885,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespacesForHostApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespacesForHostWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespacesForHostApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespacesForHostWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60972,7 +60972,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabasesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDatabasesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabasesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDatabasesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61059,7 +61059,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61185,7 +61185,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDatabaseMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDatabaseMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61272,7 +61272,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskPartitionsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDiskPartitionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskPartitionsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDiskPartitionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61356,7 +61356,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61491,7 +61491,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61733,7 +61733,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetHostMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetHostMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61829,7 +61829,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueryNamespacesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSlowQueryNamespacesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueryNamespacesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSlowQueryNamespacesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61949,7 +61949,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueriesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSlowQueriesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueriesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSlowQueriesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62085,7 +62085,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSuggestedIndexesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSuggestedIndexesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSuggestedIndexesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSuggestedIndexesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62212,7 +62212,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespaceHostMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespaceHostMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespaceHostMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespaceHostMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62285,7 +62285,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePushBasedLogConfigurationApiParams{}\n\thttpResp, err := client.Push - BasedLogExportApi.\n\t\tDeletePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePushBasedLogConfigurationApiParams{}\n\thttpResp, err := client.Push - BasedLogExportApi.\n\t\tDeletePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62356,7 +62356,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tGetPushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tGetPushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62439,7 +62439,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tUpdatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tUpdatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62522,7 +62522,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tCreatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tCreatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62604,7 +62604,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.LoadSampleDatasetApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tLoadSampleDatasetWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.LoadSampleDatasetApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tLoadSampleDatasetWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62680,7 +62680,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSampleDatasetLoadStatusApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetSampleDatasetLoadStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSampleDatasetLoadStatusApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetSampleDatasetLoadStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62756,7 +62756,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessInstancesApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tListServerlessInstancesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessInstancesApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tListServerlessInstancesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62838,7 +62838,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tCreateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tCreateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62929,7 +62929,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListServerlessBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListServerlessBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63026,7 +63026,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63120,7 +63120,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63211,7 +63211,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListServerlessBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListServerlessBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63303,7 +63303,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetServerlessBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetServerlessBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63382,7 +63382,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tGetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tGetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63465,7 +63465,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tSetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tSetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63550,7 +63550,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessInstanceApiParams{}\n\thttpResp, err := client.ServerlessInstancesApi.\n\t\tDeleteServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessInstanceApiParams{}\n\thttpResp, err := client.ServerlessInstancesApi.\n\t\tDeleteServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63633,7 +63633,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tGetServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tGetServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63724,7 +63724,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tUpdateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tUpdateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63800,7 +63800,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectServiceAccountsApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tListProjectServiceAccountsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectServiceAccountsApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tListProjectServiceAccountsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63880,7 +63880,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tCreateProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tCreateProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63960,7 +63960,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectServiceAccountApiParams{}\n\thttpResp, err := client.GroupsApi.\n\t\tDeleteProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectServiceAccountApiParams{}\n\thttpResp, err := client.GroupsApi.\n\t\tDeleteProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64037,7 +64037,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tGetProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tGetProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64128,7 +64128,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tUpdateProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tUpdateProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64221,7 +64221,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tAddProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tAddProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64294,7 +64294,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64376,7 +64376,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64449,7 +64449,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamInstancesApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tListStreamInstancesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamInstancesApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tListStreamInstancesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64528,7 +64528,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tCreateStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tCreateStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64610,7 +64610,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamInstanceApiParams{}\n\thttpResp, err := client.StreamsApi.\n\t\tDeleteStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamInstanceApiParams{}\n\thttpResp, err := client.StreamsApi.\n\t\tDeleteStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64695,7 +64695,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tGetStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tGetStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64789,7 +64789,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tUpdateStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tUpdateStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64898,7 +64898,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadStreamTenantAuditLogsApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tDownloadStreamTenantAuditLogsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadStreamTenantAuditLogsApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tDownloadStreamTenantAuditLogsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64983,7 +64983,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamConnectionsApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tListStreamConnectionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamConnectionsApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tListStreamConnectionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65074,7 +65074,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tCreateStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tCreateStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65165,7 +65165,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamConnectionApiParams{}\n\thttpResp, err := client.StreamsApi.\n\t\tDeleteStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamConnectionApiParams{}\n\thttpResp, err := client.StreamsApi.\n\t\tDeleteStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65248,7 +65248,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tGetStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tGetStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65351,7 +65351,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tUpdateStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tUpdateStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65444,7 +65444,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamProcessorApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tCreateStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamProcessorApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tCreateStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65532,7 +65532,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamProcessorApiParams{}\n\thttpResp, err := client.StreamsApi.\n\t\tDeleteStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamProcessorApiParams{}\n\thttpResp, err := client.StreamsApi.\n\t\tDeleteStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65621,7 +65621,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamProcessorApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tGetStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamProcessorApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tGetStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65712,7 +65712,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.StartStreamProcessorApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tStartStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.StartStreamProcessorApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tStartStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65803,7 +65803,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.StopStreamProcessorApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tStopStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.StopStreamProcessorApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tStopStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65894,7 +65894,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamProcessorsApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tListStreamProcessorsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamProcessorsApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tListStreamProcessorsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65979,7 +65979,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectTeamsApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListProjectTeamsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectTeamsApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListProjectTeamsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66071,7 +66071,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddAllTeamsToProjectApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tAddAllTeamsToProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddAllTeamsToProjectApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tAddAllTeamsToProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66157,7 +66157,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectTeamApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tRemoveProjectTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectTeamApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tRemoveProjectTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66258,7 +66258,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateTeamRolesApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tUpdateTeamRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateTeamRolesApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tUpdateTeamRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66325,7 +66325,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66404,7 +66404,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SaveLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tSaveLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SaveLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tSaveLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66468,7 +66468,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableCustomerManagedX509ApiParams{}\n\thttpResp, err := client.X509AuthenticationApi.\n\t\tDisableCustomerManagedX509WithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableCustomerManagedX509ApiParams{}\n\thttpResp, err := client.X509AuthenticationApi.\n\t\tDisableCustomerManagedX509WithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66535,7 +66535,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLDAPConfigurationApiParams{}\n\thttpResp, err := client.LDAPConfigurationApi.\n\t\tDeleteLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLDAPConfigurationApiParams{}\n\thttpResp, err := client.LDAPConfigurationApi.\n\t\tDeleteLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66616,7 +66616,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tVerifyLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tVerifyLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66695,7 +66695,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationStatusApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationStatusApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66789,7 +66789,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectUsersApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectUsersApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66871,7 +66871,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectUserApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tRemoveProjectUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectUserApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tRemoveProjectUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66967,7 +66967,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectRolesApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectRolesApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67042,7 +67042,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.MigrateProjectToAnotherOrgApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tMigrateProjectToAnotherOrgWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.MigrateProjectToAnotherOrgApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tMigrateProjectToAnotherOrgWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67132,7 +67132,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67217,7 +67217,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67293,7 +67293,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67367,7 +67367,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67452,7 +67452,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tRenameOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tRenameOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67532,7 +67532,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeysApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListApiKeysWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeysApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListApiKeysWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67612,7 +67612,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67695,7 +67695,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67776,7 +67776,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67871,7 +67871,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67963,7 +67963,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeyAccessListsEntriesApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListApiKeyAccessListsEntriesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeyAccessListsEntriesApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListApiKeyAccessListsEntriesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -68069,7 +68069,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -68169,7 +68169,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyAccessListEntryApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyAccessListEntryWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyAccessListEntryApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyAccessListEntryWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -68264,7 +68264,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -68342,7 +68342,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcessApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tCreateCostExplorerQueryProcessWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcessApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tCreateCostExplorerQueryProcessWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -68433,7 +68433,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcess_1ApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tCreateCostExplorerQueryProcess_1WithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcess_1ApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tCreateCostExplorerQueryProcess_1WithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -68548,7 +68548,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationEventsApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListOrganizationEventsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationEventsApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListOrganizationEventsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -68639,7 +68639,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationEventApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tGetOrganizationEventWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationEventApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tGetOrganizationEventWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -68712,7 +68712,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetFederationSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetFederationSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -68802,7 +68802,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationProjectsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationProjectsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -68887,7 +68887,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationInvitationsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationInvitationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationInvitationsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationInvitationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -68969,7 +68969,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -69051,7 +69051,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -69133,7 +69133,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationInvitationApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationInvitationApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -69213,7 +69213,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -69307,7 +69307,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -69465,7 +69465,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListInvoicesApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tListInvoicesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListInvoicesApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tListInvoicesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -69535,7 +69535,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPendingInvoicesApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tListPendingInvoicesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPendingInvoicesApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tListPendingInvoicesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -69623,7 +69623,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetInvoiceApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tGetInvoiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetInvoiceApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tGetInvoiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -69704,7 +69704,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadInvoiceCSVApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tDownloadInvoiceCSVWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadInvoiceCSVApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tDownloadInvoiceCSVWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -69777,7 +69777,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSourceProjectsApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tListSourceProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSourceProjectsApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tListSourceProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -69844,7 +69844,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLinkTokenApiParams{}\n\thttpResp, err := client.CloudMigrationServiceApi.\n\t\tDeleteLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLinkTokenApiParams{}\n\thttpResp, err := client.CloudMigrationServiceApi.\n\t\tDeleteLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -69923,7 +69923,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLinkTokenApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCreateLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLinkTokenApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCreateLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -69999,7 +69999,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServiceAccountsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListServiceAccountsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServiceAccountsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListServiceAccountsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -70078,7 +70078,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -70154,7 +70154,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServiceAccountApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServiceAccountApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -70231,7 +70231,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -70322,7 +70322,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -70407,7 +70407,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServiceAccountProjectsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListServiceAccountProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServiceAccountProjectsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListServiceAccountProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -70497,7 +70497,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServiceAccountSecretApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateServiceAccountSecretWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServiceAccountSecretApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateServiceAccountSecretWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -70582,7 +70582,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServiceAccountSecretApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteServiceAccountSecretWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServiceAccountSecretApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteServiceAccountSecretWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -70655,7 +70655,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -70737,7 +70737,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -70823,7 +70823,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationTeamsApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListOrganizationTeamsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationTeamsApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListOrganizationTeamsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -70912,7 +70912,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateTeamApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tCreateTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateTeamApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tCreateTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -70998,7 +70998,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByNameApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tGetTeamByNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByNameApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tGetTeamByNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -71087,7 +71087,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteTeamApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tDeleteTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteTeamApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tDeleteTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -71174,7 +71174,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByIdApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tGetTeamByIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByIdApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tGetTeamByIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -71275,7 +71275,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameTeamApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tRenameTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameTeamApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tRenameTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -71373,7 +71373,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListTeamUsersApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListTeamUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListTeamUsersApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListTeamUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -71477,7 +71477,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddTeamUserApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tAddTeamUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddTeamUserApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tAddTeamUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -71575,7 +71575,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveTeamUserApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tRemoveTeamUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveTeamUserApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tRemoveTeamUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -71657,7 +71657,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationUsersApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationUsersApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -71742,7 +71742,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveOrganizationUserApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tRemoveOrganizationUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveOrganizationUserApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tRemoveOrganizationUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -71838,7 +71838,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationRolesApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationRolesApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -71891,7 +71891,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnAllControlPlaneIPAddressesApiParams{}\n\tsdkResp, httpResp, err := client.RootApi.\n\t\tReturnAllControlPlaneIPAddressesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnAllControlPlaneIPAddressesApiParams{}\n\tsdkResp, httpResp, err := client.RootApi.\n\t\tReturnAllControlPlaneIPAddressesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -71969,7 +71969,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateUserApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tCreateUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateUserApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tCreateUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -72046,7 +72046,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserByUsernameApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tGetUserByUsernameWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserByUsernameApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tGetUserByUsernameWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -72125,7 +72125,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tGetUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tGetUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",

--- a/tools/cli/test/data/split/dev/openapi-v2-2024-08-05.yaml
+++ b/tools/cli/test/data/split/dev/openapi-v2-2024-08-05.yaml
@@ -30163,9 +30163,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30235,9 +30233,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30308,9 +30304,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30381,9 +30375,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30452,9 +30444,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30528,9 +30518,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30612,9 +30600,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30695,9 +30681,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30785,9 +30769,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30864,9 +30846,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30945,9 +30925,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31032,9 +31010,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31116,9 +31092,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31207,9 +31181,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31309,9 +31281,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31394,9 +31364,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31477,9 +31445,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31559,9 +31525,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31649,9 +31613,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31732,9 +31694,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31806,9 +31766,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31881,9 +31839,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31973,9 +31929,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32050,9 +32004,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32122,9 +32074,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32205,9 +32155,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32292,9 +32240,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32373,9 +32319,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32462,9 +32406,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32555,9 +32497,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32640,9 +32580,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32725,9 +32663,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32802,9 +32738,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32884,9 +32818,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32972,9 +32904,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33057,9 +32987,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33151,9 +33079,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33251,9 +33177,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33344,9 +33268,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33432,9 +33354,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33517,9 +33437,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33610,9 +33528,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33702,9 +33618,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33779,9 +33693,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33856,9 +33768,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33945,9 +33855,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34036,9 +33944,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34128,9 +34034,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34203,9 +34107,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34282,9 +34184,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34357,9 +34257,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34434,9 +34332,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34512,9 +34408,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34632,9 +34526,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34720,9 +34612,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34824,9 +34714,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34897,9 +34785,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34985,9 +34871,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35060,9 +34944,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35140,9 +35022,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35232,9 +35112,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35312,9 +35190,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35405,9 +35281,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35489,9 +35363,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35702,9 +35574,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35795,9 +35665,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35878,9 +35746,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35971,9 +35837,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36109,9 +35973,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36201,9 +36063,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36284,9 +36144,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36375,9 +36233,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36464,9 +36320,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36547,9 +36401,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36642,9 +36494,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36737,9 +36587,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36825,9 +36673,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36906,9 +36752,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36985,9 +36829,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37076,9 +36918,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37165,9 +37005,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37256,9 +37094,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37351,9 +37187,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37441,9 +37275,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37538,9 +37370,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37631,9 +37461,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37721,9 +37549,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37803,9 +37629,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37898,9 +37722,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37995,9 +37817,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38081,9 +37901,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38172,9 +37990,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38254,9 +38070,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38345,9 +38159,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38429,9 +38241,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38523,9 +38333,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38606,9 +38414,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38702,9 +38508,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38802,9 +38606,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38896,9 +38698,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38995,9 +38795,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39098,9 +38896,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39194,9 +38990,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39287,9 +39081,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39391,9 +39183,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39479,9 +39269,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39562,9 +39350,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39654,9 +39440,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39753,9 +39537,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39847,9 +39629,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40006,9 +39786,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40096,9 +39874,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40191,9 +39967,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40289,9 +40063,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40384,9 +40156,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40488,9 +40258,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40602,9 +40370,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40689,9 +40455,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40775,9 +40539,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40866,9 +40628,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40955,9 +40715,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41049,9 +40807,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41131,9 +40887,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41232,9 +40986,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41321,9 +41073,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41420,9 +41170,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41504,9 +41252,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41585,9 +41331,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41675,9 +41419,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41769,9 +41511,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41866,9 +41606,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41959,9 +41697,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42068,9 +41804,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42171,9 +41905,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42273,9 +42005,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42384,9 +42114,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42482,9 +42210,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42581,9 +42307,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42683,9 +42407,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42771,9 +42493,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42861,9 +42581,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42959,9 +42677,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43051,9 +42767,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43140,9 +42854,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43236,9 +42948,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43320,9 +43030,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43413,9 +43121,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43505,9 +43211,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43624,9 +43328,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43710,9 +43412,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43796,9 +43496,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43886,9 +43584,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43964,9 +43660,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44051,9 +43745,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44136,9 +43828,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44227,9 +43917,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44307,9 +43995,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44402,9 +44088,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44480,9 +44164,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44553,9 +44235,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44638,9 +44318,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44723,9 +44401,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44801,9 +44477,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44892,9 +44566,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44978,9 +44650,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45061,9 +44731,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45142,9 +44810,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45221,9 +44887,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45312,9 +44976,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45397,9 +45059,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45492,9 +45152,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45587,9 +45245,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45692,9 +45348,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45797,9 +45451,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45871,9 +45523,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46047,9 +45697,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46152,9 +45800,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46250,9 +45896,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46361,9 +46005,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46447,9 +46089,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46547,9 +46187,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46668,9 +46306,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46782,9 +46418,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46856,9 +46490,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46951,9 +46583,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47034,9 +46664,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47119,9 +46747,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47218,9 +46844,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47305,9 +46929,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47433,9 +47055,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47524,9 +47144,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47597,9 +47215,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47700,9 +47316,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47802,9 +47416,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47903,9 +47515,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47981,9 +47591,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48074,9 +47682,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48166,9 +47772,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48270,9 +47874,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48376,9 +47978,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48460,9 +48060,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48543,9 +48141,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48626,9 +48222,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48711,9 +48305,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48794,9 +48386,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48885,9 +48475,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48963,9 +48551,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49042,9 +48628,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49153,9 +48737,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49265,9 +48847,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49387,9 +48967,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49483,9 +49061,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49563,9 +49139,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49639,9 +49213,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49728,9 +49300,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49818,9 +49388,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49888,9 +49456,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49958,9 +49524,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50036,9 +49600,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50110,9 +49672,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50184,9 +49744,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50259,9 +49817,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50330,9 +49886,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50401,9 +49955,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50517,9 +50069,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50603,9 +50153,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50689,9 +50237,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50775,9 +50321,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50856,9 +50400,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50948,9 +50490,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51026,9 +50566,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51106,9 +50644,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51191,9 +50727,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51272,9 +50806,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51363,9 +50895,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51451,9 +50981,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51543,9 +51071,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51625,9 +51151,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51711,9 +51235,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51807,9 +51329,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51899,9 +51419,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51990,9 +51508,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52079,9 +51595,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52167,9 +51681,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52258,9 +51770,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52350,9 +51860,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52454,9 +51962,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52556,9 +52062,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52655,9 +52159,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52736,9 +52238,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52813,9 +52313,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52892,9 +52390,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52978,9 +52474,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53070,9 +52564,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53163,9 +52655,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53251,9 +52741,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53346,9 +52834,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53425,9 +52911,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53508,9 +52992,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53590,9 +53072,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53688,9 +53168,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53774,9 +53252,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53857,9 +53333,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53931,9 +53405,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54010,9 +53482,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54124,9 +53594,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54198,9 +53666,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54280,9 +53746,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54365,9 +53829,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54476,9 +53938,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54558,9 +54018,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54642,9 +54100,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54769,9 +54225,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55007,9 +54461,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55106,9 +54558,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55222,9 +54672,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55345,9 +54793,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55420,9 +54866,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55494,9 +54938,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55576,9 +55018,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55662,9 +55102,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55749,9 +55187,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55832,9 +55268,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55906,9 +55340,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55987,9 +55419,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56076,9 +55506,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56168,9 +55596,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56263,9 +55689,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56348,9 +55772,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56439,9 +55861,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56519,9 +55939,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56603,9 +56021,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56691,9 +56107,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56774,9 +56188,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56862,9 +56274,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56941,9 +56351,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57021,9 +56429,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57105,9 +56511,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57183,9 +56587,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57270,9 +56672,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57363,9 +56763,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57442,9 +56840,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57523,9 +56919,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57600,9 +56994,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57679,9 +57071,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57764,9 +57154,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57848,9 +57236,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57937,9 +57323,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58043,9 +57427,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58124,9 +57506,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58211,9 +57591,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58302,9 +57680,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58385,9 +57761,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58480,9 +57854,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58572,9 +57944,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58661,9 +58031,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58747,9 +58115,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58834,9 +58200,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58925,9 +58289,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59013,9 +58375,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59093,9 +58453,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59181,9 +58539,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59271,9 +58627,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59366,9 +58720,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59441,9 +58793,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59523,9 +58873,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59600,9 +58948,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59671,9 +59017,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59751,9 +59095,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59835,9 +59177,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59921,9 +59261,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60003,9 +59341,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60094,9 +59430,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60175,9 +59509,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60263,9 +59595,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60347,9 +59677,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60431,9 +59759,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60518,9 +59844,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60594,9 +59918,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60677,9 +59999,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60758,9 +60078,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60838,9 +60156,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60925,9 +60241,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -61007,9 +60321,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -61098,9 +60410,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -61188,9 +60498,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -61283,9 +60591,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -61382,9 +60688,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -61474,9 +60778,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -61553,9 +60855,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -61646,9 +60946,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -61752,9 +61050,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -61843,9 +61139,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -61918,9 +61212,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -62009,9 +61301,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -62092,9 +61382,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -62173,9 +61461,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -62258,9 +61544,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -62343,9 +61627,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -62425,9 +61707,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -62515,9 +61795,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -62654,9 +61932,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -62742,9 +62018,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -62831,9 +62105,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -62904,9 +62176,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -62979,9 +62249,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -63051,9 +62319,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -63130,9 +62396,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -63209,9 +62473,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -63288,9 +62550,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -63369,9 +62629,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -63447,9 +62705,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -63534,9 +62790,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -63619,9 +62873,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -63705,9 +62957,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -63792,9 +63042,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -63867,9 +63115,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -63948,9 +63194,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -64033,9 +63277,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -64119,9 +63361,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -64210,9 +63450,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -64296,9 +63534,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -64391,9 +63627,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -64486,9 +63720,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -64583,9 +63815,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -64681,9 +63911,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -64765,9 +63993,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -64843,9 +64069,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -64928,9 +64152,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -65019,9 +64241,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -65088,9 +64308,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -65172,9 +64390,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -65257,9 +64473,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -65336,9 +64550,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)

--- a/tools/cli/test/data/split/dev/openapi-v2-2025-01-01.json
+++ b/tools/cli/test/data/split/dev/openapi-v2-2025-01-01.json
@@ -37334,7 +37334,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSystemStatusApiParams{}\n\tsdkResp, httpResp, err := client.RootApi.\n\t\tGetSystemStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSystemStatusApiParams{}\n\tsdkResp, httpResp, err := client.RootApi.\n\t\tGetSystemStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37401,7 +37401,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationMatchersFieldNamesApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationMatchersFieldNamesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationMatchersFieldNamesApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationMatchersFieldNamesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37474,7 +37474,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersForAllProjectsApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListClustersForAllProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersForAllProjectsApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListClustersForAllProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37547,7 +37547,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListEventTypesApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListEventTypesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListEventTypesApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListEventTypesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37611,7 +37611,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederationAppApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tDeleteFederationAppWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederationAppApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tDeleteFederationAppWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37687,7 +37687,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListConnectedOrgConfigsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListConnectedOrgConfigsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListConnectedOrgConfigsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListConnectedOrgConfigsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37770,7 +37770,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveConnectedOrgConfigApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tRemoveConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveConnectedOrgConfigApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tRemoveConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37851,7 +37851,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -37943,7 +37943,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38016,7 +38016,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListRoleMappingsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListRoleMappingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListRoleMappingsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListRoleMappingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38098,7 +38098,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tCreateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tCreateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38181,7 +38181,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteRoleMappingApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tDeleteRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteRoleMappingApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tDeleteRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38265,7 +38265,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38360,7 +38360,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38468,7 +38468,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIdentityProvidersApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListIdentityProvidersWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIdentityProvidersApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListIdentityProvidersWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38550,7 +38550,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tCreateIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tCreateIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38627,7 +38627,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteIdentityProviderApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tDeleteIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteIdentityProviderApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tDeleteIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38708,7 +38708,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38797,7 +38797,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38874,7 +38874,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RevokeJwksFromIdentityProviderApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tRevokeJwksFromIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RevokeJwksFromIdentityProviderApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tRevokeJwksFromIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -38944,7 +38944,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderMetadataApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetIdentityProviderMetadataWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderMetadataApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetIdentityProviderMetadataWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39020,7 +39020,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39116,7 +39116,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tCreateProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tCreateProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39200,7 +39200,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectByNameApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectByNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectByNameApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectByNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39270,7 +39270,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39338,7 +39338,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39423,7 +39423,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39509,7 +39509,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddUserToProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tAddUserToProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddUserToProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tAddUserToProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39589,7 +39589,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectIpAccessListsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tListProjectIpAccessListsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectIpAccessListsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tListProjectIpAccessListsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39687,7 +39687,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectIpAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tCreateProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectIpAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tCreateProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39772,7 +39772,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectIpAccessListApiParams{}\n\thttpResp, err := client.ProjectIPAccessListApi.\n\t\tDeleteProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectIpAccessListApiParams{}\n\thttpResp, err := client.ProjectIPAccessListApi.\n\t\tDeleteProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39858,7 +39858,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpListApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tGetProjectIpListWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpListApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tGetProjectIpListWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -39945,7 +39945,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpAccessListStatusApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tGetProjectIpAccessListStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpAccessListStatusApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tGetProjectIpAccessListStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40021,7 +40021,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40100,7 +40100,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tCreateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tCreateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40180,7 +40180,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAlertConfigurationApiParams{}\n\thttpResp, err := client.AlertConfigurationsApi.\n\t\tDeleteAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAlertConfigurationApiParams{}\n\thttpResp, err := client.AlertConfigurationsApi.\n\t\tDeleteAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40261,7 +40261,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tGetAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tGetAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40353,7 +40353,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tToggleAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tToggleAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40448,7 +40448,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tUpdateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tUpdateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40540,7 +40540,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsByAlertConfigurationIdApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tListAlertsByAlertConfigurationIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsByAlertConfigurationIdApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tListAlertsByAlertConfigurationIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40632,7 +40632,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tListAlertsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tListAlertsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40714,7 +40714,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tGetAlertWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tGetAlertWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40808,7 +40808,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AcknowledgeAlertApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tAcknowledgeAlertWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AcknowledgeAlertApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tAcknowledgeAlertWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40899,7 +40899,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsByAlertIdApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationsByAlertIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsByAlertIdApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationsByAlertIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -40979,7 +40979,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectApiKeysApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListProjectApiKeysWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectApiKeysApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListProjectApiKeysWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41055,7 +41055,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41141,7 +41141,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectApiKeyApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tRemoveProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectApiKeyApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tRemoveProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41241,7 +41241,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyRolesApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyRolesApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41332,7 +41332,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tAddProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tAddProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41399,7 +41399,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AuditingApi.\n\t\tGetAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AuditingApi.\n\t\tGetAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41478,7 +41478,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AuditingApi.\n\t\tUpdateAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AuditingApi.\n\t\tUpdateAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41545,7 +41545,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := client.AWSClustersDNSApi.\n\t\tGetAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := client.AWSClustersDNSApi.\n\t\tGetAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41621,7 +41621,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := client.AWSClustersDNSApi.\n\t\tToggleAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := client.AWSClustersDNSApi.\n\t\tToggleAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41697,7 +41697,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListExportBucketsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListExportBucketsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListExportBucketsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListExportBucketsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41834,7 +41834,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateExportBucketApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateExportBucketWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateExportBucketApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateExportBucketWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -41917,7 +41917,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteExportBucketApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteExportBucketWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteExportBucketApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteExportBucketWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42029,7 +42029,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetExportBucketApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetExportBucketWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetExportBucketApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetExportBucketWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42099,7 +42099,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42191,7 +42191,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42258,7 +42258,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderAccessRolesApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tListCloudProviderAccessRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderAccessRolesApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tListCloudProviderAccessRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42338,7 +42338,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tCreateCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tCreateCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42429,7 +42429,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeauthorizeCloudProviderAccessRoleApiParams{}\n\thttpResp, err := client.CloudProviderAccessApi.\n\t\tDeauthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeauthorizeCloudProviderAccessRoleApiParams{}\n\thttpResp, err := client.CloudProviderAccessApi.\n\t\tDeauthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42508,7 +42508,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tGetCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tGetCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42606,7 +42606,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AuthorizeCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tAuthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AuthorizeCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tAuthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42691,7 +42691,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListClustersWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListClustersWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42786,7 +42786,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tCreateClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tCreateClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42881,7 +42881,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderRegionsApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListCloudProviderRegionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderRegionsApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListCloudProviderRegionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -42971,7 +42971,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpgradeSharedClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpgradeSharedClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43061,7 +43061,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterToServerlessApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpgradeSharedClusterToServerlessWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterToServerlessApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpgradeSharedClusterToServerlessWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43154,7 +43154,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteClusterApiParams{}\n\thttpResp, err := client.ClustersApi.\n\t\tDeleteClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteClusterApiParams{}\n\thttpResp, err := client.ClustersApi.\n\t\tDeleteClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43237,7 +43237,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43335,7 +43335,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpdateClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpdateClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43423,7 +43423,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupExportJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListBackupExportJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupExportJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListBackupExportJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43517,7 +43517,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43602,7 +43602,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43690,7 +43690,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43787,7 +43787,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43881,7 +43881,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CancelBackupRestoreJobApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tCancelBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CancelBackupRestoreJobApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tCancelBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -43970,7 +43970,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44049,7 +44049,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllBackupSchedulesApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteAllBackupSchedulesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllBackupSchedulesApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteAllBackupSchedulesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44126,7 +44126,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44217,7 +44217,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44308,7 +44308,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListReplicaSetBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListReplicaSetBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListReplicaSetBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListReplicaSetBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44399,7 +44399,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TakeSnapshotApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tTakeSnapshotWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TakeSnapshotApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tTakeSnapshotWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44490,7 +44490,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteShardedClusterBackupApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteShardedClusterBackupApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44582,7 +44582,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetShardedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetShardedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44664,7 +44664,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListShardedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListShardedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListShardedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListShardedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44758,7 +44758,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteReplicaSetBackupApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteReplicaSetBackupApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44850,7 +44850,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetReplicaSetBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetReplicaSetBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -44953,7 +44953,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateSnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateSnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateSnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateSnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45055,7 +45055,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tDownloadSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tDownloadSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45154,7 +45154,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tCreateSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tCreateSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45236,7 +45236,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tListSharedClusterBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tListSharedClusterBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45330,7 +45330,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tGetSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tGetSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45412,7 +45412,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tListSharedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tListSharedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45506,7 +45506,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tGetSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tGetSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45595,7 +45595,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupCheckpointsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacyBackupCheckpointsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupCheckpointsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacyBackupCheckpointsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45693,7 +45693,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupCheckpointApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacyBackupCheckpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupCheckpointApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacyBackupCheckpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45775,7 +45775,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPinnedNamespacesApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetPinnedNamespacesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPinnedNamespacesApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetPinnedNamespacesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45877,7 +45877,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PinNamespacesPatchApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tPinNamespacesPatchWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PinNamespacesPatchApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tPinNamespacesPatchWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -45979,7 +45979,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PinNamespacesPutApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tPinNamespacesPutWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PinNamespacesPutApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tPinNamespacesPutWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46072,7 +46072,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UnpinNamespacesApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tUnpinNamespacesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UnpinNamespacesApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tUnpinNamespacesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46173,7 +46173,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tCreateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tCreateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46279,7 +46279,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasSearchIndexesDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tListAtlasSearchIndexesDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasSearchIndexesDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tListAtlasSearchIndexesDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46379,7 +46379,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchIndexDeprecatedApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchIndexDeprecatedApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46474,7 +46474,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46586,7 +46586,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46670,7 +46670,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tGetManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tGetManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46753,7 +46753,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllCustomZoneMappingsApiParams{}\n\thttpResp, err := client.GlobalClustersApi.\n\t\tDeleteAllCustomZoneMappingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllCustomZoneMappingsApiParams{}\n\thttpResp, err := client.GlobalClustersApi.\n\t\tDeleteAllCustomZoneMappingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46849,7 +46849,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomZoneMappingApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tCreateCustomZoneMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomZoneMappingApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tCreateCustomZoneMappingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -46951,7 +46951,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteManagedNamespaceApiParams{}\n\thttpResp, err := client.GlobalClustersApi.\n\t\tDeleteManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteManagedNamespaceApiParams{}\n\thttpResp, err := client.GlobalClustersApi.\n\t\tDeleteManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47050,7 +47050,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tCreateManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tCreateManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47235,7 +47235,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRollingIndexApiParams{}\n\tsdkResp, httpResp, err := client.RollingIndexApi.\n\t\tCreateRollingIndexWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRollingIndexApiParams{}\n\tsdkResp, httpResp, err := client.RollingIndexApi.\n\t\tCreateRollingIndexWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47327,7 +47327,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOnlineArchivesApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tListOnlineArchivesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOnlineArchivesApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tListOnlineArchivesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47428,7 +47428,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tCreateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tCreateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47547,7 +47547,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadOnlineArchiveQueryLogsApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tDownloadOnlineArchiveQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadOnlineArchiveQueryLogsApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tDownloadOnlineArchiveQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47645,7 +47645,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOnlineArchiveApiParams{}\n\thttpResp, err := client.OnlineArchiveApi.\n\t\tDeleteOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOnlineArchiveApiParams{}\n\thttpResp, err := client.OnlineArchiveApi.\n\t\tDeleteOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47744,7 +47744,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tGetOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tGetOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47857,7 +47857,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tUpdateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tUpdateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -47946,7 +47946,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EndOutageSimulationApiParams{}\n\thttpResp, err := client.ClusterOutageSimulationApi.\n\t\tEndOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EndOutageSimulationApiParams{}\n\thttpResp, err := client.ClusterOutageSimulationApi.\n\t\tEndOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48033,7 +48033,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := client.ClusterOutageSimulationApi.\n\t\tGetOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := client.ClusterOutageSimulationApi.\n\t\tGetOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48128,7 +48128,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.StartOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := client.ClusterOutageSimulationApi.\n\t\tStartOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.StartOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := client.ClusterOutageSimulationApi.\n\t\tStartOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48214,7 +48214,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48313,7 +48313,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpdateClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpdateClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48389,7 +48389,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TestFailoverApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tTestFailoverWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TestFailoverApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tTestFailoverWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48492,7 +48492,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacyBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacyBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48584,7 +48584,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tCreateLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tCreateLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48679,7 +48679,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48764,7 +48764,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchDeploymentApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchDeploymentApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48844,7 +48844,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -48938,7 +48938,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49032,7 +49032,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tCreateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tCreateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49131,7 +49131,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasSearchIndexesClusterApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tListAtlasSearchIndexesClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasSearchIndexesClusterApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tListAtlasSearchIndexesClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49229,7 +49229,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchIndexApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tCreateAtlasSearchIndexWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchIndexApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tCreateAtlasSearchIndexWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49346,7 +49346,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasSearchIndexesApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tListAtlasSearchIndexesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasSearchIndexesApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tListAtlasSearchIndexesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49459,7 +49459,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchIndexByNameApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchIndexByNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchIndexByNameApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchIndexByNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49570,7 +49570,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchIndexByNameApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchIndexByNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchIndexByNameApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchIndexByNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49695,7 +49695,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchIndexByNameApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchIndexByNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchIndexByNameApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchIndexByNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49793,7 +49793,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchIndexApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchIndexWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchIndexApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchIndexWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -49899,7 +49899,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchIndexApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchIndexWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchIndexApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchIndexWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50009,7 +50009,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchIndexApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchIndexWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchIndexApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchIndexWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50089,7 +50089,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50178,7 +50178,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tUpdateLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tUpdateLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50281,7 +50281,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacySnapshotsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacySnapshotsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacySnapshotsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacySnapshotsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50376,7 +50376,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLegacySnapshotApiParams{}\n\thttpResp, err := client.LegacyBackupApi.\n\t\tDeleteLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLegacySnapshotApiParams{}\n\thttpResp, err := client.LegacyBackupApi.\n\t\tDeleteLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50466,7 +50466,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50567,7 +50567,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tUpdateLegacySnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tUpdateLegacySnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50646,7 +50646,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterStatusApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterStatusApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50745,7 +50745,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespacesForClusterApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespacesForClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespacesForClusterApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespacesForClusterWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50897,7 +50897,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespaceClusterMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespaceClusterMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespaceClusterMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespaceClusterMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -50996,7 +50996,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PinFeatureCompatibilityVersionApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tPinFeatureCompatibilityVersionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PinFeatureCompatibilityVersionApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tPinFeatureCompatibilityVersionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51087,7 +51087,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UnpinFeatureCompatibilityVersionApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUnpinFeatureCompatibilityVersionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UnpinFeatureCompatibilityVersionApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUnpinFeatureCompatibilityVersionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51214,7 +51214,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostLogsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetHostLogsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostLogsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetHostLogsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51284,7 +51284,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespaceMetricsApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespaceMetricsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespaceMetricsApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespaceMetricsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51378,7 +51378,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainerByCloudProviderApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringContainerByCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainerByCloudProviderApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringContainerByCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51466,7 +51466,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tCreatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tCreatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51542,7 +51542,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainersApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringContainersWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainersApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringContainersWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51631,7 +51631,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringContainerApiParams{}\n\thttpResp, err := client.NetworkPeeringApi.\n\t\tDeletePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringContainerApiParams{}\n\thttpResp, err := client.NetworkPeeringApi.\n\t\tDeletePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51709,7 +51709,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tGetPeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tGetPeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51810,7 +51810,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tUpdatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tUpdatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51880,7 +51880,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCustomDatabaseRolesApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tListCustomDatabaseRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCustomDatabaseRolesApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tListCustomDatabaseRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -51968,7 +51968,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tCreateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tCreateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52050,7 +52050,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteCustomDatabaseRoleApiParams{}\n\thttpResp, err := client.CustomDatabaseRolesApi.\n\t\tDeleteCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteCustomDatabaseRoleApiParams{}\n\thttpResp, err := client.CustomDatabaseRolesApi.\n\t\tDeleteCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52127,7 +52127,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tGetCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tGetCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52224,7 +52224,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tUpdateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tUpdateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52307,7 +52307,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListFederatedDatabasesApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tListFederatedDatabasesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListFederatedDatabasesApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tListFederatedDatabasesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52392,7 +52392,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52468,7 +52468,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederatedDatabaseApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederatedDatabaseApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52545,7 +52545,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tGetFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tGetFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52642,7 +52642,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tUpdateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tUpdateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52724,7 +52724,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52812,7 +52812,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOneDataFederationInstanceQueryLimitApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteOneDataFederationInstanceQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOneDataFederationInstanceQueryLimitApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteOneDataFederationInstanceQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -52901,7 +52901,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53004,7 +53004,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOneDataFederationQueryLimitApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateOneDataFederationQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOneDataFederationQueryLimitApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateOneDataFederationQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53110,7 +53110,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadFederatedDatabaseQueryLogsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tDownloadFederatedDatabaseQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadFederatedDatabaseQueryLogsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tDownloadFederatedDatabaseQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53186,7 +53186,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUsersApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tListDatabaseUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUsersApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tListDatabaseUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53426,7 +53426,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tCreateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tCreateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53518,7 +53518,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDatabaseUserApiParams{}\n\thttpResp, err := client.DatabaseUsersApi.\n\t\tDeleteDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDatabaseUserApiParams{}\n\thttpResp, err := client.DatabaseUsersApi.\n\t\tDeleteDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53605,7 +53605,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tGetDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tGetDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53712,7 +53712,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tUpdateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tUpdateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53800,7 +53800,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUserCertificatesApiParams{}\n\tsdkResp, httpResp, err := client.X509AuthenticationApi.\n\t\tListDatabaseUserCertificatesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUserCertificatesApiParams{}\n\tsdkResp, httpResp, err := client.X509AuthenticationApi.\n\t\tListDatabaseUserCertificatesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -53902,7 +53902,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserCertificateApiParams{}\n\tsdkResp, httpResp, err := client.X509AuthenticationApi.\n\t\tCreateDatabaseUserCertificateWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserCertificateApiParams{}\n\tsdkResp, httpResp, err := client.X509AuthenticationApi.\n\t\tCreateDatabaseUserCertificateWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54035,7 +54035,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByClusterNameApiParams{}\n\tsdkResp, httpResp, err := client.AccessTrackingApi.\n\t\tListAccessLogsByClusterNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByClusterNameApiParams{}\n\tsdkResp, httpResp, err := client.AccessTrackingApi.\n\t\tListAccessLogsByClusterNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54165,7 +54165,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByHostnameApiParams{}\n\tsdkResp, httpResp, err := client.AccessTrackingApi.\n\t\tListAccessLogsByHostnameWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByHostnameApiParams{}\n\tsdkResp, httpResp, err := client.AccessTrackingApi.\n\t\tListAccessLogsByHostnameWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54232,7 +54232,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54317,7 +54317,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tUpdateEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tUpdateEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54396,7 +54396,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointsForCloudProviderApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointsForCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointsForCloudProviderApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointsForCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54484,7 +54484,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tCreateEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tCreateEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54586,7 +54586,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RequestEncryptionAtRestPrivateEndpointDeletionApiParams{}\n\thttpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tRequestEncryptionAtRestPrivateEndpointDeletionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RequestEncryptionAtRestPrivateEndpointDeletionApiParams{}\n\thttpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tRequestEncryptionAtRestPrivateEndpointDeletionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54675,7 +54675,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54818,7 +54818,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectEventsApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListProjectEventsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectEventsApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListProjectEventsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54909,7 +54909,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectEventApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tGetProjectEventWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectEventApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tGetProjectEventWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -54979,7 +54979,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListMetricTypesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListMetricTypesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListMetricTypesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListMetricTypesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55095,7 +55095,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55214,7 +55214,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55325,7 +55325,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55407,7 +55407,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListThirdPartyIntegrationsApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tListThirdPartyIntegrationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListThirdPartyIntegrationsApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tListThirdPartyIntegrationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55502,7 +55502,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteThirdPartyIntegrationApiParams{}\n\thttpResp, err := client.Third - PartyIntegrationsApi.\n\t\tDeleteThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteThirdPartyIntegrationApiParams{}\n\thttpResp, err := client.Third - PartyIntegrationsApi.\n\t\tDeleteThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55595,7 +55595,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tGetThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tGetThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55711,7 +55711,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tCreateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tCreateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55824,7 +55824,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tUpdateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tUpdateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55904,7 +55904,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectInvitationsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectInvitationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectInvitationsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectInvitationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -55988,7 +55988,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56066,7 +56066,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tCreateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tCreateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56144,7 +56144,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectInvitationApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectInvitationApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56226,7 +56226,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56319,7 +56319,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56390,7 +56390,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnAllIPAddressesApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tReturnAllIPAddressesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnAllIPAddressesApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tReturnAllIPAddressesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56469,7 +56469,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectLimitsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectLimitsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectLimitsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectLimitsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56566,7 +56566,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectLimitApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectLimitApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56664,7 +56664,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56773,7 +56773,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tSetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tSetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56861,7 +56861,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCreatePushMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCreatePushMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -56949,7 +56949,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ValidateMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tValidateMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ValidateMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tValidateMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57035,7 +57035,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetValidationStatusApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tGetValidationStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetValidationStatusApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tGetValidationStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57111,7 +57111,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tGetPushMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tGetPushMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57187,7 +57187,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CutoverMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCutoverMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CutoverMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCutoverMigrationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57251,7 +57251,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResetMaintenanceWindowApiParams{}\n\thttpResp, err := client.MaintenanceWindowsApi.\n\t\tResetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResetMaintenanceWindowApiParams{}\n\thttpResp, err := client.MaintenanceWindowsApi.\n\t\tResetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57316,7 +57316,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tGetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tGetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57392,7 +57392,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tUpdateMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tUpdateMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57456,7 +57456,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleMaintenanceAutoDeferApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tToggleMaintenanceAutoDeferWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleMaintenanceAutoDeferApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tToggleMaintenanceAutoDeferWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57520,7 +57520,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeferMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tDeferMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeferMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tDeferMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57587,7 +57587,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedSlowMsApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tGetManagedSlowMsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedSlowMsApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tGetManagedSlowMsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57654,7 +57654,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableSlowOperationThresholdingApiParams{}\n\thttpResp, err := client.PerformanceAdvisorApi.\n\t\tDisableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableSlowOperationThresholdingApiParams{}\n\thttpResp, err := client.PerformanceAdvisorApi.\n\t\tDisableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57721,7 +57721,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EnableSlowOperationThresholdingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tEnableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EnableSlowOperationThresholdingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tEnableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57849,7 +57849,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLTSVersionsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectLTSVersionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLTSVersionsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectLTSVersionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -57942,7 +57942,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringConnectionsApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringConnectionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringConnectionsApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringConnectionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58031,7 +58031,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tCreatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tCreatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58113,7 +58113,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringConnectionApiParams{}\n\thttpResp, err := client.NetworkPeeringApi.\n\t\tDeletePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringConnectionApiParams{}\n\thttpResp, err := client.NetworkPeeringApi.\n\t\tDeletePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58193,7 +58193,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tGetPeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tGetPeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58290,7 +58290,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tUpdatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tUpdatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58360,7 +58360,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelinesApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelinesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelinesApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelinesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58439,7 +58439,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tCreatePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tCreatePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58518,7 +58518,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineApiParams{}\n\thttpResp, err := client.DataLakePipelinesApi.\n\t\tDeletePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineApiParams{}\n\thttpResp, err := client.DataLakePipelinesApi.\n\t\tDeletePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58598,7 +58598,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tGetPipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tGetPipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58692,7 +58692,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tUpdatePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tUpdatePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58777,7 +58777,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSchedulesApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineSchedulesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSchedulesApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineSchedulesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58878,7 +58878,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSnapshotsApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineSnapshotsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSnapshotsApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineSnapshotsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -58960,7 +58960,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PausePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tPausePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PausePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tPausePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59042,7 +59042,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResumePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tResumePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResumePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tResumePipelineWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59143,7 +59143,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineRunsApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineRunsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineRunsApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineRunsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59238,7 +59238,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineRunDatasetApiParams{}\n\thttpResp, err := client.DataLakePipelinesApi.\n\t\tDeletePipelineRunDatasetWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineRunDatasetApiParams{}\n\thttpResp, err := client.DataLakePipelinesApi.\n\t\tDeletePipelineRunDatasetWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59331,7 +59331,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineRunApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tGetPipelineRunWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineRunApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tGetPipelineRunWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59424,7 +59424,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TriggerSnapshotIngestionApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tTriggerSnapshotIngestionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TriggerSnapshotIngestionApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tTriggerSnapshotIngestionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59506,7 +59506,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59576,7 +59576,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59655,7 +59655,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tToggleRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tToggleRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59736,7 +59736,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tListServerlessPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tListServerlessPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59827,7 +59827,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tCreateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tCreateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -59917,7 +59917,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessPrivateEndpointApiParams{}\n\thttpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tDeleteServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessPrivateEndpointApiParams{}\n\thttpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tDeleteServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60005,7 +60005,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tGetServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tGetServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60104,7 +60104,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tUpdateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tUpdateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60189,7 +60189,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPrivateEndpointServicesApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tListPrivateEndpointServicesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPrivateEndpointServicesApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tListPrivateEndpointServicesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60283,7 +60283,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointServiceApiParams{}\n\thttpResp, err := client.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointServiceApiParams{}\n\thttpResp, err := client.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60378,7 +60378,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60492,7 +60492,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60596,7 +60596,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointApiParams{}\n\thttpResp, err := client.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointApiParams{}\n\thttpResp, err := client.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60701,7 +60701,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60773,7 +60773,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyConnectViaPeeringOnlyModeForOneProjectApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tVerifyConnectViaPeeringOnlyModeForOneProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyConnectViaPeeringOnlyModeForOneProjectApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tVerifyConnectViaPeeringOnlyModeForOneProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60857,7 +60857,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisablePeeringApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tDisablePeeringWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisablePeeringApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tDisablePeeringWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -60939,7 +60939,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDataFederationPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tListDataFederationPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDataFederationPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tListDataFederationPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61018,7 +61018,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61100,7 +61100,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDataFederationPrivateEndpointApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDataFederationPrivateEndpointApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61183,7 +61183,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tGetDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tGetDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61259,7 +61259,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasProcessesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListAtlasProcessesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasProcessesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListAtlasProcessesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61337,7 +61337,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasProcessApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetAtlasProcessWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasProcessApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetAtlasProcessWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61413,7 +61413,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespacesForHostApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespacesForHostWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespacesForHostApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespacesForHostWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61500,7 +61500,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabasesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDatabasesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabasesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDatabasesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61587,7 +61587,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDatabaseWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61713,7 +61713,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDatabaseMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDatabaseMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61800,7 +61800,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskPartitionsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDiskPartitionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskPartitionsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDiskPartitionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -61884,7 +61884,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62019,7 +62019,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62261,7 +62261,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetHostMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetHostMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62357,7 +62357,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueryNamespacesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSlowQueryNamespacesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueryNamespacesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSlowQueryNamespacesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62477,7 +62477,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueriesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSlowQueriesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueriesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSlowQueriesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62613,7 +62613,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSuggestedIndexesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSuggestedIndexesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSuggestedIndexesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSuggestedIndexesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62740,7 +62740,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespaceHostMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespaceHostMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespaceHostMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespaceHostMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62813,7 +62813,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePushBasedLogConfigurationApiParams{}\n\thttpResp, err := client.Push - BasedLogExportApi.\n\t\tDeletePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePushBasedLogConfigurationApiParams{}\n\thttpResp, err := client.Push - BasedLogExportApi.\n\t\tDeletePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62884,7 +62884,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tGetPushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tGetPushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -62967,7 +62967,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tUpdatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tUpdatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63050,7 +63050,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tCreatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tCreatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63132,7 +63132,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.LoadSampleDatasetApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tLoadSampleDatasetWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.LoadSampleDatasetApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tLoadSampleDatasetWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63208,7 +63208,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSampleDatasetLoadStatusApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetSampleDatasetLoadStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSampleDatasetLoadStatusApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetSampleDatasetLoadStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63284,7 +63284,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessInstancesApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tListServerlessInstancesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessInstancesApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tListServerlessInstancesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63366,7 +63366,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tCreateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tCreateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63457,7 +63457,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListServerlessBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListServerlessBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63554,7 +63554,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63648,7 +63648,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63739,7 +63739,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListServerlessBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListServerlessBackupsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63831,7 +63831,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetServerlessBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetServerlessBackupWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63910,7 +63910,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tGetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tGetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -63993,7 +63993,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tSetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tSetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64078,7 +64078,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessInstanceApiParams{}\n\thttpResp, err := client.ServerlessInstancesApi.\n\t\tDeleteServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessInstanceApiParams{}\n\thttpResp, err := client.ServerlessInstancesApi.\n\t\tDeleteServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64161,7 +64161,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tGetServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tGetServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64252,7 +64252,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tUpdateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tUpdateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64328,7 +64328,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectServiceAccountsApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tListProjectServiceAccountsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectServiceAccountsApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tListProjectServiceAccountsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64408,7 +64408,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tCreateProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tCreateProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64488,7 +64488,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectServiceAccountApiParams{}\n\thttpResp, err := client.GroupsApi.\n\t\tDeleteProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectServiceAccountApiParams{}\n\thttpResp, err := client.GroupsApi.\n\t\tDeleteProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64565,7 +64565,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tGetProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tGetProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64656,7 +64656,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tUpdateProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tUpdateProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64749,7 +64749,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tAddProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tAddProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64822,7 +64822,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64904,7 +64904,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -64977,7 +64977,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamInstancesApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tListStreamInstancesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamInstancesApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tListStreamInstancesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65056,7 +65056,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tCreateStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tCreateStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65138,7 +65138,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamInstanceApiParams{}\n\thttpResp, err := client.StreamsApi.\n\t\tDeleteStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamInstanceApiParams{}\n\thttpResp, err := client.StreamsApi.\n\t\tDeleteStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65223,7 +65223,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tGetStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tGetStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65317,7 +65317,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tUpdateStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tUpdateStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65426,7 +65426,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadStreamTenantAuditLogsApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tDownloadStreamTenantAuditLogsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadStreamTenantAuditLogsApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tDownloadStreamTenantAuditLogsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65511,7 +65511,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamConnectionsApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tListStreamConnectionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamConnectionsApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tListStreamConnectionsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65602,7 +65602,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tCreateStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tCreateStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65693,7 +65693,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamConnectionApiParams{}\n\thttpResp, err := client.StreamsApi.\n\t\tDeleteStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamConnectionApiParams{}\n\thttpResp, err := client.StreamsApi.\n\t\tDeleteStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65776,7 +65776,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tGetStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tGetStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65879,7 +65879,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tUpdateStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tUpdateStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -65972,7 +65972,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamProcessorApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tCreateStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamProcessorApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tCreateStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66060,7 +66060,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamProcessorApiParams{}\n\thttpResp, err := client.StreamsApi.\n\t\tDeleteStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamProcessorApiParams{}\n\thttpResp, err := client.StreamsApi.\n\t\tDeleteStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66149,7 +66149,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamProcessorApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tGetStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamProcessorApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tGetStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66240,7 +66240,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.StartStreamProcessorApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tStartStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.StartStreamProcessorApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tStartStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66331,7 +66331,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.StopStreamProcessorApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tStopStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.StopStreamProcessorApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tStopStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66422,7 +66422,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamProcessorsApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tListStreamProcessorsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamProcessorsApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tListStreamProcessorsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66507,7 +66507,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectTeamsApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListProjectTeamsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectTeamsApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListProjectTeamsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66599,7 +66599,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddAllTeamsToProjectApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tAddAllTeamsToProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddAllTeamsToProjectApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tAddAllTeamsToProjectWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66685,7 +66685,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectTeamApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tRemoveProjectTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectTeamApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tRemoveProjectTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66786,7 +66786,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateTeamRolesApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tUpdateTeamRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateTeamRolesApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tUpdateTeamRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66853,7 +66853,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66932,7 +66932,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SaveLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tSaveLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SaveLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tSaveLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -66996,7 +66996,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableCustomerManagedX509ApiParams{}\n\thttpResp, err := client.X509AuthenticationApi.\n\t\tDisableCustomerManagedX509WithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableCustomerManagedX509ApiParams{}\n\thttpResp, err := client.X509AuthenticationApi.\n\t\tDisableCustomerManagedX509WithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67063,7 +67063,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLDAPConfigurationApiParams{}\n\thttpResp, err := client.LDAPConfigurationApi.\n\t\tDeleteLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLDAPConfigurationApiParams{}\n\thttpResp, err := client.LDAPConfigurationApi.\n\t\tDeleteLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67144,7 +67144,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tVerifyLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tVerifyLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67223,7 +67223,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationStatusApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationStatusApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationStatusWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67317,7 +67317,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectUsersApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectUsersApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67399,7 +67399,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectUserApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tRemoveProjectUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectUserApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tRemoveProjectUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67495,7 +67495,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectRolesApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectRolesApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67571,7 +67571,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListUSSInstancesApiParams{}\n\tsdkResp, httpResp, err := client.USSInstancesApi.\n\t\tListUSSInstancesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListUSSInstancesApiParams{}\n\tsdkResp, httpResp, err := client.USSInstancesApi.\n\t\tListUSSInstancesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67653,7 +67653,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateUSSInstanceApiParams{}\n\tsdkResp, httpResp, err := client.USSInstancesApi.\n\t\tCreateUSSInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateUSSInstanceApiParams{}\n\tsdkResp, httpResp, err := client.USSInstancesApi.\n\t\tCreateUSSInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67738,7 +67738,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteUSSInstanceApiParams{}\n\thttpResp, err := client.USSInstancesApi.\n\t\tDeleteUSSInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteUSSInstanceApiParams{}\n\thttpResp, err := client.USSInstancesApi.\n\t\tDeleteUSSInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67824,7 +67824,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUSSInstanceApiParams{}\n\tsdkResp, httpResp, err := client.USSInstancesApi.\n\t\tGetUSSInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUSSInstanceApiParams{}\n\tsdkResp, httpResp, err := client.USSInstancesApi.\n\t\tGetUSSInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67915,7 +67915,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateUSSInstanceApiParams{}\n\tsdkResp, httpResp, err := client.USSInstancesApi.\n\t\tUpdateUSSInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateUSSInstanceApiParams{}\n\tsdkResp, httpResp, err := client.USSInstancesApi.\n\t\tUpdateUSSInstanceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -67990,7 +67990,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.MigrateProjectToAnotherOrgApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tMigrateProjectToAnotherOrgWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.MigrateProjectToAnotherOrgApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tMigrateProjectToAnotherOrgWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -68080,7 +68080,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -68165,7 +68165,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -68241,7 +68241,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -68315,7 +68315,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -68400,7 +68400,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tRenameOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tRenameOrganizationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -68480,7 +68480,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeysApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListApiKeysWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeysApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListApiKeysWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -68560,7 +68560,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -68643,7 +68643,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -68724,7 +68724,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -68819,7 +68819,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -68911,7 +68911,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeyAccessListsEntriesApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListApiKeyAccessListsEntriesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeyAccessListsEntriesApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListApiKeyAccessListsEntriesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -69017,7 +69017,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -69117,7 +69117,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyAccessListEntryApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyAccessListEntryWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyAccessListEntryApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyAccessListEntryWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -69212,7 +69212,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -69290,7 +69290,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcessApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tCreateCostExplorerQueryProcessWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcessApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tCreateCostExplorerQueryProcessWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -69381,7 +69381,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcess_1ApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tCreateCostExplorerQueryProcess_1WithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcess_1ApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tCreateCostExplorerQueryProcess_1WithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -69496,7 +69496,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationEventsApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListOrganizationEventsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationEventsApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListOrganizationEventsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -69587,7 +69587,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationEventApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tGetOrganizationEventWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationEventApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tGetOrganizationEventWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -69660,7 +69660,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetFederationSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetFederationSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -69750,7 +69750,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationProjectsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationProjectsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -69835,7 +69835,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationInvitationsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationInvitationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationInvitationsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationInvitationsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -69917,7 +69917,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -69999,7 +69999,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -70081,7 +70081,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationInvitationApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationInvitationApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -70161,7 +70161,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -70255,7 +70255,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -70413,7 +70413,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListInvoicesApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tListInvoicesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListInvoicesApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tListInvoicesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -70483,7 +70483,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPendingInvoicesApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tListPendingInvoicesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPendingInvoicesApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tListPendingInvoicesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -70571,7 +70571,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetInvoiceApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tGetInvoiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetInvoiceApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tGetInvoiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -70652,7 +70652,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadInvoiceCSVApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tDownloadInvoiceCSVWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadInvoiceCSVApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tDownloadInvoiceCSVWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -70748,7 +70748,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.QueryLineItemsFromSingleInvoiceApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tQueryLineItemsFromSingleInvoiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.QueryLineItemsFromSingleInvoiceApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tQueryLineItemsFromSingleInvoiceWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -70821,7 +70821,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSourceProjectsApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tListSourceProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSourceProjectsApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tListSourceProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -70888,7 +70888,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLinkTokenApiParams{}\n\thttpResp, err := client.CloudMigrationServiceApi.\n\t\tDeleteLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLinkTokenApiParams{}\n\thttpResp, err := client.CloudMigrationServiceApi.\n\t\tDeleteLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -70967,7 +70967,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLinkTokenApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCreateLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLinkTokenApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCreateLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -71043,7 +71043,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServiceAccountsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListServiceAccountsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServiceAccountsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListServiceAccountsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -71122,7 +71122,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -71198,7 +71198,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServiceAccountApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServiceAccountApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -71275,7 +71275,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -71366,7 +71366,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -71451,7 +71451,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServiceAccountProjectsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListServiceAccountProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServiceAccountProjectsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListServiceAccountProjectsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -71541,7 +71541,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServiceAccountSecretApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateServiceAccountSecretWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServiceAccountSecretApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateServiceAccountSecretWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -71626,7 +71626,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServiceAccountSecretApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteServiceAccountSecretWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServiceAccountSecretApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteServiceAccountSecretWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -71699,7 +71699,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -71781,7 +71781,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -71867,7 +71867,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationTeamsApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListOrganizationTeamsWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationTeamsApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListOrganizationTeamsWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -71956,7 +71956,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateTeamApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tCreateTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateTeamApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tCreateTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -72042,7 +72042,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByNameApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tGetTeamByNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByNameApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tGetTeamByNameWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -72131,7 +72131,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteTeamApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tDeleteTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteTeamApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tDeleteTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -72218,7 +72218,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByIdApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tGetTeamByIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByIdApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tGetTeamByIdWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -72319,7 +72319,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameTeamApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tRenameTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameTeamApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tRenameTeamWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -72417,7 +72417,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListTeamUsersApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListTeamUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListTeamUsersApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListTeamUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -72521,7 +72521,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddTeamUserApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tAddTeamUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddTeamUserApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tAddTeamUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -72619,7 +72619,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveTeamUserApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tRemoveTeamUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveTeamUserApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tRemoveTeamUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -72701,7 +72701,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationUsersApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationUsersApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationUsersWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -72786,7 +72786,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveOrganizationUserApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tRemoveOrganizationUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveOrganizationUserApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tRemoveOrganizationUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -72882,7 +72882,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationRolesApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationRolesApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationRolesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -72935,7 +72935,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnAllControlPlaneIPAddressesApiParams{}\n\tsdkResp, httpResp, err := client.RootApi.\n\t\tReturnAllControlPlaneIPAddressesWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnAllControlPlaneIPAddressesApiParams{}\n\tsdkResp, httpResp, err := client.RootApi.\n\t\tReturnAllControlPlaneIPAddressesWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -73013,7 +73013,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateUserApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tCreateUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateUserApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tCreateUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -73090,7 +73090,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserByUsernameApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tGetUserByUsernameWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserByUsernameApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tGetUserByUsernameWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",
@@ -73169,7 +73169,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tGetUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tGetUserWithParams(ctx, params).\n\t\tExecute()\n}\n"
           },
           {
             "lang": "cURL",

--- a/tools/cli/test/data/split/dev/openapi-v2-2025-01-01.yaml
+++ b/tools/cli/test/data/split/dev/openapi-v2-2025-01-01.yaml
@@ -30575,9 +30575,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30647,9 +30645,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30720,9 +30716,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30793,9 +30787,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30864,9 +30856,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -30940,9 +30930,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31024,9 +31012,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31107,9 +31093,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31197,9 +31181,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31276,9 +31258,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31357,9 +31337,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31444,9 +31422,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31528,9 +31504,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31619,9 +31593,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31721,9 +31693,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31806,9 +31776,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31889,9 +31857,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -31971,9 +31937,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32061,9 +32025,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32144,9 +32106,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32218,9 +32178,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32293,9 +32251,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32385,9 +32341,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32462,9 +32416,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32534,9 +32486,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32617,9 +32567,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32704,9 +32652,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32785,9 +32731,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32874,9 +32818,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -32967,9 +32909,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33052,9 +32992,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33137,9 +33075,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33214,9 +33150,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33296,9 +33230,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33384,9 +33316,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33469,9 +33399,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33563,9 +33491,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33663,9 +33589,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33756,9 +33680,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33844,9 +33766,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -33929,9 +33849,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34022,9 +33940,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34114,9 +34030,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34191,9 +34105,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34268,9 +34180,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34357,9 +34267,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34448,9 +34356,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34540,9 +34446,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34615,9 +34519,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34694,9 +34596,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34769,9 +34669,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34846,9 +34744,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -34924,9 +34820,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35044,9 +34938,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35132,9 +35024,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35236,9 +35126,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35309,9 +35197,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35397,9 +35283,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35472,9 +35356,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35552,9 +35434,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35644,9 +35524,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35724,9 +35602,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35817,9 +35693,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -35901,9 +35775,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36114,9 +35986,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36207,9 +36077,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36290,9 +36158,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36383,9 +36249,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36521,9 +36385,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36613,9 +36475,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36696,9 +36556,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36787,9 +36645,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36876,9 +36732,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -36959,9 +36813,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37054,9 +36906,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37149,9 +36999,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37237,9 +37085,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37318,9 +37164,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37397,9 +37241,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37488,9 +37330,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37577,9 +37417,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37668,9 +37506,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37763,9 +37599,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37853,9 +37687,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -37950,9 +37782,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38043,9 +37873,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38133,9 +37961,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38215,9 +38041,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38310,9 +38134,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38407,9 +38229,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38493,9 +38313,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38584,9 +38402,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38666,9 +38482,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38757,9 +38571,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38841,9 +38653,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -38935,9 +38745,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39018,9 +38826,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39114,9 +38920,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39214,9 +39018,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39308,9 +39110,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39407,9 +39207,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39510,9 +39308,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39606,9 +39402,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39699,9 +39493,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39803,9 +39595,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39891,9 +39681,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -39974,9 +39762,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40066,9 +39852,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40165,9 +39949,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40259,9 +40041,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40418,9 +40198,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40508,9 +40286,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40603,9 +40379,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40701,9 +40475,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40796,9 +40568,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -40900,9 +40670,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41014,9 +40782,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41101,9 +40867,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41187,9 +40951,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41278,9 +41040,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41367,9 +41127,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41461,9 +41219,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41543,9 +41299,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41644,9 +41398,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41733,9 +41485,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41832,9 +41582,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41916,9 +41664,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -41997,9 +41743,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42087,9 +41831,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42181,9 +41923,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42278,9 +42018,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42371,9 +42109,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42480,9 +42216,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42583,9 +42317,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42685,9 +42417,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42796,9 +42526,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42894,9 +42622,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -42993,9 +42719,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43095,9 +42819,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43183,9 +42905,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43273,9 +42993,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43371,9 +43089,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43463,9 +43179,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43552,9 +43266,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43648,9 +43360,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43732,9 +43442,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43825,9 +43533,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -43917,9 +43623,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44036,9 +43740,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44122,9 +43824,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44208,9 +43908,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44298,9 +43996,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44376,9 +44072,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44463,9 +44157,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44548,9 +44240,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44639,9 +44329,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44719,9 +44407,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44814,9 +44500,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44892,9 +44576,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -44965,9 +44647,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45050,9 +44730,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45135,9 +44813,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45213,9 +44889,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45304,9 +44978,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45390,9 +45062,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45473,9 +45143,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45554,9 +45222,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45633,9 +45299,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45724,9 +45388,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45809,9 +45471,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45904,9 +45564,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -45999,9 +45657,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46104,9 +45760,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46209,9 +45863,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46283,9 +45935,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46459,9 +46109,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46564,9 +46212,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46662,9 +46308,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46773,9 +46417,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46859,9 +46501,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -46959,9 +46599,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47080,9 +46718,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47194,9 +46830,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47268,9 +46902,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47363,9 +46995,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47446,9 +47076,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47531,9 +47159,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47630,9 +47256,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47717,9 +47341,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47845,9 +47467,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -47936,9 +47556,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48009,9 +47627,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48112,9 +47728,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48214,9 +47828,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48315,9 +47927,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48393,9 +48003,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48486,9 +48094,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48578,9 +48184,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48682,9 +48286,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48788,9 +48390,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48872,9 +48472,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -48955,9 +48553,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49038,9 +48634,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49123,9 +48717,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49206,9 +48798,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49297,9 +48887,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49375,9 +48963,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49454,9 +49040,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49565,9 +49149,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49677,9 +49259,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49799,9 +49379,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49895,9 +49473,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -49975,9 +49551,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50051,9 +49625,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50140,9 +49712,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50230,9 +49800,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50300,9 +49868,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50370,9 +49936,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50448,9 +50012,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50522,9 +50084,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50596,9 +50156,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50671,9 +50229,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50742,9 +50298,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50813,9 +50367,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -50929,9 +50481,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51015,9 +50565,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51101,9 +50649,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51187,9 +50733,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51268,9 +50812,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51360,9 +50902,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51438,9 +50978,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51518,9 +51056,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51603,9 +51139,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51684,9 +51218,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51775,9 +51307,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51863,9 +51393,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -51955,9 +51483,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52037,9 +51563,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52123,9 +51647,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52219,9 +51741,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52311,9 +51831,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52402,9 +51920,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52491,9 +52007,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52579,9 +52093,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52670,9 +52182,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52762,9 +52272,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52866,9 +52374,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -52968,9 +52474,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53067,9 +52571,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53148,9 +52650,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53225,9 +52725,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53304,9 +52802,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53390,9 +52886,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53482,9 +52976,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53575,9 +53067,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53663,9 +53153,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53758,9 +53246,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53837,9 +53323,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -53920,9 +53404,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54002,9 +53484,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54100,9 +53580,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54186,9 +53664,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54269,9 +53745,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54343,9 +53817,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54422,9 +53894,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54536,9 +54006,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54610,9 +54078,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54692,9 +54158,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54777,9 +54241,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54888,9 +54350,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -54970,9 +54430,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55054,9 +54512,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55181,9 +54637,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55419,9 +54873,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55518,9 +54970,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55634,9 +55084,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55757,9 +55205,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55832,9 +55278,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55906,9 +55350,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -55988,9 +55430,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56074,9 +55514,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56161,9 +55599,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56244,9 +55680,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56318,9 +55752,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56399,9 +55831,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56488,9 +55918,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56580,9 +56008,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56675,9 +56101,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56760,9 +56184,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56851,9 +56273,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -56931,9 +56351,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57015,9 +56433,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57103,9 +56519,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57186,9 +56600,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57274,9 +56686,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57353,9 +56763,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57433,9 +56841,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57517,9 +56923,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57595,9 +56999,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57682,9 +57084,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57775,9 +57175,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57854,9 +57252,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -57935,9 +57331,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58012,9 +57406,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58091,9 +57483,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58176,9 +57566,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58260,9 +57648,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58349,9 +57735,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58455,9 +57839,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58536,9 +57918,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58623,9 +58003,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58714,9 +58092,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58797,9 +58173,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58892,9 +58266,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -58984,9 +58356,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59073,9 +58443,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59159,9 +58527,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59246,9 +58612,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59337,9 +58701,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59425,9 +58787,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59505,9 +58865,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59593,9 +58951,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59683,9 +59039,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59778,9 +59132,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59853,9 +59205,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -59935,9 +59285,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60012,9 +59360,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60083,9 +59429,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60163,9 +59507,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60247,9 +59589,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60333,9 +59673,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60415,9 +59753,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60506,9 +59842,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60584,9 +59918,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60665,9 +59997,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60753,9 +60083,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60838,9 +60166,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -60926,9 +60252,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -61007,9 +60331,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -61095,9 +60417,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -61179,9 +60499,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -61263,9 +60581,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -61350,9 +60666,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -61426,9 +60740,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -61509,9 +60821,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -61590,9 +60900,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -61670,9 +60978,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -61757,9 +61063,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -61839,9 +61143,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -61930,9 +61232,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -62020,9 +61320,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -62115,9 +61413,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -62214,9 +61510,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -62306,9 +61600,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -62385,9 +61677,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -62478,9 +61768,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -62584,9 +61872,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -62675,9 +61961,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -62750,9 +62034,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -62841,9 +62123,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -62924,9 +62204,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -63005,9 +62283,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -63090,9 +62366,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -63175,9 +62449,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -63257,9 +62529,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -63347,9 +62617,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -63486,9 +62754,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -63574,9 +62840,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -63663,9 +62927,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -63753,9 +63015,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -63826,9 +63086,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -63901,9 +63159,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -63973,9 +63229,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -64052,9 +63306,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -64131,9 +63383,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -64210,9 +63460,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -64291,9 +63539,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -64369,9 +63615,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -64456,9 +63700,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -64541,9 +63783,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -64627,9 +63867,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -64714,9 +63952,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -64789,9 +64025,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -64870,9 +64104,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -64955,9 +64187,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -65041,9 +64271,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -65132,9 +64360,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -65218,9 +64444,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -65313,9 +64537,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -65408,9 +64630,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -65505,9 +64725,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -65603,9 +64821,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -65687,9 +64903,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -65765,9 +64979,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -65850,9 +65062,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -65941,9 +65151,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -66010,9 +65218,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -66094,9 +65300,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -66179,9 +65383,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)
@@ -66258,9 +65460,7 @@ paths:
                     	clientSecret := os.Getenv("MONGODB_ATLAS_CLIENT_SECRET")
 
                     	// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth
-                    	client, err := sdk.NewClient(
-                    		sdk.UseOAuthAuth(clientID, clientSecret),
-                    		sdk.UseBaseURL(url))
+                    	client, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))
 
                     	if err != nil {
                     		log.Fatalf("Error: %v", err)


### PR DESCRIPTION
## Proposed changes
This PR updates the go sdk code sample to remove the `UseBaseURL` since it should be used only for cloud-dev