### PR TITLE
CLOUDP-333549: --output is required when downloading logs, but this is not documented

### DIFF
--- a/.github/workflows/code-health-foascli.yml
+++ b/.github/workflows/code-health-foascli.yml
@@ -102,4 +102,4 @@ jobs:
           go-version-file: 'tools/cli/go.mod'
       - name: Run e2e tests
         working-directory: tools/cli
-        run: make e2e-test
+        run: make devtools e2e-test

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@
 /tools/cli/test/e2e/cli/output/** 
 !/tools/cli/test/e2e/cli/output/.gitkeep 
 /tools/*/dist/*
-/tools/*/output/*
+/tools/cli/test/e2e/cli/output
 # We don't want to commit env variables
 *.env
 
@@ -27,3 +27,4 @@
 **/*metric-collection-results.parquet
 **/*spectral-output.txt
 **/*spectral-report.xml
+

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /tools/cli/test/e2e/cli/output/** 
 !/tools/cli/test/e2e/cli/output/.gitkeep 
 /tools/*/dist/*
+/tools/*/output/*
 # We don't want to commit env variables
 *.env
 

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@
 /tools/cli/test/e2e/cli/output/** 
 !/tools/cli/test/e2e/cli/output/.gitkeep 
 /tools/*/dist/*
-/tools/cli/test/e2e/cli/output
+/tools/*/output/*
 # We don't want to commit env variables
 *.env
 
@@ -27,4 +27,3 @@
 **/*metric-collection-results.parquet
 **/*spectral-output.txt
 **/*spectral-report.xml
-

--- a/tools/cli/Makefile
+++ b/tools/cli/Makefile
@@ -34,6 +34,7 @@ deps:  ## Download go module dependencies
 devtools:  ## Install dev tools
 	@echo "==> Installing dev tools..."
 	go install go.uber.org/mock/mockgen@latest
+	go install github.com/oasdiff/oasdiff@v1.11.4
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin $(GOLANGCI_VERSION)
 
 .PHONY: setup

--- a/tools/cli/Makefile
+++ b/tools/cli/Makefile
@@ -71,6 +71,7 @@ list: ## List all make targets
 .PHONY: e2e-test
 e2e-test: build ## Run E2E tests
 	@echo "==> Running E2E tests..."
+	rm -rf test/e2e/cli/output
 	$(TEST_CMD) -v -p 1 -parallel $(E2E_PARALLEL) -timeout $(E2E_TIMEOUT)  ./test/e2e... $(E2E_EXTRA_ARGS)
 
 .PHONY: gen-docs

--- a/tools/cli/Makefile
+++ b/tools/cli/Makefile
@@ -34,7 +34,7 @@ deps:  ## Download go module dependencies
 devtools:  ## Install dev tools
 	@echo "==> Installing dev tools..."
 	go install go.uber.org/mock/mockgen@latest
-	go install github.com/oasdiff/oasdiff@v1.11.4
+	go install github.com/tufin/oasdiff@v1.10.29
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin $(GOLANGCI_VERSION)
 
 .PHONY: setup

--- a/tools/cli/internal/openapi/filter/code_sample.go
+++ b/tools/cli/internal/openapi/filter/code_sample.go
@@ -65,6 +65,15 @@ func (f *CodeSampleFilter) Apply() error {
 	return nil
 }
 
+func getFileExtension(format string) string {
+	switch format {
+	case "gzip":
+		return "gz"
+	default:
+		return format
+	}
+}
+
 func (f *CodeSampleFilter) newDigestCurlCodeSamplesForOperation(pathName, opMethod, format string) codeSample {
 	version := apiVersion(f.metadata.targetVersion)
 	source := "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  " +
@@ -75,7 +84,7 @@ func (f *CodeSampleFilter) newDigestCurlCodeSamplesForOperation(pathName, opMeth
 		source += "-X " + opMethod + " \"https://cloud.mongodb.com" + pathName
 		if format == "gzip" {
 			source += "\" \\\n  "
-			source += "--output \"file_name." + format + "\""
+			source += "--output \"file_name." + getFileExtension(format) + "\""
 		} else {
 			source += "?pretty=true\""
 		}
@@ -105,7 +114,7 @@ func (f *CodeSampleFilter) newServiceAccountCurlCodeSamplesForOperation(pathName
 		source += "-X " + opMethod + " \"https://cloud.mongodb.com" + pathName
 		if format == "gzip" {
 			source += "\" \\\n  "
-			source += "--output \"file_name." + format + "\""
+			source += "--output \"file_name." + getFileExtension(format) + "\""
 		} else {
 			source += "?pretty=true\""
 		}

--- a/tools/cli/internal/openapi/filter/code_sample.go
+++ b/tools/cli/internal/openapi/filter/code_sample.go
@@ -65,14 +65,21 @@ func (f *CodeSampleFilter) Apply() error {
 	return nil
 }
 
-func (f *CodeSampleFilter) newDigestCurlCodeSamplesForOperation(pathName, opMethod string) codeSample {
+func (f *CodeSampleFilter) newDigestCurlCodeSamplesForOperation(pathName, opMethod, format string) codeSample {
 	version := apiVersion(f.metadata.targetVersion)
 	source := "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  " +
-		"--header \"Accept: application/vnd.atlas." + version + "+json\" \\\n  "
+		"--header \"Accept: application/vnd.atlas." + version + "+" + format + "\" \\\n  "
 
 	switch opMethod {
 	case "GET":
-		source += "-X " + opMethod + " \"https://cloud.mongodb.com" + pathName + "?pretty=true\""
+		source += "-X " + opMethod + " \"https://cloud.mongodb.com" + pathName
+		if format == "gzip" {
+			source += "\" \\\n  "
+			source += "--output \"file_name." + format + "\""
+		} else {
+			source += "?pretty=true\""
+		}
+
 	case "DELETE":
 		source += "-X " + opMethod + " \"https://cloud.mongodb.com" + pathName + "\""
 	case "POST", "PATCH", "PUT":
@@ -88,14 +95,20 @@ func (f *CodeSampleFilter) newDigestCurlCodeSamplesForOperation(pathName, opMeth
 	}
 }
 
-func (f *CodeSampleFilter) newServiceAccountCurlCodeSamplesForOperation(pathName, opMethod string) codeSample {
+func (f *CodeSampleFilter) newServiceAccountCurlCodeSamplesForOperation(pathName, opMethod, format string) codeSample {
 	version := apiVersion(f.metadata.targetVersion)
 	source := "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  " +
-		"--header \"Accept: application/vnd.atlas." + version + "+json\" \\\n  "
+		"--header \"Accept: application/vnd.atlas." + version + "+" + format + "\" \\\n  "
 
 	switch opMethod {
 	case "GET":
-		source += "-X " + opMethod + " \"https://cloud.mongodb.com" + pathName + "?pretty=true\""
+		source += "-X " + opMethod + " \"https://cloud.mongodb.com" + pathName
+		if format == "gzip" {
+			source += "\" \\\n  "
+			source += "--output \"file_name." + format + "\""
+		} else {
+			source += "?pretty=true\""
+		}
 	case "DELETE":
 		source += "-X " + opMethod + " \"https://cloud.mongodb.com" + pathName + "\""
 	case "POST", "PATCH", "PUT":
@@ -193,10 +206,46 @@ func (f *CodeSampleFilter) includeCodeSamplesForOperation(pathName, opMethod str
 		codeSamples = append(codeSamples, *sdkSample)
 	}
 
+	supportedFormat := getSupportedFormat(op)
 	codeSamples = append(
 		codeSamples,
-		f.newServiceAccountCurlCodeSamplesForOperation(pathName, opMethod),
-		f.newDigestCurlCodeSamplesForOperation(pathName, opMethod))
+		f.newServiceAccountCurlCodeSamplesForOperation(pathName, opMethod, supportedFormat),
+		f.newDigestCurlCodeSamplesForOperation(pathName, opMethod, supportedFormat))
 	op.Extensions[codeSampleExtensionName] = codeSamples
+	return nil
+}
+
+// getSupportedFormat inspects the response content types of a given OpenAPI operation,
+// looking for a content type string in the format "application/vnd.atlas.<api_version>+<supported_format>".
+// It splits the content type on the '+' character and returns the last part, which represents the supported format (e.g., "json").
+// If no such content type is found, it defaults to returning "json".
+func getSupportedFormat(op *openapi3.Operation) string {
+	responseMap := successResponseExtensions(op.Responses.Map())
+	for k := range responseMap {
+		// k is a string with the format "application/vnd.atlas.<api_version>+<supported_format>"
+		parts := strings.Split(k, "+")
+		if len(parts) > 1 {
+			return parts[len(parts)-1]
+		}
+	}
+	return "json"
+}
+
+// successResponseExtensions returns the Content object of the first successful HTTP response (status 200, 201, 202, or 204)
+// found in the provided responses map.
+func successResponseExtensions(responsesMap map[string]*openapi3.ResponseRef) openapi3.Content {
+	if val, ok := responsesMap["200"]; ok {
+		return val.Value.Content
+	}
+	if val, ok := responsesMap["201"]; ok {
+		return val.Value.Content
+	}
+	if val, ok := responsesMap["202"]; ok {
+		return val.Value.Content
+	}
+	if val, ok := responsesMap["204"]; ok {
+		return val.Value.Content
+	}
+
 	return nil
 }

--- a/tools/cli/internal/openapi/filter/code_sample.go
+++ b/tools/cli/internal/openapi/filter/code_sample.go
@@ -221,14 +221,23 @@ func (f *CodeSampleFilter) includeCodeSamplesForOperation(pathName, opMethod str
 // If no such content type is found, it defaults to returning "json".
 func getSupportedFormat(op *openapi3.Operation) string {
 	responseMap := successResponseExtensions(op.Responses.Map())
+	format := "json"
 	for k := range responseMap {
 		// k is a string with the format "application/vnd.atlas.<api_version>+<supported_format>"
 		parts := strings.Split(k, "+")
-		if len(parts) > 1 {
-			return parts[len(parts)-1]
+		if len(parts) == 0 {
+			continue
+		}
+
+		format = parts[len(parts)-1]
+		// If the endpoint supports "json", we return it as "json" is the best supported format in our APIs
+		// and users should use it when available.
+		if format == "json" {
+			return format
 		}
 	}
-	return "json"
+
+	return format
 }
 
 // successResponseExtensions returns the Content object of the first successful HTTP response (status 200, 201, 202, or 204)

--- a/tools/cli/internal/openapi/filter/code_sample_test.go
+++ b/tools/cli/internal/openapi/filter/code_sample_test.go
@@ -257,6 +257,97 @@ func TestCodeSampleFilter(t *testing.T) {
 				})),
 			},
 		},
+		{
+			name:    "stable api gzip",
+			version: "2025-01-01",
+			oas: &openapi3.T{
+				Paths: openapi3.NewPaths(openapi3.WithPath("/test", &openapi3.PathItem{
+					Get: &openapi3.Operation{
+						OperationID: "testOperationID",
+						Summary:     "testSummary",
+						Responses: openapi3.NewResponses(openapi3.WithName("200", &openapi3.Response{
+							Content: openapi3.Content{
+								"application/vnd.atlas.2025-01-01+gzip": {
+									Schema: &openapi3.SchemaRef{
+										Ref: "#/components/schemas/PaginatedAppUserView",
+									},
+									Extensions: map[string]any{
+										"x-gen-version": "2025-01-01",
+									},
+								},
+							},
+						})),
+						Tags: []string{"TestTag"},
+						Extensions: map[string]any{
+							"x-sunset": "9999-12-31",
+						},
+					},
+				})),
+			},
+			expectedOas: &openapi3.T{
+				Paths: openapi3.NewPaths(openapi3.WithPath("/test", &openapi3.PathItem{
+					Get: &openapi3.Operation{
+						OperationID: "testOperationID",
+						Summary:     "testSummary",
+						Responses: openapi3.NewResponses(openapi3.WithName("200", &openapi3.Response{
+							Content: openapi3.Content{
+								"application/vnd.atlas.2025-01-01+gzip": {
+									Schema: &openapi3.SchemaRef{
+										Ref: "#/components/schemas/PaginatedAppUserView",
+									},
+									Extensions: map[string]any{
+										"x-gen-version": "2025-01-01",
+									},
+								},
+							},
+						})),
+						Tags: []string{"TestTag"},
+						Extensions: map[string]any{
+							"x-sunset": "9999-12-31",
+							"x-codeSamples": []codeSample{
+								{
+									Lang:   "cURL",
+									Label:  "Atlas CLI",
+									Source: "atlas api testOperationID --help",
+								},
+								{
+									Lang:  "go",
+									Label: "Go",
+									Source: "import (\n" +
+										"\t\"os\"\n	\"context\"\n" + "\t\"log\"\n" +
+										"\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\n" +
+										"func main() {\n" +
+										"\tctx := context.Background()\n" +
+										"\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n" +
+										"\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n" +
+										"\t// See https://dochub.mongodb.org/core/atlas-go-sdk-oauth\n" +
+										"\tclient, err := sdk.NewClient(sdk.UseOAuthAuth(clientID, clientSecret))\n\n" +
+										"\tif err != nil {\n" + "\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n" +
+										"\tparams = &sdk.TestOperationIDApiParams{}\n" +
+										"\tsdkResp, httpResp, err := client.TestTagApi.\n" +
+										"\t\tTestOperationIDWithParams(ctx, params).\n" +
+										"\t\tExecute()" + "\n}\n",
+								},
+								{
+									Lang:  "cURL",
+									Label: "curl (Service Accounts)",
+									Source: "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  " +
+										"--header \"Accept: application/vnd.atlas.2025-01-01+gzip\" \\\n  " +
+										"-X GET \"https://cloud.mongodb.com/test\" \\\n  --output \"file_name.gz\"",
+								},
+								{
+									Lang:  "cURL",
+									Label: "curl (Digest)",
+									Source: "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  " +
+										"--header \"Accept: application/vnd.atlas.2025-01-01+gzip\" \\\n  " +
+										"-X GET \"https://cloud.mongodb.com/test\" \\\n  --output \"file_name.gz\"",
+								},
+							},
+						},
+					},
+				})),
+			},
+		},
 	}
 
 	for _, tt := range testCases {

--- a/tools/cli/test/data/split/dev/openapi-v2-2023-01-01.json
+++ b/tools/cli/test/data/split/dev/openapi-v2-2023-01-01.json
@@ -61556,12 +61556,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
           }
         ]
       }

--- a/tools/cli/test/data/split/dev/openapi-v2-2023-01-01.json
+++ b/tools/cli/test/data/split/dev/openapi-v2-2023-01-01.json
@@ -43904,12 +43904,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz\" \\\n  --output \"file_name.gz\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz\" \\\n  --output \"file_name.gz\""
           }
         ]
       }
