### PR TITLE
feat(ipa): error on unneeded exceptions IPA 005-104

### DIFF
--- a/tools/spectral/ipa/__tests__/utils/collectionUtils.test.js
+++ b/tools/spectral/ipa/__tests__/utils/collectionUtils.test.js
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, it, jest } from '@jest/globals';
-import { collectExceptionAdoptionViolations } from '../../rulesets/functions/utils/collectionUtils.js';
+import {
+  evaluateAndCollectAdoptionStatus,
+  evaluateAndCollectAdoptionStatusWithoutExceptions,
+} from '../../rulesets/functions/utils/collectionUtils.js';
 import collector from '../../metrics/collector.js';
 
 const TEST_ERROR_MESSAGE = 'error message';
@@ -36,7 +39,7 @@ describe('tools/spectral/ipa/rulesets/functions/utils/collectionUtils.js', () =>
         },
       ];
 
-      const result = collectExceptionAdoptionViolations(testErrors, testRuleName, testObject, testPath);
+      const result = evaluateAndCollectAdoptionStatus(testErrors, testRuleName, testObject, testPath);
 
       expect(result).toEqual(testErrors);
       expect(collector.add).toHaveBeenCalledTimes(1);
@@ -59,7 +62,7 @@ describe('tools/spectral/ipa/rulesets/functions/utils/collectionUtils.js', () =>
         },
       ];
 
-      const result = collectExceptionAdoptionViolations(testErrors, testRuleName, testObject, testPath);
+      const result = evaluateAndCollectAdoptionStatus(testErrors, testRuleName, testObject, testPath);
 
       expect(result).toEqual(testErrors);
       expect(collector.add).toHaveBeenCalledTimes(1);
@@ -74,7 +77,7 @@ describe('tools/spectral/ipa/rulesets/functions/utils/collectionUtils.js', () =>
       };
       const testNoErrors = [];
 
-      const result = collectExceptionAdoptionViolations(testNoErrors, testRuleName, testObject, testPath);
+      const result = evaluateAndCollectAdoptionStatus(testNoErrors, testRuleName, testObject, testPath);
 
       expect(result).toEqual(undefined);
       expect(collector.add).toHaveBeenCalledTimes(1);
@@ -97,7 +100,7 @@ describe('tools/spectral/ipa/rulesets/functions/utils/collectionUtils.js', () =>
         },
       ];
 
-      const result = collectExceptionAdoptionViolations(testErrors, testRuleName, testObject, testPath);
+      const result = evaluateAndCollectAdoptionStatus(testErrors, testRuleName, testObject, testPath);
 
       expect(result).toEqual(undefined);
       expect(collector.add).toHaveBeenCalledTimes(1);
@@ -114,7 +117,7 @@ describe('tools/spectral/ipa/rulesets/functions/utils/collectionUtils.js', () =>
         },
       };
 
-      const result = collectExceptionAdoptionViolations([], testRuleName, testObject, testPath);
+      const result = evaluateAndCollectAdoptionStatus([], testRuleName, testObject, testPath);
 
       expect(result.length).toEqual(1);
       expect(Object.keys(result[0])).toEqual(['path', 'message']);
@@ -124,6 +127,41 @@ describe('tools/spectral/ipa/rulesets/functions/utils/collectionUtils.js', () =>
       );
       expect(collector.add).toHaveBeenCalledTimes(1);
       expect(collector.add).toHaveBeenCalledWith(TEST_ENTRY_TYPE.VIOLATION, testPath, testRuleName);
+    });
+  });
+
+  describe('evaluateAndCollectAdoptionStatusWithoutExceptions', () => {
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('returns errors and collects violations when there are errors', () => {
+      const testRuleName = 'xgen-IPA-XXX-rule';
+      const testPath = ['paths', '/resource'];
+      const testErrors = [
+        {
+          path: testPath,
+          message: TEST_ERROR_MESSAGE,
+        },
+      ];
+
+      const result = evaluateAndCollectAdoptionStatusWithoutExceptions(testErrors, testRuleName, testPath);
+
+      expect(result).toEqual(testErrors);
+      expect(collector.add).toHaveBeenCalledTimes(1);
+      expect(collector.add).toHaveBeenCalledWith(TEST_ENTRY_TYPE.VIOLATION, testPath, testRuleName);
+    });
+
+    it('returns empty and collects adoptions when there are no errors', () => {
+      const testRuleName = 'xgen-IPA-XXX-rule';
+      const testPath = ['paths', '/resource'];
+      const testNoErrors = [];
+
+      const result = evaluateAndCollectAdoptionStatusWithoutExceptions(testNoErrors, testRuleName, testPath);
+
+      expect(result).toEqual(undefined);
+      expect(collector.add).toHaveBeenCalledTimes(1);
+      expect(collector.add).toHaveBeenCalledWith(TEST_ENTRY_TYPE.ADOPTION, testPath, testRuleName);
     });
   });
 });

