### PR TITLE
fix: Add missing env to IPA release workflow

### DIFF
--- a/.github/workflows/ipa-release.yml
+++ b/.github/workflows/ipa-release.yml
@@ -24,6 +24,8 @@ jobs:
             .github/scripts
     - name: Fetch Versions
       id: version_check
+      env:   
+        BASE_BRANCH: ${{ github.ref_name }}
       run: |
         version_changed=$(./.github/scripts/ipa_version_check.sh)  
         echo "Version changed? ${version_changed}"  


### PR DESCRIPTION
## Proposed changes

Added missing env variable for version check script. Cause for [failing test run](https://github.com/mongodb/openapi/actions/runs/16676210537).