@@ -46165,12 +46165,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz\" \\\n  --output \"file_name.gzip\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz\" \\\n  --output \"file_name.gz\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz\" \\\n  --output \"file_name.gzip\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz\" \\\n  --output \"file_name.gz\""
           }
         ],
         "x-sunset": "2025-06-01"
@@ -47992,12 +47992,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz\" \\\n  --output \"file_name.gz\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz\" \\\n  --output \"file_name.gz\""
           }
         ]
       }

--- a/tools/cli/test/data/split/dev/openapi-v2-2023-01-01.json
+++ b/tools/cli/test/data/split/dev/openapi-v2-2023-01-01.json
@@ -43904,12 +43904,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
           }
         ]
       }
@@ -46165,12 +46165,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz\" \\\n  --output \"file_name.gzip\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz\" \\\n  --output \"file_name.gzip\""
           }
         ],
         "x-sunset": "2025-06-01"
@@ -47992,12 +47992,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
           }
         ]
       }
@@ -61556,12 +61556,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
           }
         ]
       }
@@ -62827,12 +62827,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/csv?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/csv?pretty=true\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/csv?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/csv?pretty=true\""
           }
         ]
       }

--- a/tools/cli/test/data/split/dev/openapi-v2-2023-01-01.yaml
+++ b/tools/cli/test/data/split/dev/openapi-v2-2023-01-01.yaml
@@ -37472,7 +37472,7 @@ paths:
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
                       --header "Accept: application/vnd.atlas.2023-01-01+gzip" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz" \
-                      --output "file_name.gzip"
+                      --output "file_name.gz"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
@@ -37480,7 +37480,7 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+gzip" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz" \
-                      --output "file_name.gzip"
+                      --output "file_name.gz"
     /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/outageSimulation:
         delete:
             description: Ends a cluster outage simulation.
@@ -39364,7 +39364,7 @@ paths:
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
                       --header "Accept: application/vnd.atlas.2023-01-01+gzip" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz" \
-                      --output "file_name.gzip"
+                      --output "file_name.gz"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
@@ -39372,7 +39372,7 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+gzip" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz" \
-                      --output "file_name.gzip"
+                      --output "file_name.gz"
             x-sunset: "2025-06-01"
     /api/atlas/v2/groups/{groupId}/clusters/provider/regions:
         get:
@@ -41418,7 +41418,7 @@ paths:
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
                       --header "Accept: application/vnd.atlas.2023-01-01+gzip" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz" \
-                      --output "file_name.gzip"
+                      --output "file_name.gz"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
@@ -41426,7 +41426,7 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+gzip" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz" \
-                      --output "file_name.gzip"
+                      --output "file_name.gz"
     /api/atlas/v2/groups/{groupId}/databaseUsers:
         get:
             description: Returns all database users that belong to the specified project. To use this resource, the requesting API Key must have the Project Read Only role.

--- a/tools/cli/test/data/split/dev/openapi-v2-2023-01-01.yaml
+++ b/tools/cli/test/data/split/dev/openapi-v2-2023-01-01.yaml
@@ -54715,14 +54715,14 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2023-01-01+csv" \
+                      --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2023-01-01+csv" \
+                      --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true"
     /api/atlas/v2/orgs/{orgId}/events:
         get:

