### PR TITLE
fix(ipa): Validate both inline and reusable enums

### DIFF
--- a/tools/spectral/ipa/__tests__/IPA123EnumValuesShouldNotExceed20.test.js
+++ b/tools/spectral/ipa/__tests__/IPA123EnumValuesShouldNotExceed20.test.js
@@ -100,7 +100,7 @@ testRule('xgen-IPA-123-allowable-enum-values-should-not-exceed-20', [
     errors: [
       {
         code: 'xgen-IPA-123-allowable-enum-values-should-not-exceed-20',
-        message: 'Inline enum arrays should not exceed 20 values. Current count: 21',
+        message: 'The number of allowable enum values should not exceed 20 values. Current count: 21',
         path: ['components', 'schemas', 'TestSchema', 'properties', 'status', 'enum'],
         severity: DiagnosticSeverity.Error,
       },
@@ -172,7 +172,7 @@ testRule('xgen-IPA-123-allowable-enum-values-should-not-exceed-20', [
     errors: [
       {
         code: 'xgen-IPA-123-allowable-enum-values-should-not-exceed-20',
-        message: 'Inline enum arrays should not exceed 20 values. Current count: 21',
+        message: 'The number of allowable enum values should not exceed 20 values. Current count: 21',
         path: ['components', 'schemas', 'TestSchema', 'properties', 'priority', 'enum'],
         severity: DiagnosticSeverity.Error,
       },
@@ -245,7 +245,7 @@ testRule('xgen-IPA-123-allowable-enum-values-should-not-exceed-20', [
     errors: [
       {
         code: 'xgen-IPA-123-allowable-enum-values-should-not-exceed-20',
-        message: 'Inline enum arrays should not exceed 20 values. Current count: 21',
+        message: 'The number of allowable enum values should not exceed 20 values. Current count: 21',
         path: ['paths', '/resources', 'get', 'parameters', '0', 'schema', 'enum'],
         severity: DiagnosticSeverity.Error,
       },
@@ -303,7 +303,7 @@ testRule('xgen-IPA-123-allowable-enum-values-should-not-exceed-20', [
     errors: [],
   },
   {
-    name: 'valid on with reusable schemas',
+    name: 'invalid on with reusable schemas',
     document: {
       paths: {
         '/resources': {
@@ -362,6 +362,68 @@ testRule('xgen-IPA-123-allowable-enum-values-should-not-exceed-20', [
         },
       },
     },
+    errors: [
+      {
+        code: 'xgen-IPA-123-allowable-enum-values-should-not-exceed-20',
+        message: 'The number of allowable enum values should not exceed 20 values. Current count: 25',
+        path: ['components', 'schemas', 'StatusEnum', 'enum'],
+        severity: DiagnosticSeverity.Error,
+      },
+    ],
+  },
+  {
+    name: 'valid enum array in items schema',
+    document: {
+      components: {
+        schemas: {
+          TestSchema: {
+            properties: {
+              statusList: {
+                type: 'array',
+                items: {
+                  type: 'string',
+                  enum: ['PENDING', 'ACTIVE', 'COMPLETE', 'FAILED', 'CANCELLED'],
+                },
+              },
+            },
+          },
+        },
+      },
+    },
     errors: [],
+  },
+  {
+    name: 'invalid enum array in items schema exceeding limit',
+    document: {
+      components: {
+        schemas: {
+          TestSchema: {
+            properties: {
+              statusList: {
+                type: 'array',
+                items: {
+                  type: 'string',
+                  enum: [
+                    'VAL_1', 'VAL_2', 'VAL_3', 'VAL_4', 'VAL_5',
+                    'VAL_6', 'VAL_7', 'VAL_8', 'VAL_9', 'VAL_10',
+                    'VAL_11', 'VAL_12', 'VAL_13', 'VAL_14', 'VAL_15',
+                    'VAL_16', 'VAL_17', 'VAL_18', 'VAL_19', 'VAL_20',
+                    'VAL_21',
+                  ],
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    errors: [
+      {
+        code: 'xgen-IPA-123-allowable-enum-values-should-not-exceed-20',
+        message: 'The number of allowable enum values should not exceed 20 values. Current count: 21',
+        path: ['components', 'schemas', 'TestSchema', 'properties', 'statusList', 'items', 'enum'],
+        severity: DiagnosticSeverity.Error,
+      },
+    ],
   },
 ]);

--- a/tools/spectral/ipa/rulesets/functions/IPA123EnumValuesShouldNotExceed20.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA123EnumValuesShouldNotExceed20.js
@@ -3,17 +3,12 @@ import { getSchemaPathFromEnumPath } from './utils/schemaUtils.js';
 import { resolveObject } from './utils/componentUtils.js';
 
 const RULE_NAME = 'xgen-IPA-123-allowable-enum-values-should-not-exceed-20';
-const ERROR_MESSAGE = 'Inline enum arrays should not exceed 20 values. Current count: ';
+const ERROR_MESSAGE = 'The number of allowable enum values should not exceed 20 values. Current count: ';
 
 export default (input, { maxEnumValues }, { path, documentInventory }) => {
   const oas = documentInventory.resolved;
   const schemaPath = getSchemaPathFromEnumPath(path);
   const schemaObject = resolveObject(oas, schemaPath);
-
-  //Ignore if the schemaObject belongs to a reusable enum
-  if (!schemaPath.includes('properties') && !schemaPath.includes('parameters')) {
-    return;
-  }
 
   if (!Array.isArray(input)) {
     return;


### PR DESCRIPTION
## Proposed changes

IPA123EnumValuesShouldNotExceed20 validation rule validates both inline and reusable enums because it does not make any difference in the use case.

_Jira ticket:_ CLOUDP-310775

<!--
What issue does this PR address? (for example, #1234), remove this section if none.
-->

Closes #[issue number]

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works

### Changes to Spectral
- [ ] I have read the [README](../tools/spectral/README.md) file for Spectral Updates

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
