### PR TITLE
feat: add apix 1 as owner of tools/cli

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # Maintained by the APIx team
 *                         @mongodb/apix
-/tools/cli/               @mongodb/apix-2
+/tools/cli/               @mongodb/apix-2 @mongodb/apix1
 /tools/spectral/ipa/      @mongodb/apix1
 /tools/postman/           @mongodb/apix1
 package.json              @mongodb/apix1


### PR DESCRIPTION
## Proposed changes

This PR adds apix1 as co-owner of tools/cli. We will remove the APIx2 after the handover