--- a/tools/cli/test/data/split/dev/openapi-v2-2023-01-01.yaml
+++ b/tools/cli/test/data/split/dev/openapi-v2-2023-01-01.yaml
@@ -37470,15 +37470,17 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2023-01-01+json" \
-                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz?pretty=true"
+                      --header "Accept: application/vnd.atlas.2023-01-01+gzip" \
+                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz" \
+                      --output "file_name.gzip"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2023-01-01+json" \
-                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz?pretty=true"
+                      --header "Accept: application/vnd.atlas.2023-01-01+gzip" \
+                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz" \
+                      --output "file_name.gzip"
     /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/outageSimulation:
         delete:
             description: Ends a cluster outage simulation.
@@ -39360,15 +39362,17 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2023-01-01+json" \
-                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz?pretty=true"
+                      --header "Accept: application/vnd.atlas.2023-01-01+gzip" \
+                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz" \
+                      --output "file_name.gzip"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2023-01-01+json" \
-                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz?pretty=true"
+                      --header "Accept: application/vnd.atlas.2023-01-01+gzip" \
+                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz" \
+                      --output "file_name.gzip"
             x-sunset: "2025-06-01"
     /api/atlas/v2/groups/{groupId}/clusters/provider/regions:
         get:
@@ -41412,15 +41416,17 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2023-01-01+json" \
-                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz?pretty=true"
+                      --header "Accept: application/vnd.atlas.2023-01-01+gzip" \
+                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz" \
+                      --output "file_name.gzip"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2023-01-01+json" \
-                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz?pretty=true"
+                      --header "Accept: application/vnd.atlas.2023-01-01+gzip" \
+                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz" \
+                      --output "file_name.gzip"
     /api/atlas/v2/groups/{groupId}/databaseUsers:
         get:
             description: Returns all database users that belong to the specified project. To use this resource, the requesting API Key must have the Project Read Only role.
@@ -54709,14 +54715,14 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2023-01-01+json" \
+                      --header "Accept: application/vnd.atlas.2023-01-01+csv" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2023-01-01+json" \
+                      --header "Accept: application/vnd.atlas.2023-01-01+csv" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true"
     /api/atlas/v2/orgs/{orgId}/events:
         get:
@@ -55868,14 +55874,14 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2023-01-01+json" \
+                      --header "Accept: application/vnd.atlas.2023-01-01+csv" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/csv?pretty=true"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2023-01-01+json" \
+                      --header "Accept: application/vnd.atlas.2023-01-01+csv" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/csv?pretty=true"
     /api/atlas/v2/orgs/{orgId}/invoices/pending:
         get:

--- a/tools/cli/test/data/split/dev/openapi-v2-2023-02-01.json
+++ b/tools/cli/test/data/split/dev/openapi-v2-2023-02-01.json
@@ -44433,12 +44433,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz\" \\\n  --output \"file_name.gz\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz\" \\\n  --output \"file_name.gz\""
           }
         ]
       }
@@ -46691,12 +46691,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz\" \\\n  --output \"file_name.gzip\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz\" \\\n  --output \"file_name.gz\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz\" \\\n  --output \"file_name.gzip\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz\" \\\n  --output \"file_name.gz\""
           }
         ]
       }
@@ -48517,12 +48517,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz\" \\\n  --output \"file_name.gz\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz\" \\\n  --output \"file_name.gz\""
           }
         ]
       }
@@ -60139,12 +60139,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs\" \\\n  --output \"file_name.gzip\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs\" \\\n  --output \"file_name.gz\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs\" \\\n  --output \"file_name.gzip\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs\" \\\n  --output \"file_name.gz\""
           }
         ]
       }

--- a/tools/cli/test/data/split/dev/openapi-v2-2023-02-01.json
+++ b/tools/cli/test/data/split/dev/openapi-v2-2023-02-01.json
@@ -63056,12 +63056,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
           }
         ]
       }
@@ -64246,12 +64246,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true\""
           }
         ]
       }

--- a/tools/cli/test/data/split/dev/openapi-v2-2023-02-01.json
+++ b/tools/cli/test/data/split/dev/openapi-v2-2023-02-01.json
@@ -44433,12 +44433,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
           }
         ]
       }
@@ -46691,12 +46691,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz\" \\\n  --output \"file_name.gzip\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz\" \\\n  --output \"file_name.gzip\""
           }
         ]
       }
@@ -48517,12 +48517,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
           }
         ]
       }
@@ -60139,12 +60139,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs\" \\\n  --output \"file_name.gzip\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs\" \\\n  --output \"file_name.gzip\""
           }
         ]
       }
@@ -63056,12 +63056,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
           }
         ]
       }
@@ -64246,12 +64246,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true\""
           }
         ]
       }
@@ -64327,12 +64327,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/csv?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/csv?pretty=true\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/csv?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/csv?pretty=true\""
           }
         ]
       }

--- a/tools/cli/test/data/split/dev/openapi-v2-2023-02-01.yaml
+++ b/tools/cli/test/data/split/dev/openapi-v2-2023-02-01.yaml
@@ -56095,14 +56095,14 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2023-02-01+csv" \
+                      --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2023-02-01+csv" \
+                      --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true"
     /api/atlas/v2/orgs/{orgId}/events:
         get:
@@ -57167,14 +57167,14 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2023-02-01+csv" \
+                      --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2023-02-01+csv" \
+                      --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true"
     /api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/csv:
         get:

--- a/tools/cli/test/data/split/dev/openapi-v2-2023-02-01.yaml
+++ b/tools/cli/test/data/split/dev/openapi-v2-2023-02-01.yaml
@@ -37919,7 +37919,7 @@ paths:
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
                       --header "Accept: application/vnd.atlas.2023-02-01+gzip" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz" \
-                      --output "file_name.gzip"
+                      --output "file_name.gz"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
@@ -37927,7 +37927,7 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+gzip" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz" \
-                      --output "file_name.gzip"
+                      --output "file_name.gz"
     /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/outageSimulation:
         delete:
             description: Ends a cluster outage simulation.
@@ -39808,7 +39808,7 @@ paths:
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
                       --header "Accept: application/vnd.atlas.2023-02-01+gzip" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz" \
-                      --output "file_name.gzip"
+                      --output "file_name.gz"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
@@ -39816,7 +39816,7 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+gzip" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz" \
-                      --output "file_name.gzip"
+                      --output "file_name.gz"
     /api/atlas/v2/groups/{groupId}/clusters/provider/regions:
         get:
             description: Returns the list of regions available for the specified cloud provider at the specified tier. To use this resource, the requesting API Key must have the Project Read Only role.
@@ -41861,7 +41861,7 @@ paths:
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
                       --header "Accept: application/vnd.atlas.2023-02-01+gzip" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz" \
-                      --output "file_name.gzip"
+                      --output "file_name.gz"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
@@ -41869,7 +41869,7 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+gzip" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz" \
-                      --output "file_name.gzip"
+                      --output "file_name.gz"
     /api/atlas/v2/groups/{groupId}/databaseUsers:
         get:
             description: Returns all database users that belong to the specified project. To use this resource, the requesting API Key must have the Project Read Only role.
@@ -53172,7 +53172,7 @@ paths:
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
                       --header "Accept: application/vnd.atlas.2023-02-01+gzip" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs" \
-                      --output "file_name.gzip"
+                      --output "file_name.gz"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
@@ -53180,7 +53180,7 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+gzip" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs" \
-                      --output "file_name.gzip"
+                      --output "file_name.gz"
     /api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections:
         get:
             description: Returns all connections of the stream instance for the specified project.To use this resource, the requesting API Key must have the Project Data Access roles, Project Owner role or Project Stream Processing Owner role.

--- a/tools/cli/test/data/split/dev/openapi-v2-2023-02-01.yaml
+++ b/tools/cli/test/data/split/dev/openapi-v2-2023-02-01.yaml
@@ -37917,15 +37917,17 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2023-02-01+json" \
-                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz?pretty=true"
+                      --header "Accept: application/vnd.atlas.2023-02-01+gzip" \
+                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz" \
+                      --output "file_name.gzip"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2023-02-01+json" \
-                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz?pretty=true"
+                      --header "Accept: application/vnd.atlas.2023-02-01+gzip" \
+                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz" \
+                      --output "file_name.gzip"
     /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/outageSimulation:
         delete:
             description: Ends a cluster outage simulation.
@@ -39804,15 +39806,17 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2023-02-01+json" \
-                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz?pretty=true"
+                      --header "Accept: application/vnd.atlas.2023-02-01+gzip" \
+                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz" \
+                      --output "file_name.gzip"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2023-02-01+json" \
-                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz?pretty=true"
+                      --header "Accept: application/vnd.atlas.2023-02-01+gzip" \
+                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz" \
+                      --output "file_name.gzip"
     /api/atlas/v2/groups/{groupId}/clusters/provider/regions:
         get:
             description: Returns the list of regions available for the specified cloud provider at the specified tier. To use this resource, the requesting API Key must have the Project Read Only role.
@@ -41855,15 +41859,17 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2023-02-01+json" \
-                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz?pretty=true"
+                      --header "Accept: application/vnd.atlas.2023-02-01+gzip" \
+                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz" \
+                      --output "file_name.gzip"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2023-02-01+json" \
-                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz?pretty=true"
+                      --header "Accept: application/vnd.atlas.2023-02-01+gzip" \
+                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz" \
+                      --output "file_name.gzip"
     /api/atlas/v2/groups/{groupId}/databaseUsers:
         get:
             description: Returns all database users that belong to the specified project. To use this resource, the requesting API Key must have the Project Read Only role.