--- a/tools/spectral/ipa/__tests__/utils/collectionUtils.test.js
+++ b/tools/spectral/ipa/__tests__/utils/collectionUtils.test.js
@@ -1,0 +1,129 @@
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+import { collectExceptionAdoptionViolations } from '../../rulesets/functions/utils/collectionUtils.js';
+import collector from '../../metrics/collector.js';
+
+const TEST_ERROR_MESSAGE = 'error message';
+const TEST_ENTRY_TYPE = {
+  EXCEPTION: 'exceptions',
+  VIOLATION: 'violations',
+  ADOPTION: 'adoptions',
+};
+
+jest.mock('../../metrics/collector.js', () => {
+  return {
+    getInstance: jest.fn(),
+    add: jest.fn(),
+    EntryType: TEST_ENTRY_TYPE,
+  };
+});
+
+describe('tools/spectral/ipa/rulesets/functions/utils/collectionUtils.js', () => {
+  describe('collectExceptionAdoptionViolations', () => {
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('returns errors and collects violations when there are errors', () => {
+      const testRuleName = 'xgen-IPA-XXX-rule';
+      const testPath = ['paths', '/resource'];
+      const testObject = {
+        get: {},
+      };
+      const testErrors = [
+        {
+          path: testPath,
+          message: TEST_ERROR_MESSAGE,
+        },
+      ];
+
+      const result = collectExceptionAdoptionViolations(testErrors, testRuleName, testObject, testPath);
+
+      expect(result).toEqual(testErrors);
+      expect(collector.add).toHaveBeenCalledTimes(1);
+      expect(collector.add).toHaveBeenCalledWith(TEST_ENTRY_TYPE.VIOLATION, testPath, testRuleName);
+    });
+
+    it('returns errors and collects violations when there are errors - ignores exception for another rule', () => {
+      const testRuleName = 'xgen-IPA-XXX-rule';
+      const testPath = ['paths', '/resource'];
+      const testObject = {
+        get: {},
+        'x-xgen-IPA-exception': {
+          'xgen-IPA-XXX-some-other-rule': 'reason',
+        },
+      };
+      const testErrors = [
+        {
+          path: testPath,
+          message: TEST_ERROR_MESSAGE,
+        },
+      ];
+
+      const result = collectExceptionAdoptionViolations(testErrors, testRuleName, testObject, testPath);
+
+      expect(result).toEqual(testErrors);
+      expect(collector.add).toHaveBeenCalledTimes(1);
+      expect(collector.add).toHaveBeenCalledWith(TEST_ENTRY_TYPE.VIOLATION, testPath, testRuleName);
+    });
+
+    it('returns empty and collects adoptions when there are no errors', () => {
+      const testRuleName = 'xgen-IPA-XXX-rule';
+      const testPath = ['paths', '/resource'];
+      const testObject = {
+        get: {},
+      };
+      const testNoErrors = [];
+
+      const result = collectExceptionAdoptionViolations(testNoErrors, testRuleName, testObject, testPath);
+
+      expect(result).toEqual(undefined);
+      expect(collector.add).toHaveBeenCalledTimes(1);
+      expect(collector.add).toHaveBeenCalledWith(TEST_ENTRY_TYPE.ADOPTION, testPath, testRuleName);
+    });
+
+    it('returns empty and collects exceptions when there are errors and exceptions', () => {
+      const testRuleName = 'xgen-IPA-XXX-rule';
+      const testPath = ['paths', '/resource'];
+      const testObject = {
+        get: {},
+        'x-xgen-IPA-exception': {
+          'xgen-IPA-XXX-rule': 'reason',
+        },
+      };
+      const testErrors = [
+        {
+          path: testPath,
+          message: TEST_ERROR_MESSAGE,
+        },
+      ];
+
+      const result = collectExceptionAdoptionViolations(testErrors, testRuleName, testObject, testPath);
+
+      expect(result).toEqual(undefined);
+      expect(collector.add).toHaveBeenCalledTimes(1);
+      expect(collector.add).toHaveBeenCalledWith(TEST_ENTRY_TYPE.EXCEPTION, testPath, testRuleName, 'reason');
+    });
+
+    it('returns error when there are exceptions and no errors', () => {
+      const testRuleName = 'xgen-IPA-XXX-rule';
+      const testPath = ['paths', '/resource'];
+      const testObject = {
+        get: {},
+        'x-xgen-IPA-exception': {
+          'xgen-IPA-XXX-rule': 'reason',
+        },
+      };
+
+      const result = collectExceptionAdoptionViolations([], testRuleName, testObject, testPath);
+
+      expect(result.length).toEqual(1);
+      expect(Object.keys(result[0])).toEqual(['path', 'message']);
+      expect(result[0].path).toEqual([...testPath, 'x-xgen-IPA-exception', testRuleName]);
+      expect(result[0].message).toEqual(
+        'This component adopts the rule and does not need an exception. Please remove the exception.'
+      );
+      expect(collector.add).toHaveBeenCalledTimes(1);
+      expect(collector.add).toHaveBeenCalledWith(TEST_ENTRY_TYPE.VIOLATION, testPath, testRuleName);
+    });
+  });
+});

--- a/tools/spectral/ipa/ipa-spectral.yaml
+++ b/tools/spectral/ipa/ipa-spectral.yaml
@@ -124,3 +124,8 @@ overrides:
       - '**#/components/schemas/DataLakeHTTPStore/allOf/1/properties/urls' # external field, to be covered by CLOUDP-293178
     rules:
       xgen-IPA-124-array-max-items: 'off'
+  - files: # To be removed in CLOUDP-337392
+      - '**#/paths/~1api~1atlas~1v2~1orgs~1%7BorgId%7D~1groups'
+      - '**#/paths/~1api~1atlas~1v2~1groups~1%7BgroupId%7D'
+    rules:
+      xgen-IPA-104-get-method-response-has-no-input-fields: 'off'

