### PR TITLE
CLOUDP-327333: Update package.json and Postman ownership to APIx 1

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,3 +2,5 @@
 *                         @mongodb/apix
 /tools/cli/               @mongodb/apix-2
 /tools/spectral/ipa/      @mongodb/apix1
+/tools/postman/           @mongodb/apix1
+package.json              @mongodb/apix1


### PR DESCRIPTION
## Proposed changes
Adding more granular ownership to the codeowners file to separate ownership between APIx 1 and APIx 2

_Jira ticket:_ [CLOUDP-327333](https://jira.mongodb.org/browse/CLOUDP-327333)