### PR TITLE
fix(ipa): Update override logic to be more lenient

### DIFF
--- a/tools/spectral/ipa/__tests__/utils/validations/validateOperationIdAndReturnErrors.test.js
+++ b/tools/spectral/ipa/__tests__/utils/validations/validateOperationIdAndReturnErrors.test.js
@@ -202,6 +202,19 @@ describe('tools/spectral/ipa/rulesets/functions/utils/validations/validateOperat
         ['paths', '/some/{id}/resource/{resourceId}/long/{id}/childResource/{id}', 'get']
       )
     ).toHaveLength(0);
+
+    // valid override on short opID
+    expect(
+      validateOperationIdAndReturnErrors(
+        'get',
+        '/some/{id}/resource/{resourceId}',
+        {
+          operationId: 'getSomeResource',
+          'x-xgen-operation-id-override': 'getResource',
+        },
+        ['paths', '/some/{id}/resource/{resourceId}', 'get']
+      )
+    ).toHaveLength(0);
   });
 
   it('should return errors for invalid operation ID', () => {
@@ -254,26 +267,6 @@ describe('tools/spectral/ipa/rulesets/functions/utils/validations/validateOperat
         path: ['paths', '/some/{id}/resource/{resourceId}/long/{id}/childResource', 'post', 'operationId'],
         message:
           "The Operation ID is longer than 4 words. Please add an 'x-xgen-operation-id-override' extension to the operation with a shorter operation ID. For example: 'createLongChildResource'.",
-      },
-    ]);
-  });
-
-  it('should return errors for valid operation ID with unnecessary override', () => {
-    expect(
-      validateOperationIdAndReturnErrors(
-        'get',
-        '/some/{id}/resource/{resourceId}',
-        {
-          operationId: 'getSomeResource',
-          'x-xgen-operation-id-override': 'getResource',
-        },
-        ['paths', '/some/{id}/resource/{resourceId}', 'get']
-      )
-    ).toEqual([
-      {
-        path: ['paths', '/some/{id}/resource/{resourceId}', 'get', 'x-xgen-operation-id-override'],
-        message:
-          "Please remove the 'x-xgen-operation-id-override' extension from the operation. The Operation ID already has a valid length (<=4 words).",
       },
     ]);
   });

--- a/tools/spectral/ipa/rulesets/functions/IPA104ValidOperationID.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA104ValidOperationID.js
@@ -6,7 +6,7 @@ import {
 } from './utils/collectionUtils.js';
 import { hasException } from './utils/exceptions.js';
 import { getResourcePathItems, isCustomMethodIdentifier } from './utils/resourceEvaluation.js';
-import { hasCustomMethodOverride, hasMethodVerbOverride } from './utils/extensions.js';
+import { hasCustomMethodOverride, hasMethodVerbOverride, VERB_OVERRIDE_EXTENSION } from './utils/extensions.js';
 import { isInvalidGetMethod } from './utils/methodLogic.js';
 import { validateOperationIdAndReturnErrors } from './utils/validations/validateOperationIdAndReturnErrors.js';
 