@@ -53164,15 +53170,17 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2023-02-01+json" \
-                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs?pretty=true"
+                      --header "Accept: application/vnd.atlas.2023-02-01+gzip" \
+                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs" \
+                      --output "file_name.gzip"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2023-02-01+json" \
-                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs?pretty=true"
+                      --header "Accept: application/vnd.atlas.2023-02-01+gzip" \
+                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs" \
+                      --output "file_name.gzip"
     /api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections:
         get:
             description: Returns all connections of the stream instance for the specified project.To use this resource, the requesting API Key must have the Project Data Access roles, Project Owner role or Project Stream Processing Owner role.
@@ -56087,14 +56095,14 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2023-02-01+json" \
+                      --header "Accept: application/vnd.atlas.2023-02-01+csv" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2023-02-01+json" \
+                      --header "Accept: application/vnd.atlas.2023-02-01+csv" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true"
     /api/atlas/v2/orgs/{orgId}/events:
         get:
@@ -57159,14 +57167,14 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2023-02-01+json" \
+                      --header "Accept: application/vnd.atlas.2023-02-01+csv" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2023-02-01+json" \
+                      --header "Accept: application/vnd.atlas.2023-02-01+csv" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true"
     /api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/csv:
         get:
@@ -57246,14 +57254,14 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2023-02-01+json" \
+                      --header "Accept: application/vnd.atlas.2023-02-01+csv" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/csv?pretty=true"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2023-02-01+json" \
+                      --header "Accept: application/vnd.atlas.2023-02-01+csv" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/csv?pretty=true"
     /api/atlas/v2/orgs/{orgId}/invoices/pending:
         get:

--- a/tools/cli/test/data/split/dev/openapi-v2-2023-10-01.json
+++ b/tools/cli/test/data/split/dev/openapi-v2-2023-10-01.json
@@ -64085,12 +64085,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
           }
         ]
       }
@@ -65275,12 +65275,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true\""
           }
         ]
       }

--- a/tools/cli/test/data/split/dev/openapi-v2-2023-10-01.json
+++ b/tools/cli/test/data/split/dev/openapi-v2-2023-10-01.json
@@ -44965,12 +44965,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
           }
         ]
       }
@@ -47223,12 +47223,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz\" \\\n  --output \"file_name.gzip\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz\" \\\n  --output \"file_name.gzip\""
           }
         ]
       }
@@ -49049,12 +49049,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
           }
         ]
       }
@@ -61168,12 +61168,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs\" \\\n  --output \"file_name.gzip\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs\" \\\n  --output \"file_name.gzip\""
           }
         ]
       }
@@ -64085,12 +64085,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
           }
         ]
       }
@@ -65275,12 +65275,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true\""
           }
         ]
       }
@@ -65356,12 +65356,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/csv?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/csv?pretty=true\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/csv?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/csv?pretty=true\""
           }
         ]
       }

--- a/tools/cli/test/data/split/dev/openapi-v2-2023-10-01.json
+++ b/tools/cli/test/data/split/dev/openapi-v2-2023-10-01.json
@@ -44965,12 +44965,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz\" \\\n  --output \"file_name.gz\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz\" \\\n  --output \"file_name.gz\""
           }
         ]
       }
@@ -47223,12 +47223,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz\" \\\n  --output \"file_name.gzip\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz\" \\\n  --output \"file_name.gz\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz\" \\\n  --output \"file_name.gzip\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz\" \\\n  --output \"file_name.gz\""
           }
         ]
       }
@@ -49049,12 +49049,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz\" \\\n  --output \"file_name.gz\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz\" \\\n  --output \"file_name.gz\""
           }
         ]
       }
@@ -61168,12 +61168,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs\" \\\n  --output \"file_name.gzip\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs\" \\\n  --output \"file_name.gz\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs\" \\\n  --output \"file_name.gzip\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs\" \\\n  --output \"file_name.gz\""
           }
         ]
       }

--- a/tools/cli/test/data/split/dev/openapi-v2-2023-10-01.yaml
+++ b/tools/cli/test/data/split/dev/openapi-v2-2023-10-01.yaml
@@ -38333,15 +38333,17 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2023-10-01+json" \
-                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz?pretty=true"
+                      --header "Accept: application/vnd.atlas.2023-10-01+gzip" \
+                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz" \
+                      --output "file_name.gzip"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2023-10-01+json" \
-                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz?pretty=true"
+                      --header "Accept: application/vnd.atlas.2023-10-01+gzip" \
+                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz" \
+                      --output "file_name.gzip"
     /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/outageSimulation:
         delete:
             description: Ends a cluster outage simulation.
@@ -40220,15 +40222,17 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2023-10-01+json" \
-                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz?pretty=true"
+                      --header "Accept: application/vnd.atlas.2023-10-01+gzip" \
+                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz" \
+                      --output "file_name.gzip"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2023-10-01+json" \
-                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz?pretty=true"
+                      --header "Accept: application/vnd.atlas.2023-10-01+gzip" \
+                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz" \
+                      --output "file_name.gzip"
     /api/atlas/v2/groups/{groupId}/clusters/provider/regions:
         get:
             description: Returns the list of regions available for the specified cloud provider at the specified tier. To use this resource, the requesting API Key must have the Project Read Only role.
@@ -42271,15 +42275,17 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2023-10-01+json" \
-                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz?pretty=true"
+                      --header "Accept: application/vnd.atlas.2023-10-01+gzip" \
+                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz" \
+                      --output "file_name.gzip"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2023-10-01+json" \
-                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz?pretty=true"
+                      --header "Accept: application/vnd.atlas.2023-10-01+gzip" \
+                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz" \
+                      --output "file_name.gzip"
     /api/atlas/v2/groups/{groupId}/databaseUsers:
         get:
             description: Returns all database users that belong to the specified project. To use this resource, the requesting API Key must have the Project Read Only role.
@@ -54069,15 +54075,17 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2023-10-01+json" \
-                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs?pretty=true"
+                      --header "Accept: application/vnd.atlas.2023-10-01+gzip" \
+                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs" \
+                      --output "file_name.gzip"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2023-10-01+json" \
-                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs?pretty=true"
+                      --header "Accept: application/vnd.atlas.2023-10-01+gzip" \
+                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs" \
+                      --output "file_name.gzip"
     /api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections:
         get:
             description: Returns all connections of the stream instance for the specified project.To use this resource, the requesting API Key must have the Project Data Access roles, Project Owner role or Project Stream Processing Owner role.
@@ -56992,14 +57000,14 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2023-10-01+json" \
+                      --header "Accept: application/vnd.atlas.2023-10-01+csv" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2023-10-01+json" \
+                      --header "Accept: application/vnd.atlas.2023-10-01+csv" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true"
     /api/atlas/v2/orgs/{orgId}/events:
         get:
@@ -58064,14 +58072,14 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2023-10-01+json" \
+                      --header "Accept: application/vnd.atlas.2023-10-01+csv" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2023-10-01+json" \
+                      --header "Accept: application/vnd.atlas.2023-10-01+csv" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true"
     /api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/csv:
         get:
@@ -58151,14 +58159,14 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2023-10-01+json" \
+                      --header "Accept: application/vnd.atlas.2023-10-01+csv" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/csv?pretty=true"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2023-10-01+json" \
+                      --header "Accept: application/vnd.atlas.2023-10-01+csv" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/csv?pretty=true"
     /api/atlas/v2/orgs/{orgId}/invoices/pending:
         get:

--- a/tools/cli/test/data/split/dev/openapi-v2-2023-10-01.yaml
+++ b/tools/cli/test/data/split/dev/openapi-v2-2023-10-01.yaml
@@ -38335,7 +38335,7 @@ paths:
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
                       --header "Accept: application/vnd.atlas.2023-10-01+gzip" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz" \
-                      --output "file_name.gzip"
+                      --output "file_name.gz"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
@@ -38343,7 +38343,7 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+gzip" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz" \
-                      --output "file_name.gzip"
+                      --output "file_name.gz"
     /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/outageSimulation:
         delete:
             description: Ends a cluster outage simulation.
@@ -40224,7 +40224,7 @@ paths:
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
                       --header "Accept: application/vnd.atlas.2023-10-01+gzip" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz" \
-                      --output "file_name.gzip"
+                      --output "file_name.gz"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
@@ -40232,7 +40232,7 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+gzip" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz" \
-                      --output "file_name.gzip"
+                      --output "file_name.gz"
     /api/atlas/v2/groups/{groupId}/clusters/provider/regions:
         get:
             description: Returns the list of regions available for the specified cloud provider at the specified tier. To use this resource, the requesting API Key must have the Project Read Only role.
@@ -42277,7 +42277,7 @@ paths:
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
                       --header "Accept: application/vnd.atlas.2023-10-01+gzip" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz" \
-                      --output "file_name.gzip"
+                      --output "file_name.gz"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
@@ -42285,7 +42285,7 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+gzip" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz" \
-                      --output "file_name.gzip"
+                      --output "file_name.gz"
     /api/atlas/v2/groups/{groupId}/databaseUsers:
         get:
             description: Returns all database users that belong to the specified project. To use this resource, the requesting API Key must have the Project Read Only role.