--- a/tools/spectral/ipa/rulesets/functions/IPA005ExceptionExtensionFormat.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA005ExceptionExtensionFormat.js
@@ -1,4 +1,4 @@
-import { collectAdoption, collectAndReturnViolation, handleInternalError } from './utils/collectionUtils.js';
+import { collectAdoptionViolations, handleInternalError } from './utils/collectionUtils.js';
 
 const RULE_NAME = 'xgen-IPA-005-exception-extension-format';
 const ERROR_MESSAGE = 'IPA exceptions must have a valid rule name and a reason.';
@@ -7,10 +7,7 @@ const RULE_NAME_PREFIX = 'xgen-IPA-';
 // Note: This rule does not allow exceptions
 export default (input, _, { path }) => {
   const errors = checkViolationsAndReturnErrors(input, path);
-  if (errors.length !== 0) {
-    return collectAndReturnViolation(path, RULE_NAME, errors);
-  }
-  collectAdoption(path, RULE_NAME);
+  return collectAdoptionViolations(errors, RULE_NAME, path);
 };
 
 function isValidException(ruleName, reason) {

--- a/tools/spectral/ipa/rulesets/functions/IPA005ExceptionExtensionFormat.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA005ExceptionExtensionFormat.js
@@ -1,4 +1,4 @@
-import { collectAdoptionViolations, handleInternalError } from './utils/collectionUtils.js';
+import { evaluateAndCollectAdoptionStatusWithoutExceptions, handleInternalError } from './utils/collectionUtils.js';
 
 const RULE_NAME = 'xgen-IPA-005-exception-extension-format';
 const ERROR_MESSAGE = 'IPA exceptions must have a valid rule name and a reason.';
@@ -7,7 +7,7 @@ const RULE_NAME_PREFIX = 'xgen-IPA-';
 // Note: This rule does not allow exceptions
 export default (input, _, { path }) => {
   const errors = checkViolationsAndReturnErrors(input, path);
-  return collectAdoptionViolations(errors, RULE_NAME, path);
+  return evaluateAndCollectAdoptionStatusWithoutExceptions(errors, RULE_NAME, path);
 };
 
 function isValidException(ruleName, reason) {

--- a/tools/spectral/ipa/rulesets/functions/IPA102CollectionIdentifierCamelCase.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA102CollectionIdentifierCamelCase.js
@@ -1,4 +1,4 @@
-import { collectExceptionAdoptionViolations, handleInternalError } from './utils/collectionUtils.js';
+import { evaluateAndCollectAdoptionStatus, handleInternalError } from './utils/collectionUtils.js';
 import { isPathParam } from './utils/componentUtils.js';
 import { casing } from '@stoplight/spectral-functions';
 
@@ -21,7 +21,7 @@ export default (input, options, { path, documentInventory }) => {
 
   const violations = checkViolations(pathKey, path, ignoredValues);
 
-  return collectExceptionAdoptionViolations(violations, RULE_NAME, oas.paths[input], path);
+  return evaluateAndCollectAdoptionStatus(violations, RULE_NAME, oas.paths[input], path);
 };
 
 function checkViolations(pathKey, path, ignoredValues = []) {

--- a/tools/spectral/ipa/rulesets/functions/IPA102CollectionIdentifierCamelCase.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA102CollectionIdentifierCamelCase.js
@@ -1,10 +1,4 @@
-import {
-  collectAdoption,
-  collectAndReturnViolation,
-  collectException,
-  handleInternalError,
-} from './utils/collectionUtils.js';
-import { hasException } from './utils/exceptions.js';
+import { collectExceptionAdoptionViolations, handleInternalError } from './utils/collectionUtils.js';
 import { isPathParam } from './utils/componentUtils.js';
 import { casing } from '@stoplight/spectral-functions';
 
@@ -22,21 +16,12 @@ export default (input, options, { path, documentInventory }) => {
   const oas = documentInventory.resolved;
   const pathKey = input;
 
-  // Check for exception at the path level
-  if (hasException(oas.paths[input], RULE_NAME)) {
-    collectException(oas.paths[input], RULE_NAME, path);
-    return;
-  }
-
   // Extract ignored values from options
   const ignoredValues = options?.ignoredValues || [];
 
   const violations = checkViolations(pathKey, path, ignoredValues);
-  if (violations.length > 0) {
-    return collectAndReturnViolation(path, RULE_NAME, violations);
-  }
 
-  return collectAdoption(path, RULE_NAME);
+  return collectExceptionAdoptionViolations(violations, RULE_NAME, oas.paths[input], path);
 };
 
 function checkViolations(pathKey, path, ignoredValues = []) {

--- a/tools/spectral/ipa/rulesets/functions/IPA102CollectionIdentifierPattern.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA102CollectionIdentifierPattern.js
@@ -1,4 +1,4 @@
-import { collectExceptionAdoptionViolations } from './utils/collectionUtils.js';
+import { evaluateAndCollectAdoptionStatus } from './utils/collectionUtils.js';
 
 const RULE_NAME = 'xgen-IPA-102-collection-identifier-pattern';
 const ERROR_MESSAGE =
@@ -17,7 +17,7 @@ export default (input, _, { path, documentInventory }) => {
 
   const violations = checkViolations(input, path);
 
-  return collectExceptionAdoptionViolations(violations, RULE_NAME, oas.paths[input], path);
+  return evaluateAndCollectAdoptionStatus(violations, RULE_NAME, oas.paths[input], path);
 };
 
 function checkViolations(pathKey, path) {

--- a/tools/spectral/ipa/rulesets/functions/IPA102CollectionIdentifierPattern.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA102CollectionIdentifierPattern.js
@@ -1,5 +1,4 @@
-import { collectAdoption, collectAndReturnViolation, collectException } from './utils/collectionUtils.js';
-import { hasException } from './utils/exceptions.js';
+import { collectExceptionAdoptionViolations } from './utils/collectionUtils.js';
 
 const RULE_NAME = 'xgen-IPA-102-collection-identifier-pattern';
 const ERROR_MESSAGE =
@@ -15,20 +14,10 @@ const VALID_IDENTIFIER_PATTERN = /^[a-z][a-zA-Z0-9]*$/;
  */
 export default (input, _, { path, documentInventory }) => {
   const oas = documentInventory.resolved;
-  const pathKey = input;
 
-  // Check for exception at the path level
-  if (hasException(oas.paths[input], RULE_NAME)) {
-    collectException(oas.paths[input], RULE_NAME, path);
-    return;
-  }
+  const violations = checkViolations(input, path);
 
-  const violations = checkViolations(pathKey, path);
-  if (violations.length > 0) {
-    return collectAndReturnViolation(path, RULE_NAME, violations);
-  }
-
-  return collectAdoption(path, RULE_NAME);
+  return collectExceptionAdoptionViolations(violations, RULE_NAME, oas.paths[input], path);
 };
 
 function checkViolations(pathKey, path) {

--- a/tools/spectral/ipa/rulesets/functions/IPA102EachPathAlternatesBetweenResourceNameAndPathParam.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA102EachPathAlternatesBetweenResourceNameAndPathParam.js
@@ -1,11 +1,5 @@
 import { isPathParam } from './utils/componentUtils.js';
-import { hasException } from './utils/exceptions.js';
-import {
-  collectAdoption,
-  collectAndReturnViolation,
-  collectException,
-  handleInternalError,
-} from './utils/collectionUtils.js';
+import { collectExceptionAdoptionViolations, handleInternalError } from './utils/collectionUtils.js';
 import { AUTH_PREFIX, UNAUTH_PREFIX } from './utils/resourceEvaluation.js';
 
 const RULE_NAME = 'xgen-IPA-102-path-alternate-resource-name-path-param';
@@ -41,16 +35,9 @@ export default (input, _, { path, documentInventory }) => {
     return;
   }
 
-  if (hasException(oas.paths[input], RULE_NAME)) {
-    collectException(oas.paths[input], RULE_NAME, path);
-    return;
-  }
-
   const errors = checkViolationsAndReturnErrors(suffixWithLeadingSlash, path);
-  if (errors.length !== 0) {
-    return collectAndReturnViolation(path, RULE_NAME, errors);
-  }
-  collectAdoption(path, RULE_NAME);
+
+  return collectExceptionAdoptionViolations(errors, RULE_NAME, oas.paths[input], path);
 };
 
 function checkViolationsAndReturnErrors(suffixWithLeadingSlash, path) {

--- a/tools/spectral/ipa/rulesets/functions/IPA102EachPathAlternatesBetweenResourceNameAndPathParam.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA102EachPathAlternatesBetweenResourceNameAndPathParam.js
@@ -1,5 +1,5 @@
 import { isPathParam } from './utils/componentUtils.js';
-import { collectExceptionAdoptionViolations, handleInternalError } from './utils/collectionUtils.js';
+import { evaluateAndCollectAdoptionStatus, handleInternalError } from './utils/collectionUtils.js';
 import { AUTH_PREFIX, UNAUTH_PREFIX } from './utils/resourceEvaluation.js';
 
 const RULE_NAME = 'xgen-IPA-102-path-alternate-resource-name-path-param';
@@ -37,7 +37,7 @@ export default (input, _, { path, documentInventory }) => {
 
   const errors = checkViolationsAndReturnErrors(suffixWithLeadingSlash, path);
 
-  return collectExceptionAdoptionViolations(errors, RULE_NAME, oas.paths[input], path);
+  return evaluateAndCollectAdoptionStatus(errors, RULE_NAME, oas.paths[input], path);
 };
 
 function checkViolationsAndReturnErrors(suffixWithLeadingSlash, path) {

--- a/tools/spectral/ipa/rulesets/functions/IPA104EachResourceHasGetMethod.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA104EachResourceHasGetMethod.js
@@ -5,13 +5,7 @@ import {
   isResourceCollectionIdentifier,
   isSingleResourceIdentifier,
 } from './utils/resourceEvaluation.js';
-import { hasException } from './utils/exceptions.js';
-import {
-  collectAdoption,
-  collectAndReturnViolation,
-  collectException,
-  handleInternalError,
-} from './utils/collectionUtils.js';
+import { collectExceptionAdoptionViolations, handleInternalError } from './utils/collectionUtils.js';
 
 const RULE_NAME = 'xgen-IPA-104-resource-has-GET';
 const ERROR_MESSAGE = 'APIs must provide a get method for resources.';
@@ -23,16 +17,9 @@ export default (input, _, { path, documentInventory }) => {
 
   const oas = documentInventory.resolved;
 
-  if (hasException(oas.paths[input], RULE_NAME)) {
-    collectException(oas.paths[input], RULE_NAME, path);
-    return;
-  }
-
   const errors = checkViolationsAndReturnErrors(oas.paths, input, path);
-  if (errors.length !== 0) {
-    return collectAndReturnViolation(path, RULE_NAME, errors);
-  }
-  collectAdoption(path, RULE_NAME);
+
+  return collectExceptionAdoptionViolations(errors, RULE_NAME, oas.paths[input], path);
 };
 
 function checkViolationsAndReturnErrors(oasPaths, input, path) {

--- a/tools/spectral/ipa/rulesets/functions/IPA104EachResourceHasGetMethod.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA104EachResourceHasGetMethod.js
@@ -5,7 +5,7 @@ import {
   isResourceCollectionIdentifier,
   isSingleResourceIdentifier,
 } from './utils/resourceEvaluation.js';
-import { collectExceptionAdoptionViolations, handleInternalError } from './utils/collectionUtils.js';
+import { evaluateAndCollectAdoptionStatus, handleInternalError } from './utils/collectionUtils.js';
 
 const RULE_NAME = 'xgen-IPA-104-resource-has-GET';
 const ERROR_MESSAGE = 'APIs must provide a get method for resources.';
@@ -19,7 +19,7 @@ export default (input, _, { path, documentInventory }) => {
 
   const errors = checkViolationsAndReturnErrors(oas.paths, input, path);
 
-  return collectExceptionAdoptionViolations(errors, RULE_NAME, oas.paths[input], path);
+  return evaluateAndCollectAdoptionStatus(errors, RULE_NAME, oas.paths[input], path);
 };
 
 function checkViolationsAndReturnErrors(oasPaths, input, path) {

--- a/tools/spectral/ipa/rulesets/functions/IPA104GetMethodHasNoRequestBody.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA104GetMethodHasNoRequestBody.js
@@ -1,4 +1,4 @@
-import { collectExceptionAdoptionViolations } from './utils/collectionUtils.js';
+import { evaluateAndCollectAdoptionStatus } from './utils/collectionUtils.js';
 import {
   getResourcePathItems,
   isResourceCollectionIdentifier,
@@ -24,7 +24,7 @@ export default (input, _, { path, documentInventory }) => {
 
   const errors = checkViolationsAndReturnErrors(input, path);
 
-  return collectExceptionAdoptionViolations(errors, RULE_NAME, input, path);
+  return evaluateAndCollectAdoptionStatus(errors, RULE_NAME, input, path);
 };
 
 function checkViolationsAndReturnErrors(getOperationObject, path) {

--- a/tools/spectral/ipa/rulesets/functions/IPA104GetMethodHasNoRequestBody.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA104GetMethodHasNoRequestBody.js
@@ -1,5 +1,4 @@
-import { hasException } from './utils/exceptions.js';
-import { collectAdoption, collectAndReturnViolation, collectException } from './utils/collectionUtils.js';
+import { collectExceptionAdoptionViolations } from './utils/collectionUtils.js';
 import {
   getResourcePathItems,
   isResourceCollectionIdentifier,
@@ -23,17 +22,9 @@ export default (input, _, { path, documentInventory }) => {
     return;
   }
 
-  if (hasException(input, RULE_NAME)) {
-    collectException(input, RULE_NAME, path);
-    return;
-  }
-
   const errors = checkViolationsAndReturnErrors(input, path);
 
-  if (errors.length !== 0) {
-    return collectAndReturnViolation(path, RULE_NAME, errors);
-  }
-  collectAdoption(path, RULE_NAME);
+  return collectExceptionAdoptionViolations(errors, RULE_NAME, input, path);
 };
 
 function checkViolationsAndReturnErrors(getOperationObject, path) {

--- a/tools/spectral/ipa/rulesets/functions/IPA104GetMethodResponseHasNoInputFields.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA104GetMethodResponseHasNoInputFields.js
@@ -1,5 +1,4 @@
-import { hasException } from './utils/exceptions.js';
-import { collectAdoption, collectAndReturnViolation, collectException } from './utils/collectionUtils.js';
+import { collectExceptionAdoptionViolations } from './utils/collectionUtils.js';
 import {
   getResourcePathItems,
   isResourceCollectionIdentifier,
@@ -30,11 +29,6 @@ export default (input, _, { path, documentInventory }) => {
     return;
   }
 
-  if (hasException(contentPerMediaType, RULE_NAME)) {
-    collectException(contentPerMediaType, RULE_NAME, path);
-    return;
-  }
-
   const errors = checkForbiddenPropertyAttributesAndReturnErrors(
     contentPerMediaType.schema,
     'writeOnly',
@@ -43,8 +37,5 @@ export default (input, _, { path, documentInventory }) => {
     ERROR_MESSAGE
   );
 
-  if (errors.length !== 0) {
-    return collectAndReturnViolation(path, RULE_NAME, errors);
-  }
-  return collectAdoption(path, RULE_NAME);
+  return collectExceptionAdoptionViolations(errors, RULE_NAME, contentPerMediaType, path);
 };

--- a/tools/spectral/ipa/rulesets/functions/IPA104GetMethodResponseHasNoInputFields.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA104GetMethodResponseHasNoInputFields.js
@@ -1,4 +1,4 @@
-import { collectExceptionAdoptionViolations } from './utils/collectionUtils.js';
+import { evaluateAndCollectAdoptionStatus } from './utils/collectionUtils.js';
 import {
   getResourcePathItems,
   isResourceCollectionIdentifier,
@@ -37,5 +37,5 @@ export default (input, _, { path, documentInventory }) => {
     ERROR_MESSAGE
   );
 
-  return collectExceptionAdoptionViolations(errors, RULE_NAME, contentPerMediaType, path);
+  return evaluateAndCollectAdoptionStatus(errors, RULE_NAME, contentPerMediaType, path);
 };

--- a/tools/spectral/ipa/rulesets/functions/IPA104GetMethodReturnsResponseSuffixedObject.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA104GetMethodReturnsResponseSuffixedObject.js
@@ -5,8 +5,7 @@ import {
   isResourceCollectionIdentifier,
 } from './utils/resourceEvaluation.js';
 import { resolveObject } from './utils/componentUtils.js';
-import { hasException } from './utils/exceptions.js';
-import { collectAdoption, collectAndReturnViolation, collectException } from './utils/collectionUtils.js';
+import { collectExceptionAdoptionViolations } from './utils/collectionUtils.js';
 import { checkSchemaRefSuffixAndReturnErrors } from './utils/validations/checkSchemaRefSuffixAndReturnErrors.js';
 
 const RULE_NAME = 'xgen-IPA-104-get-method-returns-response-suffixed-object';
@@ -29,15 +28,7 @@ export default (input, _, { path, documentInventory }) => {
     return;
   }
 
-  if (hasException(contentPerMediaType, RULE_NAME)) {
-    collectException(contentPerMediaType, RULE_NAME, path);
-    return;
-  }
-
   const errors = checkSchemaRefSuffixAndReturnErrors(path, contentPerMediaType, 'Response', RULE_NAME);
 
-  if (errors.length !== 0) {
-    return collectAndReturnViolation(path, RULE_NAME, errors);
-  }
-  collectAdoption(path, RULE_NAME);
+  return collectExceptionAdoptionViolations(errors, RULE_NAME, contentPerMediaType, path);
 };

--- a/tools/spectral/ipa/rulesets/functions/IPA104GetMethodReturnsResponseSuffixedObject.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA104GetMethodReturnsResponseSuffixedObject.js
@@ -5,7 +5,7 @@ import {
   isResourceCollectionIdentifier,
 } from './utils/resourceEvaluation.js';
 import { resolveObject } from './utils/componentUtils.js';
-import { collectExceptionAdoptionViolations } from './utils/collectionUtils.js';
+import { evaluateAndCollectAdoptionStatus } from './utils/collectionUtils.js';
 import { checkSchemaRefSuffixAndReturnErrors } from './utils/validations/checkSchemaRefSuffixAndReturnErrors.js';
 
 const RULE_NAME = 'xgen-IPA-104-get-method-returns-response-suffixed-object';
@@ -30,5 +30,5 @@ export default (input, _, { path, documentInventory }) => {
 
   const errors = checkSchemaRefSuffixAndReturnErrors(path, contentPerMediaType, 'Response', RULE_NAME);
 
-  return collectExceptionAdoptionViolations(errors, RULE_NAME, contentPerMediaType, path);
+  return evaluateAndCollectAdoptionStatus(errors, RULE_NAME, contentPerMediaType, path);
 };

--- a/tools/spectral/ipa/rulesets/functions/IPA104GetMethodReturnsSingleResource.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA104GetMethodReturnsSingleResource.js
@@ -4,13 +4,7 @@ import {
   isSingleResourceIdentifier,
   isSingletonResource,
 } from './utils/resourceEvaluation.js';
-import {
-  collectAdoption,
-  collectAndReturnViolation,
-  collectException,
-  handleInternalError,
-} from './utils/collectionUtils.js';
-import { hasException } from './utils/exceptions.js';
+import { collectExceptionAdoptionViolations, handleInternalError } from './utils/collectionUtils.js';
 import { schemaIsArray, schemaIsPaginated } from './utils/schemaUtils.js';
 import { resolveObject } from './utils/componentUtils.js';
 
@@ -40,17 +34,9 @@ export default (input, _, { path, documentInventory }) => {
     return;
   }
 
-  if (hasException(contentPerMediaType, RULE_NAME)) {
-    collectException(contentPerMediaType, RULE_NAME, path);
-    return;
-  }
-
   const errors = checkViolationsAndReturnErrors(contentPerMediaType, path, isSingleton);
 
-  if (errors.length !== 0) {
-    return collectAndReturnViolation(path, RULE_NAME, errors);
-  }
-  return collectAdoption(path, RULE_NAME);
+  return collectExceptionAdoptionViolations(errors, RULE_NAME, contentPerMediaType, path);
 };
 
 function checkViolationsAndReturnErrors(contentPerMediaType, path, isSingleton) {

--- a/tools/spectral/ipa/rulesets/functions/IPA104GetMethodReturnsSingleResource.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA104GetMethodReturnsSingleResource.js
@@ -4,7 +4,7 @@ import {
   isSingleResourceIdentifier,
   isSingletonResource,
 } from './utils/resourceEvaluation.js';
-import { collectExceptionAdoptionViolations, handleInternalError } from './utils/collectionUtils.js';
+import { evaluateAndCollectAdoptionStatus, handleInternalError } from './utils/collectionUtils.js';
 import { schemaIsArray, schemaIsPaginated } from './utils/schemaUtils.js';
 import { resolveObject } from './utils/componentUtils.js';
 
@@ -36,7 +36,7 @@ export default (input, _, { path, documentInventory }) => {
 
   const errors = checkViolationsAndReturnErrors(contentPerMediaType, path, isSingleton);
 
-  return collectExceptionAdoptionViolations(errors, RULE_NAME, contentPerMediaType, path);
+  return evaluateAndCollectAdoptionStatus(errors, RULE_NAME, contentPerMediaType, path);
 };
 
 function checkViolationsAndReturnErrors(contentPerMediaType, path, isSingleton) {

--- a/tools/spectral/ipa/rulesets/functions/IPA104GetResponseCodeShouldBe200OK.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA104GetResponseCodeShouldBe200OK.js
@@ -1,5 +1,4 @@
-import { hasException } from './utils/exceptions.js';
-import { collectAdoption, collectAndReturnViolation, collectException } from './utils/collectionUtils.js';
+import { collectExceptionAdoptionViolations } from './utils/collectionUtils.js';
 import {
   getResourcePathItems,
   isResourceCollectionIdentifier,
@@ -24,14 +23,7 @@ export default (input, _, { path, documentInventory }) => {
     return;
   }
 
-  if (hasException(input, RULE_NAME)) {
-    collectException(input, RULE_NAME, path);
-    return;
-  }
-
   const errors = checkResponseCodeAndReturnErrors(input, '200', path, RULE_NAME, ERROR_MESSAGE);
-  if (errors.length !== 0) {
-    return collectAndReturnViolation(path, RULE_NAME, errors);
-  }
-  collectAdoption(path, RULE_NAME);
+
+  return collectExceptionAdoptionViolations(errors, RULE_NAME, input, path);
 };

--- a/tools/spectral/ipa/rulesets/functions/IPA104GetResponseCodeShouldBe200OK.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA104GetResponseCodeShouldBe200OK.js
@@ -1,4 +1,4 @@
-import { collectExceptionAdoptionViolations } from './utils/collectionUtils.js';
+import { evaluateAndCollectAdoptionStatus } from './utils/collectionUtils.js';
 import {
   getResourcePathItems,
   isResourceCollectionIdentifier,
@@ -25,5 +25,5 @@ export default (input, _, { path, documentInventory }) => {
 
   const errors = checkResponseCodeAndReturnErrors(input, '200', path, RULE_NAME, ERROR_MESSAGE);
 
-  return collectExceptionAdoptionViolations(errors, RULE_NAME, input, path);
+  return evaluateAndCollectAdoptionStatus(errors, RULE_NAME, input, path);
 };

--- a/tools/spectral/ipa/rulesets/functions/IPA104ValidOperationID.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA104ValidOperationID.js
@@ -1,10 +1,4 @@
-import {
-  collectAdoption,
-  collectAndReturnViolation,
-  collectException,
-  handleInternalError,
-} from './utils/collectionUtils.js';
-import { hasException } from './utils/exceptions.js';
+import { collectExceptionAdoptionViolations, handleInternalError } from './utils/collectionUtils.js';
 import { getResourcePathItems } from './utils/resourceEvaluation.js';
 import { hasCustomMethodOverride, hasMethodVerbOverride, VERB_OVERRIDE_EXTENSION } from './utils/extensions.js';
 import { isInvalidGetMethod } from './utils/methodLogic.js';
@@ -25,22 +19,13 @@ export default (input, { methodName }, { path, documentInventory }) => {
     return;
   }
 
-  if (hasException(input, RULE_NAME)) {
-    collectException(input, RULE_NAME, path);
-    return;
-  }
-
   try {
     if (hasMethodVerbOverride(input, methodName)) {
       methodName = input[VERB_OVERRIDE_EXTENSION].verb;
     }
     const errors = validateOperationIdAndReturnErrors(methodName, resourcePath, input, path);
 
-    if (errors.length > 0) {
-      return collectAndReturnViolation(path, RULE_NAME, errors);
-    }
-
-    return collectAdoption(path, RULE_NAME);
+    return collectExceptionAdoptionViolations(errors, RULE_NAME, input, path);
   } catch (e) {
     return handleInternalError(RULE_NAME, path, e);
   }

--- a/tools/spectral/ipa/rulesets/functions/IPA104ValidOperationID.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA104ValidOperationID.js
@@ -1,4 +1,4 @@
-import { collectExceptionAdoptionViolations, handleInternalError } from './utils/collectionUtils.js';
+import { evaluateAndCollectAdoptionStatus, handleInternalError } from './utils/collectionUtils.js';
 import { getResourcePathItems } from './utils/resourceEvaluation.js';
 import { hasCustomMethodOverride, hasMethodVerbOverride, VERB_OVERRIDE_EXTENSION } from './utils/extensions.js';
 import { isInvalidGetMethod } from './utils/methodLogic.js';
@@ -25,7 +25,7 @@ export default (input, { methodName }, { path, documentInventory }) => {
     }
     const errors = validateOperationIdAndReturnErrors(methodName, resourcePath, input, path);
 
-    return collectExceptionAdoptionViolations(errors, RULE_NAME, input, path);
+    return evaluateAndCollectAdoptionStatus(errors, RULE_NAME, input, path);
   } catch (e) {
     return handleInternalError(RULE_NAME, path, e);
   }

--- a/tools/spectral/ipa/rulesets/functions/utils/collectionUtils.js
+++ b/tools/spectral/ipa/rulesets/functions/utils/collectionUtils.js
@@ -6,10 +6,10 @@ import { EXCEPTION_EXTENSION, hasException } from './exceptions.js';
  * If the object is violating the rule, but has an exception, the validation error is ignored
  * If the object is adopting the rule, but has an exception, a validation error will be returned
  *
- * @param validationErrors the error results from the rule
- * @param ruleName the name of the rule
- * @param object the object evaluated for the rule, should contain an exception object if an exception is needed
- * @param objectPath the JSON path to the object
+ * @param {Array<{path: Array<string>, message: string}>} validationErrors the error results from the rule
+ * @param {string} ruleName the name of the rule
+ * @param {*} object the object evaluated for the rule, should contain an exception object if an exception is needed
+ * @param {Array<string>} objectPath the JSON path to the object
  * @returns {Array<{path: Array<string>, message: string}>|undefined} an array of the validation errors, or undefined if there are no errors
  */
 export function collectExceptionAdoptionViolations(validationErrors, ruleName, object, objectPath) {
@@ -21,12 +21,12 @@ export function collectExceptionAdoptionViolations(validationErrors, ruleName, o
     return collectAndReturnViolation(objectPath, ruleName, validationErrors);
   }
   if (hasException(object, ruleName)) {
-    const error = {
-      path: [...objectPath, EXCEPTION_EXTENSION, ruleName],
-      message: 'This component adopts the rule and does not need an exception. Please remove the exception.',
-    };
-    validationErrors.push(error);
-    return collectAndReturnViolation(objectPath, ruleName, [error]);
+    return collectAndReturnViolation(objectPath, ruleName, [
+      {
+        path: [...objectPath, EXCEPTION_EXTENSION, ruleName],
+        message: 'This component adopts the rule and does not need an exception. Please remove the exception.',
+      },
+    ]);
   }
   collectAdoption(objectPath, ruleName);
 }
@@ -35,9 +35,9 @@ export function collectExceptionAdoptionViolations(validationErrors, ruleName, o
  * Evaluates and collects adoptions and violations based on the rule, evaluated object and the validation errors.
  * No exceptions are allowed.
  *
- * @param validationErrors the error results from the rule
- * @param ruleName the name of the rule
- * @param objectPath the JSON path to the object
+ * @param {Array<{path: Array<string>, message: string}>} validationErrors the error results from the rule
+ * @param {string} ruleName the name of the rule
+ * @param {Array<string>} objectPath the JSON path to the object
  * @returns {Array<{path: Array<string>, message: string}>|undefined} an array of the validation errors, or undefined if there are no errors
  */
 export function collectAdoptionViolations(validationErrors, ruleName, objectPath) {

--- a/tools/spectral/ipa/rulesets/functions/utils/collectionUtils.js
+++ b/tools/spectral/ipa/rulesets/functions/utils/collectionUtils.js
@@ -12,7 +12,7 @@ import { EXCEPTION_EXTENSION, hasException } from './exceptions.js';
  * @param {Array<string>} objectPath the JSON path to the object
  * @returns {Array<{path: Array<string>, message: string}>|undefined} an array of the validation errors, or undefined if there are no errors
  */
-export function collectExceptionAdoptionViolations(validationErrors, ruleName, object, objectPath) {
+export function evaluateAndCollectAdoptionStatus(validationErrors, ruleName, object, objectPath) {
   if (validationErrors.length !== 0) {
     if (hasException(object, ruleName)) {
       collectException(object, ruleName, objectPath);
@@ -40,7 +40,7 @@ export function collectExceptionAdoptionViolations(validationErrors, ruleName, o
  * @param {Array<string>} objectPath the JSON path to the object
  * @returns {Array<{path: Array<string>, message: string}>|undefined} an array of the validation errors, or undefined if there are no errors
  */
-export function collectAdoptionViolations(validationErrors, ruleName, objectPath) {
+export function evaluateAndCollectAdoptionStatusWithoutExceptions(validationErrors, ruleName, objectPath) {
   if (validationErrors.length !== 0) {
     return collectAndReturnViolation(objectPath, ruleName, validationErrors);
   }


### PR DESCRIPTION
## Proposed changes

This PR introduces a new helper function to handle all violations, exceptions and adoptions for a rule. 

The idea is that when violations are collected in a rule, this function gets called to handle metric collection as well as silencing violations with exceptions.

Additionally, thing brings the functionality to error if there are no violations, but the component still has exceptions. This allows us to remove unnecessary exceptions in the OAS.

For now IPA 005-104 are updated using the new helper function. I'll adjust the other IPAs in incremental follow-up PRs to keep the PRs smaller.

Finally, I'll update the OAS and remove identified exceptions that are no longer needed + remove temporary Spectral overrides.

_Jira ticket:_ [CLOUDP-307585](https://jira.mongodb.org/browse/CLOUDP-307585)

Exceptions found that can be removed:
```
error  xgen-IPA-104-get-method-response-has-no-input-fields  This component adopts the rule and does not need an exception. Please remove the exception. https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-104-get-method-response-has-no-input-fields  paths./api/atlas/v2/groups/{groupId}.get.responses[200].content.application/vnd.atlas.2023-01-01+json.x-xgen-IPA-exception.xgen-IPA-104-get-method-response-has-no-input-fields

error  xgen-IPA-104-get-method-response-has-no-input-fields  This component adopts the rule and does not need an exception. Please remove the exception. https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-104-get-method-response-has-no-input-fields  paths./api/atlas/v2/orgs/{orgId}/groups.get.responses[200].content.application/vnd.atlas.2023-01-01+json.x-xgen-IPA-exception.xgen-IPA-104-get-method-response-has-no-input-fields
```