### PR TITLE
ci: deploy bump.sh spec only when there are relevant spec changes

### DIFF
--- a/.github/workflows/release-spec.yml
+++ b/.github/workflows/release-spec.yml
@@ -106,6 +106,7 @@ jobs:
       needs: [run-required-validations]
       outputs:
         changes_detected: ${{ steps.commit.outputs.changes_detected }}
+        bump_release: ${{ steps.bump_changes.outputs.bump_release }}
       steps:
         - name: Checkout repository
           uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -156,6 +157,22 @@ jobs:
           env:
               target_env: ${{ inputs.env }}
           run: ../release-scripts/branded_preview.sh
+        - name: Check if changes should be deployed to bump.sh
+          id: bump_changes
+          run: |
+            # We often only update the x-xgen-sha property in OAS since we need
+            # this piece of information during the changelog release. However, this small changes
+            # should not trigger a bump.sh release since the rendered spec is still the same.
+            # This logic makes sure that the v2.json file changes are more than 1 lines
+            # which suggests that we are not only updating the x-xgen-sha property.
+            
+            export bump_release='false'
+            changed_lines=$(git diff --numstat openapi/v2.json | awk '{print $1}')
+            if [ "${changed_lines}" -gt 1 ]; then
+              export bump_release='true'
+            fi
+            
+            echo "bump_release=${bump_release}" >> "${GITHUB_OUTPUT:?}"
         - name: Commit changes
           id: commit
           uses: stefanzweifel/git-auto-commit-action@778341af668090896ca464160c2def5d1d1a3eb0
@@ -197,7 +214,7 @@ jobs:
   release-bump-sh:
     name: Release API Specification to Bump.sh for ${{ inputs.branch }}
     needs: release
-    if: ${{needs.release.outputs.changes_detected == 'true'}}
+    if: ${{needs.release.outputs.bump_release == 'true'}}
     uses: ./.github/workflows/generate-bump-pages.yml
     secrets:
       api_bot_pat: ${{ secrets.api_bot_pat }}


### PR DESCRIPTION
This pull request updates the `.github/workflows/release-spec.yml` file to improve the logic for determining when API specification changes should trigger a release to Bump.sh. The changes introduce a new check to ensure that only significant modifications to the `v2.json` file (beyond minor metadata updates) result in a release.

### Workflow Enhancements:

* Added a new step, `Check if changes should be deployed to bump.sh`, to analyze the number of changed lines in the `openapi/v2.json` file. This ensures that minor updates, such as metadata changes, do not trigger a release. (`[.github/workflows/release-spec.ymlR160-R175](diffhunk://#diff-aea44faec3c0b85ba535263f9b540a317c4ab32d8a8c221871a5b231fc4468b1R160-R175)`)
* Updated the `outputs` section to include a new `bump_release` output, which reflects whether significant changes were detected. (`[.github/workflows/release-spec.ymlR109](diffhunk://#diff-aea44faec3c0b85ba535263f9b540a317c4ab32d8a8c221871a5b231fc4468b1R109)`)
* Modified the `if` condition for the `release-bump-sh` job to rely on the new `bump_release` output instead of `changes_detected`. (`[.github/workflows/release-spec.ymlL200-R217](diffhunk://#diff-aea44faec3c0b85ba535263f9b540a317c4ab32d8a8c221871a5b231fc4468b1L200-R217)`)## Proposed changes