@@ -54077,7 +54077,7 @@ paths:
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
                       --header "Accept: application/vnd.atlas.2023-10-01+gzip" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs" \
-                      --output "file_name.gzip"
+                      --output "file_name.gz"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
@@ -54085,7 +54085,7 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+gzip" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs" \
-                      --output "file_name.gzip"
+                      --output "file_name.gz"
     /api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections:
         get:
             description: Returns all connections of the stream instance for the specified project.To use this resource, the requesting API Key must have the Project Data Access roles, Project Owner role or Project Stream Processing Owner role.

--- a/tools/cli/test/data/split/dev/openapi-v2-2023-10-01.yaml
+++ b/tools/cli/test/data/split/dev/openapi-v2-2023-10-01.yaml
@@ -57000,14 +57000,14 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2023-10-01+csv" \
+                      --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2023-10-01+csv" \
+                      --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true"
     /api/atlas/v2/orgs/{orgId}/events:
         get:
@@ -58072,14 +58072,14 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2023-10-01+csv" \
+                      --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2023-10-01+csv" \
+                      --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true"
     /api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/csv:
         get:

--- a/tools/cli/test/data/split/dev/openapi-v2-2023-11-15.json
+++ b/tools/cli/test/data/split/dev/openapi-v2-2023-11-15.json
@@ -46263,12 +46263,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz\" \\\n  --output \"file_name.gz\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz\" \\\n  --output \"file_name.gz\""
           }
         ]
       }
@@ -48772,12 +48772,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz\" \\\n  --output \"file_name.gzip\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz\" \\\n  --output \"file_name.gz\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz\" \\\n  --output \"file_name.gzip\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz\" \\\n  --output \"file_name.gz\""
           }
         ]
       }
@@ -50668,12 +50668,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz\" \\\n  --output \"file_name.gz\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz\" \\\n  --output \"file_name.gz\""
           }
         ]
       }
@@ -62990,12 +62990,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs\" \\\n  --output \"file_name.gzip\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs\" \\\n  --output \"file_name.gz\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs\" \\\n  --output \"file_name.gzip\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs\" \\\n  --output \"file_name.gz\""
           }
         ]
       }

--- a/tools/cli/test/data/split/dev/openapi-v2-2023-11-15.json
+++ b/tools/cli/test/data/split/dev/openapi-v2-2023-11-15.json
@@ -65907,12 +65907,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
           }
         ]
       }

--- a/tools/cli/test/data/split/dev/openapi-v2-2023-11-15.json
+++ b/tools/cli/test/data/split/dev/openapi-v2-2023-11-15.json
@@ -46263,12 +46263,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
           }
         ]
       }
@@ -48772,12 +48772,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz\" \\\n  --output \"file_name.gzip\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz\" \\\n  --output \"file_name.gzip\""
           }
         ]
       }
@@ -50668,12 +50668,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
           }
         ]
       }
@@ -62990,12 +62990,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs\" \\\n  --output \"file_name.gzip\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs\" \\\n  --output \"file_name.gzip\""
           }
         ]
       }
@@ -65907,12 +65907,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
           }
         ]
       }
@@ -67178,12 +67178,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/csv?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/csv?pretty=true\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/csv?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/csv?pretty=true\""
           }
         ]
       }

--- a/tools/cli/test/data/split/dev/openapi-v2-2023-11-15.yaml
+++ b/tools/cli/test/data/split/dev/openapi-v2-2023-11-15.yaml
@@ -39683,7 +39683,7 @@ paths:
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
                       --header "Accept: application/vnd.atlas.2023-11-15+gzip" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz" \
-                      --output "file_name.gzip"
+                      --output "file_name.gz"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
@@ -39691,7 +39691,7 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+gzip" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz" \
-                      --output "file_name.gzip"
+                      --output "file_name.gz"
     /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/outageSimulation:
         delete:
             description: Ends a cluster outage simulation.
@@ -41572,7 +41572,7 @@ paths:
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
                       --header "Accept: application/vnd.atlas.2023-11-15+gzip" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz" \
-                      --output "file_name.gzip"
+                      --output "file_name.gz"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
@@ -41580,7 +41580,7 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+gzip" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz" \
-                      --output "file_name.gzip"
+                      --output "file_name.gz"
     /api/atlas/v2/groups/{groupId}/clusters/provider/regions:
         get:
             description: Returns the list of regions available for the specified cloud provider at the specified tier. To use this resource, the requesting API Key must have the Project Read Only role.
@@ -43697,7 +43697,7 @@ paths:
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
                       --header "Accept: application/vnd.atlas.2023-11-15+gzip" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz" \
-                      --output "file_name.gzip"
+                      --output "file_name.gz"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
@@ -43705,7 +43705,7 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+gzip" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz" \
-                      --output "file_name.gzip"
+                      --output "file_name.gz"
     /api/atlas/v2/groups/{groupId}/databaseUsers:
         get:
             description: Returns all database users that belong to the specified project. To use this resource, the requesting API Key must have the Project Read Only role.
@@ -55681,7 +55681,7 @@ paths:
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
                       --header "Accept: application/vnd.atlas.2023-11-15+gzip" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs" \
-                      --output "file_name.gzip"
+                      --output "file_name.gz"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
@@ -55689,7 +55689,7 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+gzip" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs" \
-                      --output "file_name.gzip"
+                      --output "file_name.gz"
     /api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections:
         get:
             description: Returns all connections of the stream instance for the specified project.To use this resource, the requesting API Key must have the Project Data Access roles, Project Owner role or Project Stream Processing Owner role.

--- a/tools/cli/test/data/split/dev/openapi-v2-2023-11-15.yaml
+++ b/tools/cli/test/data/split/dev/openapi-v2-2023-11-15.yaml
@@ -58604,14 +58604,14 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2023-11-15+csv" \
+                      --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2023-11-15+csv" \
+                      --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true"
     /api/atlas/v2/orgs/{orgId}/events:
         get:

--- a/tools/cli/test/data/split/dev/openapi-v2-2023-11-15.yaml
+++ b/tools/cli/test/data/split/dev/openapi-v2-2023-11-15.yaml
@@ -39681,15 +39681,17 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2023-11-15+json" \
-                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz?pretty=true"
+                      --header "Accept: application/vnd.atlas.2023-11-15+gzip" \
+                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz" \
+                      --output "file_name.gzip"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2023-11-15+json" \
-                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz?pretty=true"
+                      --header "Accept: application/vnd.atlas.2023-11-15+gzip" \
+                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz" \
+                      --output "file_name.gzip"
     /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/outageSimulation:
         delete:
             description: Ends a cluster outage simulation.
@@ -41568,15 +41570,17 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2023-11-15+json" \
-                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz?pretty=true"
+                      --header "Accept: application/vnd.atlas.2023-11-15+gzip" \
+                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz" \
+                      --output "file_name.gzip"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2023-11-15+json" \
-                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz?pretty=true"
+                      --header "Accept: application/vnd.atlas.2023-11-15+gzip" \
+                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz" \
+                      --output "file_name.gzip"
     /api/atlas/v2/groups/{groupId}/clusters/provider/regions:
         get:
             description: Returns the list of regions available for the specified cloud provider at the specified tier. To use this resource, the requesting API Key must have the Project Read Only role.
@@ -43691,15 +43695,17 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2023-11-15+json" \
-                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz?pretty=true"
+                      --header "Accept: application/vnd.atlas.2023-11-15+gzip" \
+                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz" \
+                      --output "file_name.gzip"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2023-11-15+json" \
-                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz?pretty=true"
+                      --header "Accept: application/vnd.atlas.2023-11-15+gzip" \
+                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz" \
+                      --output "file_name.gzip"
     /api/atlas/v2/groups/{groupId}/databaseUsers:
         get:
             description: Returns all database users that belong to the specified project. To use this resource, the requesting API Key must have the Project Read Only role.
@@ -55673,15 +55679,17 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2023-11-15+json" \
-                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs?pretty=true"
+                      --header "Accept: application/vnd.atlas.2023-11-15+gzip" \
+                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs" \
+                      --output "file_name.gzip"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2023-11-15+json" \
-                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs?pretty=true"
+                      --header "Accept: application/vnd.atlas.2023-11-15+gzip" \
+                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs" \
+                      --output "file_name.gzip"
     /api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections:
         get:
             description: Returns all connections of the stream instance for the specified project.To use this resource, the requesting API Key must have the Project Data Access roles, Project Owner role or Project Stream Processing Owner role.
@@ -58596,14 +58604,14 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2023-11-15+json" \
+                      --header "Accept: application/vnd.atlas.2023-11-15+csv" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2023-11-15+json" \
+                      --header "Accept: application/vnd.atlas.2023-11-15+csv" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true"
     /api/atlas/v2/orgs/{orgId}/events:
         get:
@@ -59755,14 +59763,14 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2023-11-15+json" \
+                      --header "Accept: application/vnd.atlas.2023-11-15+csv" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/csv?pretty=true"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2023-11-15+json" \
+                      --header "Accept: application/vnd.atlas.2023-11-15+csv" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/csv?pretty=true"
     /api/atlas/v2/orgs/{orgId}/invoices/pending:
         get:

