### PR TITLE
CLOUDP-293819: Update the GH action to send sunset reminder for endpoints approaching sunset in 1 month and 1 week

### DIFF
--- a/.github/scripts/get_sunset_apis.sh
+++ b/.github/scripts/get_sunset_apis.sh
@@ -27,6 +27,13 @@
 #   - Non-zero if any commands fail (due to set -e)
 set -eou pipefail
 
+if [ $# -lt 2 ]; then
+  echo "Error: Missing required arguments"
+  echo "Usage: ./get_sunset_apis.sh <openapi_spec_url> <to_date>"
+  echo "Example: ./get_sunset_apis.sh openapi/openapi/v2.json 2025-09-22"
+  exit 1
+fi
+
 openapi_spec_url="$1"
 to_date="$2"
 from_date=$(date +"%y-%m-%d")

--- a/.github/scripts/get_sunset_apis.sh
+++ b/.github/scripts/get_sunset_apis.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#!/usr/bin/env bash
+# get_sunset_apis.sh - Identifies API versions scheduled for sunset
+#
+# This script queries an OpenAPI specification to find API versions that will be
+# sunset within a specified date range. When sunset APIs are found,
+# it generates a hash code from the results to help with deduplication in
+# downstream processes (like JIRA ticket creation) and saves the list to a file.
+#
+# Usage:
+#   ./get_sunset_apis.sh <openapi_spec_url> <to_date>
+#
+# Parameters:
+#   openapi_spec_url - URL of the OpenAPI specification to analyze
+#   to_date - End date for the sunset check (format: YY-MM-DD)
+#
+# Outputs:
+#   - Prints information about sunset APIs to stdout
+#   - Writes hash_code_sunset_apis to GitHub Actions output if sunset APIs are found
+#   - Creates sunset_apis.json containing the list of sunset APIs if any are found
+#
+# Dependencies:
+#   - foascli - CLI tool for querying sunset information from OpenAPI specs
+#   - jq - JSON processor for hash code generation
+#
+# Exit Status:
+#   - 0 if the script completes successfully, regardless if sunset APIs are found
+#   - Non-zero if any commands fail (due to set -e)
+set -eou pipefail
+
+openapi_spec_url="$1"
+to_date="$2"
+from_date=$(date +"%y-%m-%d")
+
+echo "openapi_spec_url: ${openapi_spec_url}"
+echo "from_date: ${from_date}, to_date: ${to_date}"
+
+sunset_apis=$(foascli sunset ls -s "${openapi_spec_url}" --from "${from_date}" --to "${to_date}")
+if [[ "${sunset_apis}" != "null" ]]; then
+  echo "api versions that will be sunsets between '${from_date}' - '${to_date}' are: ${sunset_apis}"
+
+  # we calculate the md5sum of the json object which will be included in the jira ticket title.
+  # this approach ensures we create a new jira ticket only if the there is not already a ticket
+  # with the same title
+  hash_code_sunset_apis=$(echo "${sunset_apis}" | jq -cs . | md5sum | awk '{print $1}')
+  echo "hash: ${hash_code_sunset_apis}"
+  echo hash_code_sunset_apis="${hash_code_sunset_apis}" >> "${GITHUB_OUTPUT:?}"
+  echo "${sunset_apis}" > sunset_apis.json
+
+else
+  echo "no api versions will be sunset within the next 3 months."
+fi

--- a/.github/scripts/get_sunset_apis.sh
+++ b/.github/scripts/get_sunset_apis.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-#!/usr/bin/env bash
 # get_sunset_apis.sh - Identifies API versions scheduled for sunset
 #
 # This script queries an OpenAPI specification to find API versions that will be

--- a/.github/workflows/api-versions-reminder.yml
+++ b/.github/workflows/api-versions-reminder.yml
@@ -68,7 +68,7 @@ jobs:
           message_id=$(curl -X POST -H 'Authorization: Bearer '"${SLACK_BEARER_TOKEN}" \
           -H 'Content-type: application/json' \
           --data '{"channel":"'"${SLACK_CHANNEL_ID}"'","text":"The following APIs are scheduled to be sunset in the next 3 months ('"${SLACK_APIX_2_ONCALL_USER}"'). See Jira Ticket: https://jira.mongodb.org/browse/'"${JIRA_TICKET_ID}"'","parse": "full",}' https://slack.com/api/chat.postMessage | jq '.ts')
-          echo "message_id=${message_id}"]
+          echo "message_id=${message_id}"
 
   sunset-api-version-1month-reminder:
     name: Sunset APIs Reminder
@@ -132,7 +132,7 @@ jobs:
           message_id=$(curl -X POST -H 'Authorization: Bearer '"${SLACK_BEARER_TOKEN}" \
           -H 'Content-type: application/json' \
           --data '{"channel":"'"${SLACK_CHANNEL_ID}"'","text":"The following APIs are scheduled to be sunset in the next month ('"${SLACK_APIX_2_ONCALL_USER}"'). See Jira Ticket: https://jira.mongodb.org/browse/'"${JIRA_TICKET_ID}"'","parse": "full",}' https://slack.com/api/chat.postMessage | jq '.ts')
-          echo "message_id=${message_id}"]
+          echo "message_id=${message_id}"
 
   sunset-api-version-1week-reminder:
     name: Sunset APIs Reminder
@@ -196,4 +196,4 @@ jobs:
           message_id=$(curl -X POST -H 'Authorization: Bearer '"${SLACK_BEARER_TOKEN}" \
           -H 'Content-type: application/json' \
           --data '{"channel":"'"${SLACK_CHANNEL_ID}"'","text":"The following APIs are scheduled to be sunset in the next week ('"${SLACK_APIX_2_ONCALL_USER}"'). See Jira Ticket: https://jira.mongodb.org/browse/'"${JIRA_TICKET_ID}"'","parse": "full",}' https://slack.com/api/chat.postMessage | jq '.ts')
-          echo "message_id=${message_id}"]
+          echo "message_id=${message_id}"

--- a/.github/workflows/api-versions-reminder.yml
+++ b/.github/workflows/api-versions-reminder.yml
@@ -6,18 +6,16 @@ on:
     - cron: '0 9 * * 1' # at 9:00 UTC on Monday
 
 jobs:
-  sunset-api-version-reminder:
+  sunset-api-version-3months-reminder:
     name: Sunset APIs Reminder
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
-
       - name: Install Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: '3.12'
-
       - name: Install FOASCLI
         env:
           foascli_version: ${{ vars.FOASCLI_VERSION }}
@@ -27,7 +25,6 @@ jobs:
           pushd mongodb-foas-cli_*
           echo "$(pwd)/bin" >> "${GITHUB_PATH}"
           popd
-
       - name: Retrieve Sunset APIs
         id: retrieve-sunset-apis
         env:
@@ -42,29 +39,8 @@ jobs:
           else
           # Linux date command format
             three_months_date=$(date --date="3 months" +"%Y-%m-%d")
-          fi
-          
-          echo "three_months_date: ${three_months_date}"
-          
-          current_date=$(date +"%Y-%m-%d")
-          echo "current_date: ${current_date}"
-          
-          sunset_apis=$(foascli sunset ls -s "${openapi_spec_url}" --from "${current_date}" --to "${three_months_date}")
-          if [[ "${sunset_apis}" != "null" ]]; then
-            echo "API Versions that will be sunsets in the next 3 months: ${sunset_apis}"
-          
-            # We calculate the md5sum of the JSON object which will be included in the Jira ticket title. 
-            # This approach ensures we create a new jira ticket only if the there is not already a ticket 
-            # with the same title
-            hash_code_sunset_apis=$(echo "$sunset_apis" | jq -cS . | md5sum | awk '{print $1}')
-            echo "hash: ${hash_code_sunset_apis}"
-            echo hash_code_sunset_apis="${hash_code_sunset_apis}" >> "${GITHUB_OUTPUT:?}"
-            echo "${sunset_apis}" > sunset_apis.json
-          
-          else
-            echo "No API Versions will be sunset within the next 3 months."
-          fi
-
+          fi 
+          ./.github/scripts/get_list_files_to_delete.sh "${openapi_spec_url}" "${three_months_date}"
       # Create a JIRA ticket only if the there is not already a ticket with the same title
       - name: Create JIRA Ticket
         id: create-jira-ticket
@@ -92,4 +68,132 @@ jobs:
           message_id=$(curl -X POST -H 'Authorization: Bearer '"${SLACK_BEARER_TOKEN}" \
           -H 'Content-type: application/json' \
           --data '{"channel":"'"${SLACK_CHANNEL_ID}"'","text":"The following APIs are scheduled to be sunset in the next 3 months ('"${SLACK_APIX_2_ONCALL_USER}"'). See Jira Ticket: https://jira.mongodb.org/browse/'"${JIRA_TICKET_ID}"'","parse": "full",}' https://slack.com/api/chat.postMessage | jq '.ts')
+          echo "message_id=${message_id}"]
+
+  sunset-api-version-1month-reminder:
+    name: Sunset APIs Reminder
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - name: Install Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: '3.12'
+      - name: Install FOASCLI
+        env:
+          foascli_version: ${{ vars.FOASCLI_VERSION }}
+        run: |
+          wget https://github.com/mongodb/openapi/releases/download/v"${foascli_version}"/mongodb-foas-cli_"${foascli_version}"_linux_x86_64.tar.gz -O foascli.tar.gz
+          tar -xzvf foascli.tar.gz 
+          pushd mongodb-foas-cli_*
+          echo "$(pwd)/bin" >> "${GITHUB_PATH}"
+          popd
+      - name: Retrieve Sunset APIs
+        id: retrieve-sunset-apis
+        env:
+          openapi_spec_url: "https://raw.githubusercontent.com/mongodb/openapi/refs/heads/dev/openapi/.raw/v2.json"
+        run: |
+          one_month_date=""
+          
+          # Determine if the system is macOS or Linux
+          if [[ "$(uname)" == "Darwin" ]]; then
+          # macOS date command format
+            one_month_date=$(date -v+1m +"%Y-%m-%d")
+          else
+          # Linux date command format
+            one_month_date=$(date --date="1 months" +"%Y-%m-%d")
+          fi 
+          ./.github/scripts/get_list_files_to_delete.sh "${openapi_spec_url}" "${one_month_date}"
+      # Create a JIRA ticket only if the there is not already a ticket with the same title
+      - name: Create JIRA Ticket
+        id: create-jira-ticket
+        if: steps.retrieve-sunset-apis.outputs.hash_code_sunset_apis != null
+        env:
+          JIRA_API_TOKEN: ${{ secrets.jira_api_token }}
+          JIRA_TEAM_ID: ${{ vars.JIRA_TEAM_ID_APIX_2}}
+          JIRA_TICKET_TITLE: "Some APIs are approaching their sunset date in the next month. ID: ${{steps.retrieve-sunset-apis.outputs.hash_code_sunset_apis}}"
+        run: |
+          sunset_apis=$(sed 's/"/\\"/g' sunset_apis.json)
+          JIRA_TICKET_DESCRIPTION="The following APIs will be sunset in the next month. Please follow our [wiki|https://wiki.corp.mongodb.com/display/MMS/API+eXperience+Production+Checklist#APIeXperienceProductionChecklist-APISunsetActionItems]. {noformat}${sunset_apis}{noformat}"
+          export JIRA_TICKET_DESCRIPTION
+          .github/scripts/create_jira_ticket.sh
+
+      # Send Slack notification only if the Jira ticket was created
+      - name: Send Slack Notification
+        if: steps.create-jira-ticket.outputs.jira-ticket-id != null
+        env:
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+          SLACK_BEARER_TOKEN: ${{ secrets.SLACK_BEARER_TOKEN }}
+          SLACK_APIX_2_ONCALL_USER: ${{secrets.SLACK_APIX_2_ONCALL_USER}}
+          JIRA_TICKET_ID: ${{ steps.create-jira-ticket.outputs.jira-ticket-id }}
+        run: |
+          echo "JIRA_TICKET_ID: ${JIRA_TICKET_ID}"
+          message_id=$(curl -X POST -H 'Authorization: Bearer '"${SLACK_BEARER_TOKEN}" \
+          -H 'Content-type: application/json' \
+          --data '{"channel":"'"${SLACK_CHANNEL_ID}"'","text":"The following APIs are scheduled to be sunset in the next month ('"${SLACK_APIX_2_ONCALL_USER}"'). See Jira Ticket: https://jira.mongodb.org/browse/'"${JIRA_TICKET_ID}"'","parse": "full",}' https://slack.com/api/chat.postMessage | jq '.ts')
+          echo "message_id=${message_id}"]
+
+  sunset-api-version-1week-reminder:
+    name: Sunset APIs Reminder
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - name: Install Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: '3.12'
+      - name: Install FOASCLI
+        env:
+          foascli_version: ${{ vars.FOASCLI_VERSION }}
+        run: |
+          wget https://github.com/mongodb/openapi/releases/download/v"${foascli_version}"/mongodb-foas-cli_"${foascli_version}"_linux_x86_64.tar.gz -O foascli.tar.gz
+          tar -xzvf foascli.tar.gz 
+          pushd mongodb-foas-cli_*
+          echo "$(pwd)/bin" >> "${GITHUB_PATH}"
+          popd
+      - name: Retrieve Sunset APIs
+        id: retrieve-sunset-apis
+        env:
+          openapi_spec_url: "https://raw.githubusercontent.com/mongodb/openapi/refs/heads/dev/openapi/.raw/v2.json"
+        run: |
+          1_week_date=""
+          
+          # Determine if the system is macOS or Linux
+          if [[ "$(uname)" == "Darwin" ]]; then
+          # macOS date command format
+            1_week_date=$(date -v+1w +"%Y-%m-%d")
+          else
+          # Linux date command format
+            1_week_date=$(date --date="+1 week" +"%Y-%m-%d")
+          fi 
+          ./.github/scripts/get_list_files_to_delete.sh "${openapi_spec_url}" "${1_week_date}"
+      # Create a JIRA ticket only if the there is not already a ticket with the same title
+      - name: Create JIRA Ticket
+        id: create-jira-ticket
+        if: steps.retrieve-sunset-apis.outputs.hash_code_sunset_apis != null
+        env:
+          JIRA_API_TOKEN: ${{ secrets.jira_api_token }}
+          JIRA_TEAM_ID: ${{ vars.JIRA_TEAM_ID_APIX_2}}
+          JIRA_TICKET_TITLE: "Some APIs are approaching their sunset date in the next week. ID: ${{steps.retrieve-sunset-apis.outputs.hash_code_sunset_apis}}"
+        run: |
+          sunset_apis=$(sed 's/"/\\"/g' sunset_apis.json)
+          JIRA_TICKET_DESCRIPTION="The following APIs will be sunset in the next week. Please follow our [wiki|https://wiki.corp.mongodb.com/display/MMS/API+eXperience+Production+Checklist#APIeXperienceProductionChecklist-APISunsetActionItems]. {noformat}${sunset_apis}{noformat}"
+          export JIRA_TICKET_DESCRIPTION
+          .github/scripts/create_jira_ticket.sh
+
+      # Send Slack notification only if the Jira ticket was created
+      - name: Send Slack Notification
+        if: steps.create-jira-ticket.outputs.jira-ticket-id != null
+        env:
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+          SLACK_BEARER_TOKEN: ${{ secrets.SLACK_BEARER_TOKEN }}
+          SLACK_APIX_2_ONCALL_USER: ${{secrets.SLACK_APIX_2_ONCALL_USER}}
+          JIRA_TICKET_ID: ${{ steps.create-jira-ticket.outputs.jira-ticket-id }}
+        run: |
+          echo "JIRA_TICKET_ID: ${JIRA_TICKET_ID}"
+          message_id=$(curl -X POST -H 'Authorization: Bearer '"${SLACK_BEARER_TOKEN}" \
+          -H 'Content-type: application/json' \
+          --data '{"channel":"'"${SLACK_CHANNEL_ID}"'","text":"The following APIs are scheduled to be sunset in the next week ('"${SLACK_APIX_2_ONCALL_USER}"'). See Jira Ticket: https://jira.mongodb.org/browse/'"${JIRA_TICKET_ID}"'","parse": "full",}' https://slack.com/api/chat.postMessage | jq '.ts')
           echo "message_id=${message_id}"]


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-293819

<!--
What issue does this PR address? (for example, #1234), remove this section if none.
-->
This pull request introduces a new script for identifying APIs scheduled for sunset and updates the GitHub Actions workflow to automate reminders and notifications for API sunsets. The changes streamline the process of tracking and managing API deprecations by integrating JIRA ticket creation and Slack notifications for different timeframes (3 months, 1 month, and 1 week).

### New Script for API Sunset Identification:
* Added `get_sunset_apis.sh`: A Bash script that queries OpenAPI specifications to identify APIs scheduled for sunset within a specified date range. It generates a hash code for deduplication, saves the results to a file, and outputs relevant information for downstream processes.

### Updates to GitHub Actions Workflow:
#### Workflow Enhancements:
* Renamed the workflow job from `sunset-api-version-reminder` to `sunset-api-version-3months-reminder` and added two new jobs: `sunset-api-version-1month-reminder` and `sunset-api-version-1week-reminder`. Each job targets a specific timeframe for API sunset reminders. [[1]](diffhunk://#diff-748c926d38adafae763c4488f4c422262f57fd167f21072f93c47eb0b7970c7bL9-L20) [[2]](diffhunk://#diff-748c926d38adafae763c4488f4c422262f57fd167f21072f93c47eb0b7970c7bR43-R182) [[3]](diffhunk://#diff-748c926d38adafae763c4488f4c422262f57fd167f21072f93c47eb0b7970c7bL94-R198)

#### Automated Notifications:
* Integrated JIRA ticket creation for each reminder job, ensuring unique tickets are created based on the hash code of sunset APIs.
* Added Slack notifications triggered by successful JIRA ticket creation, with messages tailored to the specific timeframe (3 months, 1 month, or 1 week). [[1]](diffhunk://#diff-748c926d38adafae763c4488f4c422262f57fd167f21072f93c47eb0b7970c7bR43-R182) [[2]](diffhunk://#diff-748c926d38adafae763c4488f4c422262f57fd167f21072f93c47eb0b7970c7bL94-R198)

#### Script Integration:
* Updated the workflow to use the new `get_sunset_apis.sh` script for retrieving sunset APIs and determining the need for notifications. [[1]](diffhunk://#diff-748c926d38adafae763c4488f4c422262f57fd167f21072f93c47eb0b7970c7bR43-R182) [[2]](diffhunk://#diff-748c926d38adafae763c4488f4c422262f57fd167f21072f93c47eb0b7970c7bL94-R198)