### PR TITLE
fix: make check on PR titles more lenient

### DIFF
--- a/.github/workflows/semantic-commit.yml
+++ b/.github/workflows/semantic-commit.yml
@@ -30,9 +30,9 @@ jobs:
             ipa
             prod
           requireScope: false
-          subjectPattern: "^[A-Z].+[^.]$"
+          subjectPattern: "^[A-Za-z].+[^.]$"
           subjectPatternError: |
             The subject "{subject}" found in the pull request title "{title}"
             didn't match the configured pattern. Please ensure that the subject
-            starts with an uppercase letter and doesn't end with a period.
+            starts with a letter and doesn't end with a period.
           validateSingleCommit: false


### PR DESCRIPTION
## Proposed changes
In order to prevent this check from failing for dependabot it should allow PR title subjects to begin with lowercase letters.