--- a/tools/cli/test/data/split/dev/openapi-v2-2024-05-30.json
+++ b/tools/cli/test/data/split/dev/openapi-v2-2024-05-30.json
@@ -68115,12 +68115,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
           }
         ]
       }
@@ -69305,12 +69305,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true\""
           }
         ]
       }

--- a/tools/cli/test/data/split/dev/openapi-v2-2024-05-30.json
+++ b/tools/cli/test/data/split/dev/openapi-v2-2024-05-30.json
@@ -46697,12 +46697,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz\" \\\n  --output \"file_name.gz\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz\" \\\n  --output \"file_name.gz\""
           }
         ]
       }
@@ -50368,12 +50368,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz\" \\\n  --output \"file_name.gzip\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz\" \\\n  --output \"file_name.gz\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz\" \\\n  --output \"file_name.gzip\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz\" \\\n  --output \"file_name.gz\""
           }
         ]
       }
@@ -52264,12 +52264,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz\" \\\n  --output \"file_name.gz\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz\" \\\n  --output \"file_name.gz\""
           }
         ]
       }
@@ -64580,12 +64580,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs\" \\\n  --output \"file_name.gzip\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs\" \\\n  --output \"file_name.gz\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs\" \\\n  --output \"file_name.gzip\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs\" \\\n  --output \"file_name.gz\""
           }
         ]
       }

--- a/tools/cli/test/data/split/dev/openapi-v2-2024-05-30.json
+++ b/tools/cli/test/data/split/dev/openapi-v2-2024-05-30.json
@@ -46697,12 +46697,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
           }
         ]
       }
@@ -50368,12 +50368,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz\" \\\n  --output \"file_name.gzip\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz\" \\\n  --output \"file_name.gzip\""
           }
         ]
       }
@@ -52264,12 +52264,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
           }
         ]
       }
@@ -64580,12 +64580,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs\" \\\n  --output \"file_name.gzip\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs\" \\\n  --output \"file_name.gzip\""
           }
         ]
       }
@@ -68115,12 +68115,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
           }
         ]
       }
@@ -69305,12 +69305,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true\""
           }
         ]
       }
@@ -69386,12 +69386,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/csv?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/csv?pretty=true\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/csv?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/csv?pretty=true\""
           }
         ]
       }

--- a/tools/cli/test/data/split/dev/openapi-v2-2024-05-30.yaml
+++ b/tools/cli/test/data/split/dev/openapi-v2-2024-05-30.yaml
@@ -60588,14 +60588,14 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2024-05-30+csv" \
+                      --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2024-05-30+csv" \
+                      --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true"
     /api/atlas/v2/orgs/{orgId}/events:
         get:
@@ -61660,14 +61660,14 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2024-05-30+csv" \
+                      --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2024-05-30+csv" \
+                      --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true"
     /api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/csv:
         get:

--- a/tools/cli/test/data/split/dev/openapi-v2-2024-05-30.yaml
+++ b/tools/cli/test/data/split/dev/openapi-v2-2024-05-30.yaml
@@ -40002,7 +40002,7 @@ paths:
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
                       --header "Accept: application/vnd.atlas.2024-05-30+gzip" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz" \
-                      --output "file_name.gzip"
+                      --output "file_name.gz"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
@@ -40010,7 +40010,7 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+gzip" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz" \
-                      --output "file_name.gzip"
+                      --output "file_name.gz"
     /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/outageSimulation:
         delete:
             description: Ends a cluster outage simulation.
@@ -42966,7 +42966,7 @@ paths:
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
                       --header "Accept: application/vnd.atlas.2024-05-30+gzip" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz" \
-                      --output "file_name.gzip"
+                      --output "file_name.gz"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
@@ -42974,7 +42974,7 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+gzip" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz" \
-                      --output "file_name.gzip"
+                      --output "file_name.gz"
     /api/atlas/v2/groups/{groupId}/clusters/provider/regions:
         get:
             description: Returns the list of regions available for the specified cloud provider at the specified tier. To use this resource, the requesting API Key must have the Project Read Only role.
@@ -45091,7 +45091,7 @@ paths:
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
                       --header "Accept: application/vnd.atlas.2024-05-30+gzip" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz" \
-                      --output "file_name.gzip"
+                      --output "file_name.gz"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
@@ -45099,7 +45099,7 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+gzip" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz" \
-                      --output "file_name.gzip"
+                      --output "file_name.gz"
     /api/atlas/v2/groups/{groupId}/databaseUsers:
         get:
             description: Returns all database users that belong to the specified project. To use this resource, the requesting API Key must have the Project Read Only role.
@@ -57069,7 +57069,7 @@ paths:
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
                       --header "Accept: application/vnd.atlas.2024-05-30+gzip" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs" \
-                      --output "file_name.gzip"
+                      --output "file_name.gz"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
@@ -57077,7 +57077,7 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+gzip" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs" \
-                      --output "file_name.gzip"
+                      --output "file_name.gz"
     /api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections:
         get:
             description: Returns all connections of the stream instance for the specified project.To use this resource, the requesting API Key must have the Project Data Access roles, Project Owner role or Project Stream Processing Owner role.

--- a/tools/cli/test/data/split/dev/openapi-v2-2024-05-30.yaml
+++ b/tools/cli/test/data/split/dev/openapi-v2-2024-05-30.yaml
@@ -40000,15 +40000,17 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2024-05-30+json" \
-                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz?pretty=true"
+                      --header "Accept: application/vnd.atlas.2024-05-30+gzip" \
+                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz" \
+                      --output "file_name.gzip"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2024-05-30+json" \
-                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz?pretty=true"
+                      --header "Accept: application/vnd.atlas.2024-05-30+gzip" \
+                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz" \
+                      --output "file_name.gzip"
     /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/outageSimulation:
         delete:
             description: Ends a cluster outage simulation.
@@ -42962,15 +42964,17 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2024-05-30+json" \
-                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz?pretty=true"
+                      --header "Accept: application/vnd.atlas.2024-05-30+gzip" \
+                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz" \
+                      --output "file_name.gzip"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2024-05-30+json" \
-                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz?pretty=true"
+                      --header "Accept: application/vnd.atlas.2024-05-30+gzip" \
+                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz" \
+                      --output "file_name.gzip"
     /api/atlas/v2/groups/{groupId}/clusters/provider/regions:
         get:
             description: Returns the list of regions available for the specified cloud provider at the specified tier. To use this resource, the requesting API Key must have the Project Read Only role.
@@ -45085,15 +45089,17 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2024-05-30+json" \
-                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz?pretty=true"
+                      --header "Accept: application/vnd.atlas.2024-05-30+gzip" \
+                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz" \
+                      --output "file_name.gzip"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2024-05-30+json" \
-                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz?pretty=true"
+                      --header "Accept: application/vnd.atlas.2024-05-30+gzip" \
+                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz" \
+                      --output "file_name.gzip"
     /api/atlas/v2/groups/{groupId}/databaseUsers:
         get:
             description: Returns all database users that belong to the specified project. To use this resource, the requesting API Key must have the Project Read Only role.
@@ -57061,15 +57067,17 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2024-05-30+json" \
-                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs?pretty=true"
+                      --header "Accept: application/vnd.atlas.2024-05-30+gzip" \
+                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs" \
+                      --output "file_name.gzip"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2024-05-30+json" \
-                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs?pretty=true"
+                      --header "Accept: application/vnd.atlas.2024-05-30+gzip" \
+                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs" \
+                      --output "file_name.gzip"
     /api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections:
         get:
             description: Returns all connections of the stream instance for the specified project.To use this resource, the requesting API Key must have the Project Data Access roles, Project Owner role or Project Stream Processing Owner role.
@@ -60580,14 +60588,14 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2024-05-30+json" \
+                      --header "Accept: application/vnd.atlas.2024-05-30+csv" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2024-05-30+json" \
+                      --header "Accept: application/vnd.atlas.2024-05-30+csv" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true"
     /api/atlas/v2/orgs/{orgId}/events:
         get:
@@ -61652,14 +61660,14 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2024-05-30+json" \
+                      --header "Accept: application/vnd.atlas.2024-05-30+csv" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2024-05-30+json" \
+                      --header "Accept: application/vnd.atlas.2024-05-30+csv" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true"
     /api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/csv:
         get:
@@ -61739,14 +61747,14 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2024-05-30+json" \
+                      --header "Accept: application/vnd.atlas.2024-05-30+csv" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/csv?pretty=true"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2024-05-30+json" \
+                      --header "Accept: application/vnd.atlas.2024-05-30+csv" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/csv?pretty=true"
     /api/atlas/v2/orgs/{orgId}/invoices/pending:
         get:

--- a/tools/cli/test/data/split/dev/openapi-v2-2024-08-05.json
+++ b/tools/cli/test/data/split/dev/openapi-v2-2024-08-05.json
@@ -47024,12 +47024,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
           }
         ]
       }
@@ -50691,12 +50691,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz\" \\\n  --output \"file_name.gzip\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz\" \\\n  --output \"file_name.gzip\""
           }
         ]
       }
@@ -52587,12 +52587,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
           }
         ]
       }
@@ -64903,12 +64903,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs\" \\\n  --output \"file_name.gzip\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs\" \\\n  --output \"file_name.gzip\""
           }
         ]
       }
