### PR TITLE
ci: update ipa release to allow workflow dispatch

### DIFF
--- a/.github/workflows/ipa-release.yml
+++ b/.github/workflows/ipa-release.yml
@@ -2,6 +2,12 @@ name: Release IPA Package
 
 on:  
   workflow_dispatch:
+    inputs:
+      workflow_call:
+        description: 'To distinguish workflow_call from regular push'
+        type: boolean
+        required: false
+        default: true
   push: 
     branches:
       - main
@@ -10,12 +16,12 @@ on:
 
 jobs:
   check-version:
-    runs-on: ubuntu-latest  
-    outputs:  
-      version_changed: ${{ steps.version_check.outputs.version_changed }}  
-      
+    runs-on: ubuntu-latest
+    outputs:
+      version_changed: ${{ steps.version_check.outputs.version_changed }}
+
     steps:
-    - name: Checkout Repository  
+    - name: Checkout Repository
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       with:
           fetch-depth: 0
@@ -24,7 +30,7 @@ jobs:
             .github/scripts
     - name: Fetch Versions
       id: version_check
-      env:   
+      env:
         BASE_BRANCH: "main~1"
       run: |
         version_changed=$(./.github/scripts/ipa_version_check.sh)  
@@ -37,7 +43,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: ${{ needs.check-version.outputs.version_changed == 'true' }}
+    if: ${{ needs.check-version.outputs.version_changed == 'true' || inputs.externall_call }}
 
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332

--- a/.github/workflows/ipa-release.yml
+++ b/.github/workflows/ipa-release.yml
@@ -43,7 +43,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: ${{ needs.check-version.outputs.version_changed == 'true' || inputs.externall_call }}
+    if: ${{ needs.check-version.outputs.version_changed == 'true' || inputs.workflow_call }}
 
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332


### PR DESCRIPTION
## Proposed changes

Update ipa release workflow to trigger on dispatch regardless of version change, or on push when version is changed.