@@ -32,6 +32,9 @@ export default (input, { methodName }, { path, documentInventory }) => {
   }
 
   try {
+    if (hasMethodVerbOverride(input, methodName)) {
+      methodName = input[VERB_OVERRIDE_EXTENSION].verb;
+    }
     const errors = validateOperationIdAndReturnErrors(methodName, resourcePath, input, path);
 
     if (errors.length > 0) {

--- a/tools/spectral/ipa/rulesets/functions/IPA105ValidOperationID.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA105ValidOperationID.js
@@ -7,7 +7,7 @@ import {
 } from './utils/collectionUtils.js';
 import { getResourcePathItems, isCustomMethodIdentifier } from './utils/resourceEvaluation.js';
 import { isInvalidListMethod } from './utils/methodLogic.js';
-import { hasCustomMethodOverride, hasMethodVerbOverride } from './utils/extensions.js';
+import { hasCustomMethodOverride, hasMethodVerbOverride, VERB_OVERRIDE_EXTENSION } from './utils/extensions.js';
 import { validateOperationIdAndReturnErrors } from './utils/validations/validateOperationIdAndReturnErrors.js';
 
 const RULE_NAME = 'xgen-IPA-105-valid-operation-id';
@@ -29,6 +29,10 @@ export default (input, { methodName }, { path, documentInventory }) => {
   if (hasException(input, RULE_NAME)) {
     collectException(input, RULE_NAME, path);
     return;
+  }
+
+  if (hasMethodVerbOverride(input, methodName)) {
+    methodName = input[VERB_OVERRIDE_EXTENSION].verb;
   }
 
   try {

--- a/tools/spectral/ipa/rulesets/functions/IPA106ValidOperationID.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA106ValidOperationID.js
@@ -6,7 +6,7 @@ import {
   handleInternalError,
 } from './utils/collectionUtils.js';
 import { isCustomMethodIdentifier } from './utils/resourceEvaluation.js';
-import { hasCustomMethodOverride } from './utils/extensions.js';
+import { hasCustomMethodOverride, hasMethodVerbOverride, VERB_OVERRIDE_EXTENSION } from './utils/extensions.js';
 import { validateOperationIdAndReturnErrors } from './utils/validations/validateOperationIdAndReturnErrors.js';
 
 const RULE_NAME = 'xgen-IPA-106-valid-operation-id';
@@ -21,6 +21,10 @@ export default (input, { methodName }, { path }) => {
   if (hasException(input, RULE_NAME)) {
     collectException(input, RULE_NAME, path);
     return;
+  }
+
+  if (hasMethodVerbOverride(input, methodName)) {
+    methodName = input[VERB_OVERRIDE_EXTENSION].verb;
   }
 
   try {

--- a/tools/spectral/ipa/rulesets/functions/IPA107ValidOperationID.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA107ValidOperationID.js
@@ -6,7 +6,7 @@ import {
   handleInternalError,
 } from './utils/collectionUtils.js';
 import { isCustomMethodIdentifier } from './utils/resourceEvaluation.js';
-import { hasCustomMethodOverride } from './utils/extensions.js';
+import { hasCustomMethodOverride, hasMethodVerbOverride, VERB_OVERRIDE_EXTENSION } from './utils/extensions.js';
 import { validateOperationIdAndReturnErrors } from './utils/validations/validateOperationIdAndReturnErrors.js';
 
 const RULE_NAME = 'xgen-IPA-107-valid-operation-id';
@@ -21,6 +21,10 @@ export default (input, { methodName }, { path }) => {
   if (hasException(input, RULE_NAME)) {
     collectException(input, RULE_NAME, path);
     return;
+  }
+
+  if (hasMethodVerbOverride(input, methodName)) {
+    methodName = input[VERB_OVERRIDE_EXTENSION].verb;
   }
 
   try {

--- a/tools/spectral/ipa/rulesets/functions/IPA108ValidOperationID.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA108ValidOperationID.js
@@ -6,7 +6,7 @@ import {
   handleInternalError,
 } from './utils/collectionUtils.js';
 import { isCustomMethodIdentifier } from './utils/resourceEvaluation.js';
-import { hasCustomMethodOverride } from './utils/extensions.js';
+import { hasCustomMethodOverride, hasMethodVerbOverride, VERB_OVERRIDE_EXTENSION } from './utils/extensions.js';
 import { validateOperationIdAndReturnErrors } from './utils/validations/validateOperationIdAndReturnErrors.js';
 
 const RULE_NAME = 'xgen-IPA-108-valid-operation-id';
@@ -21,6 +21,10 @@ export default (input, { methodName }, { path }) => {
   if (hasException(input, RULE_NAME)) {
     collectException(input, RULE_NAME, path);
     return;
+  }
+
+  if (hasMethodVerbOverride(input, methodName)) {
+    methodName = input[VERB_OVERRIDE_EXTENSION].verb;
   }
 
   try {

--- a/tools/spectral/ipa/rulesets/functions/utils/extensions.js
+++ b/tools/spectral/ipa/rulesets/functions/utils/extensions.js
@@ -19,7 +19,7 @@ export function hasCustomMethodOverride(object) {
  * @returns {boolean} true if the object has the extension with the given verb, otherwise false
  */
 export function hasMethodVerbOverride(object, verb) {
-  return hasVerbOverride(object) && object[VERB_OVERRIDE_EXTENSION].verb === verb;
+  return hasVerbOverride(object) && object[VERB_OVERRIDE_EXTENSION].verb.startsWith(verb);
 }
 
 /**

--- a/tools/spectral/ipa/rulesets/functions/utils/validations/validateOperationIdAndReturnErrors.js
+++ b/tools/spectral/ipa/rulesets/functions/utils/validations/validateOperationIdAndReturnErrors.js
@@ -8,10 +8,6 @@ const TOO_LONG_OP_ID_ERROR_MESSAGE =
   "The Operation ID is longer than 4 words. Please add an '" +
   OPERATION_ID_OVERRIDE_EXTENSION +
   "' extension to the operation with a shorter operation ID.";
-const REMOVE_OP_ID_OVERRIDE_ERROR_MESSAGE =
-  "Please remove the '" +
-  OPERATION_ID_OVERRIDE_EXTENSION +
-  "' extension from the operation. The Operation ID already has a valid length (<=4 words).";
 
 /**
  * Validates the operationId of an operation object and returns errors if it does not match the expected format. Also validates that the operationId override, if present, follows the expected rules.
@@ -37,26 +33,23 @@ export function validateOperationIdAndReturnErrors(methodName, resourcePath, ope
   }
 
   const operationIdOverridePath = path.concat([OPERATION_ID_OVERRIDE_EXTENSION]);
-  if (numberOfWords(operationId) > 4) {
-    if (!hasOperationIdOverride(operationObject)) {
-      errors.push({
-        path: operationIdPath,
-        message: TOO_LONG_OP_ID_ERROR_MESSAGE + " For example: '" + shortenOperationId(expectedOperationId) + "'.",
-      });
-      return errors;
-    }
+  if (numberOfWords(operationId) > 4 && !hasOperationIdOverride(operationObject)) {
+    errors.push({
+      path: operationIdPath,
+      message: TOO_LONG_OP_ID_ERROR_MESSAGE + " For example: '" + shortenOperationId(expectedOperationId) + "'.",
+    });
+    return errors;
+  }
+
+  if (hasOperationIdOverride(operationObject)) {
     const overrideErrors = validateOperationIdOverride(
       operationIdOverridePath,
       getOperationIdOverride(operationObject),
       expectedOperationId
     );
     errors.push(...overrideErrors);
-  } else if (hasOperationIdOverride(operationObject)) {
-    errors.push({
-      path: operationIdOverridePath,
-      message: REMOVE_OP_ID_OVERRIDE_ERROR_MESSAGE,
-    });
   }
+
   return errors;
 }
 


### PR DESCRIPTION
## Proposed changes
Following [discussions](https://docs.google.com/document/d/14H3FIJMO79zuqSPTGPwqXze7_TyQUsKdHuywiwVk4RY/edit?tab=t.0#heading=h.dssie6h3wy7x) on accommodating customer experience with Operation ID overrides, the logic has been updated to:
- **Support `x-xgen-method-verb-override` usage on non-custom methods** This change allows for nouns that do not appear in the resource path to be included in the Operation ID. ie: `getGroupStream` -> `getGroupStreamInstance`
- **Allow `x-xgen-operation-id-override` to be present on any length of Operation Id.** This override is still required for ids of length > 4, but now it can also be used to change shorter ids. ie: `getGroupStreamInstance` -> `getStreamInstance`.

_Jira ticket:_ [CLOUDP-335029](https://jira.mongodb.org/browse/CLOUDP-335029)