@@ -68438,12 +68438,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
           }
         ]
       }
@@ -69628,12 +69628,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true\""
           }
         ]
       }
@@ -69709,12 +69709,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/csv?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/csv?pretty=true\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/csv?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/csv?pretty=true\""
           }
         ]
       }

--- a/tools/cli/test/data/split/dev/openapi-v2-2024-08-05.json
+++ b/tools/cli/test/data/split/dev/openapi-v2-2024-08-05.json
@@ -47024,12 +47024,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz\" \\\n  --output \"file_name.gz\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz\" \\\n  --output \"file_name.gz\""
           }
         ]
       }
@@ -50691,12 +50691,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz\" \\\n  --output \"file_name.gzip\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz\" \\\n  --output \"file_name.gz\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz\" \\\n  --output \"file_name.gzip\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz\" \\\n  --output \"file_name.gz\""
           }
         ]
       }
@@ -52587,12 +52587,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz\" \\\n  --output \"file_name.gz\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz\" \\\n  --output \"file_name.gz\""
           }
         ]
       }
@@ -64903,12 +64903,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs\" \\\n  --output \"file_name.gzip\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs\" \\\n  --output \"file_name.gz\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs\" \\\n  --output \"file_name.gzip\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs\" \\\n  --output \"file_name.gz\""
           }
         ]
       }

--- a/tools/cli/test/data/split/dev/openapi-v2-2024-08-05.json
+++ b/tools/cli/test/data/split/dev/openapi-v2-2024-08-05.json
@@ -68438,12 +68438,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
           }
         ]
       }
@@ -69628,12 +69628,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true\""
           }
         ]
       }

--- a/tools/cli/test/data/split/dev/openapi-v2-2024-08-05.yaml
+++ b/tools/cli/test/data/split/dev/openapi-v2-2024-08-05.yaml
@@ -60969,14 +60969,14 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2024-08-05+csv" \
+                      --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2024-08-05+csv" \
+                      --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true"
     /api/atlas/v2/orgs/{orgId}/events:
         get:
@@ -62041,14 +62041,14 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2024-08-05+csv" \
+                      --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2024-08-05+csv" \
+                      --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true"
     /api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/csv:
         get:

--- a/tools/cli/test/data/split/dev/openapi-v2-2024-08-05.yaml
+++ b/tools/cli/test/data/split/dev/openapi-v2-2024-08-05.yaml
@@ -40385,15 +40385,17 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2024-08-05+json" \
-                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz?pretty=true"
+                      --header "Accept: application/vnd.atlas.2024-08-05+gzip" \
+                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz" \
+                      --output "file_name.gzip"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2024-08-05+json" \
-                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz?pretty=true"
+                      --header "Accept: application/vnd.atlas.2024-08-05+gzip" \
+                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz" \
+                      --output "file_name.gzip"
     /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/outageSimulation:
         delete:
             description: Ends a cluster outage simulation.
@@ -43343,15 +43345,17 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2024-08-05+json" \
-                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz?pretty=true"
+                      --header "Accept: application/vnd.atlas.2024-08-05+gzip" \
+                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz" \
+                      --output "file_name.gzip"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2024-08-05+json" \
-                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz?pretty=true"
+                      --header "Accept: application/vnd.atlas.2024-08-05+gzip" \
+                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz" \
+                      --output "file_name.gzip"
     /api/atlas/v2/groups/{groupId}/clusters/provider/regions:
         get:
             description: Returns the list of regions available for the specified cloud provider at the specified tier. To use this resource, the requesting API Key must have the Project Read Only role.
@@ -45466,15 +45470,17 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2024-08-05+json" \
-                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz?pretty=true"
+                      --header "Accept: application/vnd.atlas.2024-08-05+gzip" \
+                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz" \
+                      --output "file_name.gzip"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2024-08-05+json" \
-                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz?pretty=true"
+                      --header "Accept: application/vnd.atlas.2024-08-05+gzip" \
+                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz" \
+                      --output "file_name.gzip"
     /api/atlas/v2/groups/{groupId}/databaseUsers:
         get:
             description: Returns all database users that belong to the specified project. To use this resource, the requesting API Key must have the Project Read Only role.
@@ -57442,15 +57448,17 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2024-08-05+json" \
-                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs?pretty=true"
+                      --header "Accept: application/vnd.atlas.2024-08-05+gzip" \
+                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs" \
+                      --output "file_name.gzip"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2024-08-05+json" \
-                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs?pretty=true"
+                      --header "Accept: application/vnd.atlas.2024-08-05+gzip" \
+                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs" \
+                      --output "file_name.gzip"
     /api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections:
         get:
             description: Returns all connections of the stream instance for the specified project.To use this resource, the requesting API Key must have the Project Data Access roles, Project Owner role or Project Stream Processing Owner role.
@@ -60961,14 +60969,14 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2024-08-05+json" \
+                      --header "Accept: application/vnd.atlas.2024-08-05+csv" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2024-08-05+json" \
+                      --header "Accept: application/vnd.atlas.2024-08-05+csv" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true"
     /api/atlas/v2/orgs/{orgId}/events:
         get:
@@ -62033,14 +62041,14 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2024-08-05+json" \
+                      --header "Accept: application/vnd.atlas.2024-08-05+csv" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2024-08-05+json" \
+                      --header "Accept: application/vnd.atlas.2024-08-05+csv" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true"
     /api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/csv:
         get:
@@ -62120,14 +62128,14 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2024-08-05+json" \
+                      --header "Accept: application/vnd.atlas.2024-08-05+csv" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/csv?pretty=true"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2024-08-05+json" \
+                      --header "Accept: application/vnd.atlas.2024-08-05+csv" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/csv?pretty=true"
     /api/atlas/v2/orgs/{orgId}/invoices/pending:
         get:

--- a/tools/cli/test/data/split/dev/openapi-v2-2024-08-05.yaml
+++ b/tools/cli/test/data/split/dev/openapi-v2-2024-08-05.yaml
@@ -40387,7 +40387,7 @@ paths:
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
                       --header "Accept: application/vnd.atlas.2024-08-05+gzip" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz" \
-                      --output "file_name.gzip"
+                      --output "file_name.gz"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
@@ -40395,7 +40395,7 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+gzip" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz" \
-                      --output "file_name.gzip"
+                      --output "file_name.gz"
     /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/outageSimulation:
         delete:
             description: Ends a cluster outage simulation.
@@ -43347,7 +43347,7 @@ paths:
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
                       --header "Accept: application/vnd.atlas.2024-08-05+gzip" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz" \
-                      --output "file_name.gzip"
+                      --output "file_name.gz"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
@@ -43355,7 +43355,7 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+gzip" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz" \
-                      --output "file_name.gzip"
+                      --output "file_name.gz"
     /api/atlas/v2/groups/{groupId}/clusters/provider/regions:
         get:
             description: Returns the list of regions available for the specified cloud provider at the specified tier. To use this resource, the requesting API Key must have the Project Read Only role.
@@ -45472,7 +45472,7 @@ paths:
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
                       --header "Accept: application/vnd.atlas.2024-08-05+gzip" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz" \
-                      --output "file_name.gzip"
+                      --output "file_name.gz"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
@@ -45480,7 +45480,7 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+gzip" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz" \
-                      --output "file_name.gzip"
+                      --output "file_name.gz"
     /api/atlas/v2/groups/{groupId}/databaseUsers:
         get:
             description: Returns all database users that belong to the specified project. To use this resource, the requesting API Key must have the Project Read Only role.
@@ -57450,7 +57450,7 @@ paths:
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
                       --header "Accept: application/vnd.atlas.2024-08-05+gzip" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs" \
-                      --output "file_name.gzip"
+                      --output "file_name.gz"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
@@ -57458,7 +57458,7 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+gzip" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs" \
-                      --output "file_name.gzip"
+                      --output "file_name.gz"
     /api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections:
         get:
             description: Returns all connections of the stream instance for the specified project.To use this resource, the requesting API Key must have the Project Data Access roles, Project Owner role or Project Stream Processing Owner role.

--- a/tools/cli/test/data/split/dev/openapi-v2-2025-01-01.json
+++ b/tools/cli/test/data/split/dev/openapi-v2-2025-01-01.json
@@ -47552,12 +47552,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
           }
         ]
       }
@@ -51219,12 +51219,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz\" \\\n  --output \"file_name.gzip\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz\" \\\n  --output \"file_name.gzip\""
           }
         ]
       }
@@ -53115,12 +53115,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
           }
         ]
       }
@@ -65431,12 +65431,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs\" \\\n  --output \"file_name.gzip\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs\" \\\n  --output \"file_name.gzip\""
           }
         ]
       }
@@ -69386,12 +69386,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
           }
         ]
       }
@@ -70576,12 +70576,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true\""
           }
         ]
       }
@@ -70657,12 +70657,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/csv?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/csv?pretty=true\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/csv?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/csv?pretty=true\""
           }
         ]
       }

--- a/tools/cli/test/data/split/dev/openapi-v2-2025-01-01.json
+++ b/tools/cli/test/data/split/dev/openapi-v2-2025-01-01.json
@@ -69386,12 +69386,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true\""
           }
         ]
       }
