### PR TITLE
fix: ping brace-expansion to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
         "husky": "^9.1.7",
         "jest": "^30.0.3",
         "lint-staged": "^16.1.2",
-        "prettier": "3.6.2"
+        "prettier": "3.6.2",
+        "brace-expansion": "4.0.1"
     },
     "engineStrict": false,
     "engines": {


### PR DESCRIPTION
## Proposed changes

Fix : https://github.com/mongodb/openapi/security/dependabot/6


> A vulnerability was found in juliangruber brace-expansion up to 1.1.11/2.0.1/3.0.0/4.0.0. It has been rated as problematic. Affected by this issue is the function expand of the file index.js. The manipulation leads to inefficient regular expression complexity. The attack may be launched remotely. The complexity of an attack is rather high. The exploitation is known to be difficult. The exploit has been disclosed to the public and may be used. Upgrading to version 1.1.12, 2.0.2, 3.0.1 and 4.0.1 is able to address this issue. The name of the patch is a5b98a4f30d7813266b221435e1eaaf25a1b0ac5. It is recommended to upgrade the affected component.