### PR TITLE
CLOUDP-330237: Removed OperationID Validation yamls and updated docs

### DIFF
--- a/tools/spectral/ipa/rulesets/IPA-104.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-104.yaml
@@ -8,7 +8,6 @@ functions:
   - IPA104GetResponseCodeShouldBe200OK
   - IPA104GetMethodResponseHasNoInputFields
   - IPA104GetMethodHasNoRequestBody
-  - IPA104ValidOperationID
 
 aliases:
   GetOperationObject:
@@ -98,21 +97,3 @@ rules:
     given: '#GetOperationObject'
     then:
       function: 'IPA104GetMethodHasNoRequestBody'
-  xgen-IPA-104-valid-operation-id:
-    description: |
-      The Operation ID must start with the verb “get” and should be followed by a noun or compound noun.
-      The noun(s) in the Operation ID should be the collection identifiers from the resource identifier in singular form.
-      If the resource is a singleton resource, the last noun may be the plural form of the collection identifier.
-
-      ##### Implementation details
-      Rule checks for the following conditions:
-        - Applies only to GET methods on single resources or singleton resources
-        - Generates the expected OperationId given the resource identifier
-        - Confirms that the existing operationId is compliant with generated IPA Compliant OperationId
-    message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-104-valid-operation-id'
-    severity: off
-    given: '#GetOperationObject'
-    then:
-      function: 'IPA104ValidOperationID'
-      functionOptions:
-        methodName: 'get'

--- a/tools/spectral/ipa/rulesets/IPA-105.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-105.yaml
@@ -6,7 +6,6 @@ functions:
   - IPA105ListMethodHasNoRequestBody
   - IPA105EachResourceHasListMethod
   - IPA105ListMethodResponseIsGetMethodResponse
-  - IPA105ValidOperationID
 
 aliases:
   GetOperationObject:
@@ -78,21 +77,3 @@ rules:
     then:
       field: '@key'
       function: 'IPA105ListMethodResponseIsGetMethodResponse'
-  xgen-IPA-105-valid-operation-id:
-    description: |
-      The Operation ID must start with the verb “list” and should be followed by a noun or compound noun.
-      The noun(s) in the Operation ID should be the collection identifiers from the resource identifier in singular form, where the last noun is in plural form.
-
-      ##### Implementation details
-      Rule checks for the following conditions:
-        - Applies only to GET methods on resource collection paths
-        - Ignores singleton resources
-        - Generates the expected OperationId given the resource identifier
-        - Confirms that the existing operationId is compliant with generated IPA Compliant OperationId
-    message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-105-valid-operation-id'
-    severity: off
-    given: '#GetOperationObject'
-    then:
-      function: 'IPA105ValidOperationID'
-      functionOptions:
-        methodName: 'list'

--- a/tools/spectral/ipa/rulesets/IPA-106.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-106.yaml
@@ -8,7 +8,6 @@ functions:
   - IPA106CreateMethodRequestHasNoReadonlyFields
   - IPA106CreateMethodResponseCodeIs201Created
   - IPA106CreateMethodResponseIsGetMethodResponse
-  - IPA106ValidOperationID
 
 aliases:
   CreateOperationObject:
@@ -113,20 +112,3 @@ rules:
     then:
       field: '@key'
       function: 'IPA106CreateMethodResponseIsGetMethodResponse'
-  xgen-IPA-106-valid-operation-id:
-    description: |
-      The Operation ID must start with the verb “create” and should be followed by a noun or compound noun.
-      The noun(s) in the Operation ID should be the collection identifiers from the resource identifier in singular form.
-
-      ##### Implementation details
-      Rule checks for the following conditions:
-        - Applies only to POST methods on resource collection paths
-        - Generates the expected OperationId given the resource identifier
-        - Confirms that the existing operationId is compliant with generated IPA Compliant OperationId
-    message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-106-valid-operation-id'
-    severity: off
-    given: '#CreateOperationObject'
-    then:
-      function: 'IPA106ValidOperationID'
-      functionOptions:
-        methodName: 'create'

--- a/tools/spectral/ipa/rulesets/IPA-107.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-107.yaml
@@ -8,7 +8,6 @@ functions:
   - IPA107UpdateMethodRequestHasNoReadonlyFields
   - IPA107UpdateMethodRequestBodyIsGetResponse
   - IPA107UpdateMethodRequestBodyIsUpdateRequestSuffixedObject
-  - IPA107ValidOperationID
 
 aliases:
   UpdateOperationObject:
@@ -113,21 +112,3 @@ rules:
     then:
       field: '@key'
       function: 'IPA107UpdateMethodRequestBodyIsUpdateRequestSuffixedObject'
-  xgen-IPA-107-valid-operation-id:
-    description: |
-      The Operation ID must start with the verb “update” and should be followed by a noun or compound noun.
-      The noun(s) in the Operation ID should be the collection identifiers from the resource identifier in singular form.
-      If the resource is a singleton resource, the last noun may be the plural form of the collection identifier.
-
-      ##### Implementation details
-      Rule checks for the following conditions:
-        - Validation checks the PATCH/PUT methods for single resource paths and [singleton resources](https://go/ipa/113).
-        - Generates the expected OperationId given the resource identifier
-        - Confirms that the existing operationId is compliant with generated IPA Compliant OperationId
-    message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-107-valid-operation-id'
-    severity: off
-    given: '#UpdateOperationObject'
-    then:
-      function: 'IPA107ValidOperationID'
-      functionOptions:
-        methodName: 'update'

--- a/tools/spectral/ipa/rulesets/IPA-108.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-108.yaml
@@ -55,26 +55,8 @@ rules:
     given: '#DeleteOperationObject'
     then:
       function: IPA108DeleteMethodNoRequestBody
-  xgen-IPA-108-valid-operation-id:
-    description: |
-      The Operation ID must start with the verb “delete” and should be followed by a noun or compound noun.
-      The noun(s) in the Operation ID should be the collection identifiers from the resource identifier in singular form.
-
-      ##### Implementation details
-      Rule checks for the following conditions:
-        - Applies to all DELETE methods for single resource endpoints (with path parameters)
-        - Generates the expected OperationId given the resource identifier
-        - Confirms that the existing operationId is compliant with generated IPA Compliant OperationId
-    message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-108-valid-operation-id'
-    severity: off
-    given: '#DeleteOperationObject'
-    then:
-      function: 'IPA108ValidOperationID'
-      functionOptions:
-        methodName: 'delete'
 
 functions:
   - IPA108DeleteMethodResponseShouldNotHaveSchema
   - IPA108DeleteMethod204Response
   - IPA108DeleteMethodNoRequestBody
-  - IPA108ValidOperationID

--- a/tools/spectral/ipa/rulesets/IPA-109.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-109.yaml
@@ -57,22 +57,3 @@ rules:
     given: '$.paths[*]'
     then:
       function: 'IPA109CustomMethodIdentifierFormat'
-  xgen-IPA-109-valid-operation-id:
-    description: |
-      The Operation ID must start with the custom method verb (the custom method path section delimited by the colon (:) character) and should be followed by a noun or compound noun.
-      If the custom Operation ID has a verb + noun, the Operation ID should end with the noun.
-      The noun(s) in the Operation ID should be the collection identifiers from the resource identifier.
-      The noun(s) in the Operation ID should be the collection identifiers from the resource identifier in singular form, where the last noun:
-        - Is in plural form if the method applies to a collection of resources
-        - Is in singular form if the method applies to a single resource
-
-      ##### Implementation details
-      Rule checks for the following conditions:
-        - Applies only to paths containing custom method identifiers (with colon format)
-        - Generates the expected OperationId given the resource identifier and the method name portion following the colon
-        - Confirms that the existing operationId is compliant with generated IPA Compliant OperationId
-    message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-109-valid-operation-id'
-    severity: off
-    given: '$.paths[*]'
-    then:
-      function: 'IPA109ValidOperationID'

--- a/tools/spectral/ipa/rulesets/README.md
+++ b/tools/spectral/ipa/rulesets/README.md
@@ -139,19 +139,6 @@ Rule checks for the following conditions:
   - Applies only to GET methods on single resources or singleton resources
   - Verifies that the operation object does not contain a requestBody property
 
-#### xgen-IPA-104-valid-operation-id
-
- `off` 
-The Operation ID must start with the verb “get” and should be followed by a noun or compound noun.
-The noun(s) in the Operation ID should be the collection identifiers from the resource identifier in singular form.
-If the resource is a singleton resource, the last noun may be the plural form of the collection identifier.
-
-##### Implementation details
-Rule checks for the following conditions:
-  - Applies only to GET methods on single resources or singleton resources
-  - Generates the expected OperationId given the resource identifier
-  - Confirms that the existing operationId is compliant with generated IPA Compliant OperationId
-
 
 
 ### IPA-105
@@ -206,19 +193,6 @@ The response body of the List method should consist of the same resource object 
   - Fails if the Get method doesn't have a schema reference or if the schemas don't match
   - Validation ignores resources without a Get method
   - Paths with `x-xgen-IPA-exception` for this rule are excluded from validation
-#### xgen-IPA-105-valid-operation-id
-
- `off` 
-The Operation ID must start with the verb “list” and should be followed by a noun or compound noun.
-The noun(s) in the Operation ID should be the collection identifiers from the resource identifier in singular form, where the last noun is in plural form.
-
-##### Implementation details
-Rule checks for the following conditions:
-  - Applies only to GET methods on resource collection paths
-  - Ignores singleton resources
-  - Generates the expected OperationId given the resource identifier
-  - Confirms that the existing operationId is compliant with generated IPA Compliant OperationId
-
 
 
 ### IPA-106
@@ -299,18 +273,6 @@ Rule checks for the following conditions:
   - Ignores resources without a Get method
   - Paths with `x-xgen-IPA-exception` for this rule are excluded from validation
 
-#### xgen-IPA-106-valid-operation-id
-
- `off` 
-The Operation ID must start with the verb “create” and should be followed by a noun or compound noun.
-The noun(s) in the Operation ID should be the collection identifiers from the resource identifier in singular form.
-
-##### Implementation details
-Rule checks for the following conditions:
-  - Applies only to POST methods on resource collection paths
-  - Generates the expected OperationId given the resource identifier
-  - Confirms that the existing operationId is compliant with generated IPA Compliant OperationId
-
 
 
 ### IPA-107
@@ -382,19 +344,6 @@ Rule checks for the following conditions:
   - Validation only applies to schema references to a predefined schema (not inline)
   - Confirms the referenced schema name ends with "Request" suffix
 
-#### xgen-IPA-107-valid-operation-id
-
- `off` 
-The Operation ID must start with the verb “update” and should be followed by a noun or compound noun.
-The noun(s) in the Operation ID should be the collection identifiers from the resource identifier in singular form.
-If the resource is a singleton resource, the last noun may be the plural form of the collection identifier.
-
-##### Implementation details
-Rule checks for the following conditions:
-  - Validation checks the PATCH/PUT methods for single resource paths and [singleton resources](https://go/ipa/113).
-  - Generates the expected OperationId given the resource identifier
-  - Confirms that the existing operationId is compliant with generated IPA Compliant OperationId
-
 
 
 ### IPA-108
@@ -438,18 +387,6 @@ Rule checks for the following conditions:
   - Verifies that the operation object does not contain a requestBody property
   - Fails if any requestBody is defined for the DELETE method
   - Skips validation for collection endpoints (without path parameters)
-
-#### xgen-IPA-108-valid-operation-id
-
- `off` 
-The Operation ID must start with the verb “delete” and should be followed by a noun or compound noun.
-The noun(s) in the Operation ID should be the collection identifiers from the resource identifier in singular form.
-
-##### Implementation details
-Rule checks for the following conditions:
-  - Applies to all DELETE methods for single resource endpoints (with path parameters)
-  - Generates the expected OperationId given the resource identifier
-  - Confirms that the existing operationId is compliant with generated IPA Compliant OperationId
 
 
 
@@ -495,22 +432,6 @@ Rule checks for the following conditions:
   - Fails if a slash appears before a colon
   - Fails if multiple colons appear in the path
   - Fails if other than an alphabetical character or a closing curly brace appears before a colon
-
-#### xgen-IPA-109-valid-operation-id
-
- `off` 
-The Operation ID must start with the custom method verb (the custom method path section delimited by the colon (:) character) and should be followed by a noun or compound noun.
-If the custom Operation ID has a verb + noun, the Operation ID should end with the noun.
-The noun(s) in the Operation ID should be the collection identifiers from the resource identifier.
-The noun(s) in the Operation ID should be the collection identifiers from the resource identifier in singular form, where the last noun:
-  - Is in plural form if the method applies to a collection of resources
-  - Is in singular form if the method applies to a single resource
-
-##### Implementation details
-Rule checks for the following conditions:
-  - Applies only to paths containing custom method identifiers (with colon format)
-  - Generates the expected OperationId given the resource identifier and the method name portion following the colon
-  - Confirms that the existing operationId is compliant with generated IPA Compliant OperationId
 
 
 


### PR DESCRIPTION
## Proposed changes
Removed reference to OperationID validation functions in order to prevent errors in subsequent SHA updates on MMS due to custom package usage. They will be re-added after [CLOUDP-329999](https://jira.mongodb.org/browse/CLOUDP-329999).

_Jira ticket:_ [CLOUDP-330237](https://jira.mongodb.org/browse/CLOUDP-330237)