### PR TITLE
CLOUDP-332939: Updated husky usage

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,2 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 # Run lint-staged to process only changed JS files
-npx lint-staged
+lint-staged

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "ipa-filter-violations": "node tools/spectral/ipa/scripts/filter-ipa-violations.js",
         "spectral-validation": "spectral lint ./openapi/.raw/v2.yaml --ruleset=./tools/spectral/.spectral.yaml",
         "test": "jest",
-        "precommit": "husky install"
+        "precommit": "husky"
     },
     "jest": {
         "transform": {


### PR DESCRIPTION
## Proposed changes

Husky is used in the precommit script for linting staged changes. I removed deprecated uses of `husky install`,  `#!/usr/bin/env.sh` and `. "$(dirname -- "$0")/_/husky.sh"` and altered the script to run package commands directly (which makes the hook a little faster). 

More details on deprecation/new releases: https://github.com/typicode/husky/releases

_Jira ticket:_ [CLOUDP-332939](https://jira.mongodb.org/browse/CLOUDP-332939)