@@ -70576,12 +70576,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+csv\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true\""
           }
         ]
       }

--- a/tools/cli/test/data/split/dev/openapi-v2-2025-01-01.json
+++ b/tools/cli/test/data/split/dev/openapi-v2-2025-01-01.json
@@ -47552,12 +47552,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz\" \\\n  --output \"file_name.gz\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz\" \\\n  --output \"file_name.gz\""
           }
         ]
       }
@@ -51219,12 +51219,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz\" \\\n  --output \"file_name.gzip\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz\" \\\n  --output \"file_name.gz\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz\" \\\n  --output \"file_name.gzip\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz\" \\\n  --output \"file_name.gz\""
           }
         ]
       }
@@ -53115,12 +53115,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz\" \\\n  --output \"file_name.gz\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz\" \\\n  --output \"file_name.gzip\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz\" \\\n  --output \"file_name.gz\""
           }
         ]
       }
@@ -65431,12 +65431,12 @@
           {
             "lang": "cURL",
             "label": "curl (Service Accounts)",
-            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs\" \\\n  --output \"file_name.gzip\""
+            "source": "curl --header \"Authorization: Bearer ${ACCESS_TOKEN}\" \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs\" \\\n  --output \"file_name.gz\""
           },
           {
             "lang": "cURL",
             "label": "curl (Digest)",
-            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs\" \\\n  --output \"file_name.gzip\""
+            "source": "curl --user \"${PUBLIC_KEY}:${PRIVATE_KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+gzip\" \\\n  -X GET \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs\" \\\n  --output \"file_name.gz\""
           }
         ]
       }

--- a/tools/cli/test/data/split/dev/openapi-v2-2025-01-01.yaml
+++ b/tools/cli/test/data/split/dev/openapi-v2-2025-01-01.yaml
@@ -40797,15 +40797,17 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2025-01-01+json" \
-                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz?pretty=true"
+                      --header "Accept: application/vnd.atlas.2025-01-01+gzip" \
+                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz" \
+                      --output "file_name.gzip"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2025-01-01+json" \
-                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz?pretty=true"
+                      --header "Accept: application/vnd.atlas.2025-01-01+gzip" \
+                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz" \
+                      --output "file_name.gzip"
     /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/outageSimulation:
         delete:
             description: Ends a cluster outage simulation.
@@ -43755,15 +43757,17 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2025-01-01+json" \
-                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz?pretty=true"
+                      --header "Accept: application/vnd.atlas.2025-01-01+gzip" \
+                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz" \
+                      --output "file_name.gzip"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2025-01-01+json" \
-                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz?pretty=true"
+                      --header "Accept: application/vnd.atlas.2025-01-01+gzip" \
+                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz" \
+                      --output "file_name.gzip"
     /api/atlas/v2/groups/{groupId}/clusters/provider/regions:
         get:
             description: Returns the list of regions available for the specified cloud provider at the specified tier. To use this resource, the requesting API Key must have the Project Read Only role.
@@ -45878,15 +45882,17 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2025-01-01+json" \
-                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz?pretty=true"
+                      --header "Accept: application/vnd.atlas.2025-01-01+gzip" \
+                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz" \
+                      --output "file_name.gzip"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2025-01-01+json" \
-                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz?pretty=true"
+                      --header "Accept: application/vnd.atlas.2025-01-01+gzip" \
+                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz" \
+                      --output "file_name.gzip"
     /api/atlas/v2/groups/{groupId}/databaseUsers:
         get:
             description: Returns all database users that belong to the specified project. To use this resource, the requesting API Key must have the Project Read Only role.
@@ -57854,15 +57860,17 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2025-01-01+json" \
-                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs?pretty=true"
+                      --header "Accept: application/vnd.atlas.2025-01-01+gzip" \
+                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs" \
+                      --output "file_name.gzip"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2025-01-01+json" \
-                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs?pretty=true"
+                      --header "Accept: application/vnd.atlas.2025-01-01+gzip" \
+                      -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs" \
+                      --output "file_name.gzip"
     /api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections:
         get:
             description: Returns all connections of the stream instance for the specified project.To use this resource, the requesting API Key must have the Project Data Access roles, Project Owner role or Project Stream Processing Owner role.
@@ -61783,14 +61791,14 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2025-01-01+json" \
+                      --header "Accept: application/vnd.atlas.2025-01-01+csv" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2025-01-01+json" \
+                      --header "Accept: application/vnd.atlas.2025-01-01+csv" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true"
     /api/atlas/v2/orgs/{orgId}/events:
         get:
@@ -62855,14 +62863,14 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2025-01-01+json" \
+                      --header "Accept: application/vnd.atlas.2025-01-01+csv" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2025-01-01+json" \
+                      --header "Accept: application/vnd.atlas.2025-01-01+csv" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true"
     /api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/csv:
         get:
@@ -62942,14 +62950,14 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2025-01-01+json" \
+                      --header "Accept: application/vnd.atlas.2025-01-01+csv" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/csv?pretty=true"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2025-01-01+json" \
+                      --header "Accept: application/vnd.atlas.2025-01-01+csv" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/csv?pretty=true"
     /api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/lineItems/:search:
         get:

--- a/tools/cli/test/data/split/dev/openapi-v2-2025-01-01.yaml
+++ b/tools/cli/test/data/split/dev/openapi-v2-2025-01-01.yaml
@@ -40799,7 +40799,7 @@ paths:
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
                       --header "Accept: application/vnd.atlas.2025-01-01+gzip" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz" \
-                      --output "file_name.gzip"
+                      --output "file_name.gz"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
@@ -40807,7 +40807,7 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+gzip" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/queryLogs.gz" \
-                      --output "file_name.gzip"
+                      --output "file_name.gz"
     /api/atlas/v2/groups/{groupId}/clusters/{clusterName}/outageSimulation:
         delete:
             description: Ends a cluster outage simulation.
@@ -43759,7 +43759,7 @@ paths:
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
                       --header "Accept: application/vnd.atlas.2025-01-01+gzip" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz" \
-                      --output "file_name.gzip"
+                      --output "file_name.gz"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
@@ -43767,7 +43767,7 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+gzip" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{hostName}/logs/{logName}.gz" \
-                      --output "file_name.gzip"
+                      --output "file_name.gz"
     /api/atlas/v2/groups/{groupId}/clusters/provider/regions:
         get:
             description: Returns the list of regions available for the specified cloud provider at the specified tier. To use this resource, the requesting API Key must have the Project Read Only role.
@@ -45884,7 +45884,7 @@ paths:
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
                       --header "Accept: application/vnd.atlas.2025-01-01+gzip" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz" \
-                      --output "file_name.gzip"
+                      --output "file_name.gz"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
@@ -45892,7 +45892,7 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+gzip" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/queryLogs.gz" \
-                      --output "file_name.gzip"
+                      --output "file_name.gz"
     /api/atlas/v2/groups/{groupId}/databaseUsers:
         get:
             description: Returns all database users that belong to the specified project. To use this resource, the requesting API Key must have the Project Read Only role.
@@ -57862,7 +57862,7 @@ paths:
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
                       --header "Accept: application/vnd.atlas.2025-01-01+gzip" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs" \
-                      --output "file_name.gzip"
+                      --output "file_name.gz"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
@@ -57870,7 +57870,7 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+gzip" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/auditLogs" \
-                      --output "file_name.gzip"
+                      --output "file_name.gz"
     /api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections:
         get:
             description: Returns all connections of the stream instance for the specified project.To use this resource, the requesting API Key must have the Project Data Access roles, Project Owner role or Project Stream Processing Owner role.

--- a/tools/cli/test/data/split/dev/openapi-v2-2025-01-01.yaml
+++ b/tools/cli/test/data/split/dev/openapi-v2-2025-01-01.yaml
@@ -61791,14 +61791,14 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2025-01-01+csv" \
+                      --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2025-01-01+csv" \
+                      --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage/{token}?pretty=true"
     /api/atlas/v2/orgs/{orgId}/events:
         get:
@@ -62863,14 +62863,14 @@ paths:
                   lang: cURL
                   source: |-
                     curl --header "Authorization: Bearer ${ACCESS_TOKEN}" \
-                      --header "Accept: application/vnd.atlas.2025-01-01+csv" \
+                      --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true"
                 - label: curl (Digest)
                   lang: cURL
                   source: |-
                     curl --user "${PUBLIC_KEY}:${PRIVATE_KEY}" \
                       --digest \
-                      --header "Accept: application/vnd.atlas.2025-01-01+csv" \
+                      --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       -X GET "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}?pretty=true"
     /api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/csv:
         get:


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-333549

<!--
What issue does this PR address? (for example, #1234), remove this section if none.
-->

This PR fixes two bugs related to the logic to generate curl examples for endpoints not supporting the json accept header:

- General bugs: the autogeneration logic was adding the `Accept: application/vnd.atlas.<api_version>+json"` to endpoints not supporting `json`
- gzip bug: the curl examples were missing the `--output` flag for endpoints supporting only `gzip` 




## Example:
<img width="882" height="388" alt="Screenshot 2025-07-28 at 15 35 10" src="https://github.com/user-attachments/assets/fd6dec24-05c6-4c05-bad8-53c07e7a6c54" />



