### PR TITLE
CLOUDP-327328: Replace dependabot reviewers with codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,4 @@
 # Maintained by the APIx team
-*       @mongodb/apix
+*                         @mongodb/apix
+/tools/cli/               @mongodb/apix-2
+/tools/spectral/ipa/      @mongodb/apix1

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,6 @@ updates:
     open-pull-requests-limit: 20
     commit-message:
       prefix: "chore"
-    reviewers:
-      - "mongodb/apix-2"
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
@@ -17,8 +15,6 @@ updates:
       day: tuesday
     commit-message:
       prefix: "chore"
-    reviewers:
-      - "mongodb/apix-2"
   - package-ecosystem: npm
     directory: "/"
     schedule:
@@ -26,5 +22,3 @@ updates:
       day: tuesday
     commit-message:
       prefix: "chore"
-    reviewers:
-      - "mongodb/APIx"


### PR DESCRIPTION
## Proposed changes

The reviewers option for dependabot is retired and replaced with codeowners, see [blog post announcement](https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/)

_Jira ticket:_ [CLOUDP-327328](https://jira.mongodb.org/browse/CLOUDP-327328)
