### PR TITLE
ci(ipa): fix IPA release tag creation

### DIFF
--- a/.github/workflows/ipa-release.yml
+++ b/.github/workflows/ipa-release.yml
@@ -49,7 +49,8 @@ jobs:
     needs: check-version
     if: >-
       !cancelled()
-      && (!inputs.use_existing_tag && needs.check-version.outputs.version_changed == 'true')
+      && (!inputs.use_existing_tag || inputs.use_existing_tag == 'false')
+      && needs.check-version.outputs.version_changed == 'true'
     steps:
       - name: Validation of version format
         run: |

--- a/.github/workflows/ipa-release.yml
+++ b/.github/workflows/ipa-release.yml
@@ -59,31 +59,33 @@ jobs:
       - name: Get the latest commit SHA
         id: get-sha
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-      - name: Create release tag
-        uses: rickstaa/action-create-tag@a1c7777fcb2fee4f19b0f283ba888afa11678b72
-        with:
-          tag: 'ipa-validation-ruleset-v${{ needs.check-version.outputs.current_version }}'
-          commit_sha: ${{ steps.get-sha.outputs.sha }}
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          gpg_passphrase: ${{ secrets.PASSPHRASE }}
+      - name: Test
+        run: echo "creating tag ipa-validation-ruleset-v${needs.check-version.outputs.current_version} for sha ${steps.get-sha.outputs.sha}"
+#      - name: Create release tag
+#        uses: rickstaa/action-create-tag@a1c7777fcb2fee4f19b0f283ba888afa11678b72
+#        with:
+#          tag: 'ipa-validation-ruleset-v${{ needs.check-version.outputs.current_version }}'
+#          commit_sha: ${{ steps.get-sha.outputs.sha }}
+#          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+#          gpg_passphrase: ${{ secrets.PASSPHRASE }}
 
-  publish:
-    needs: check-version
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
-    if: ${{ needs.check-version.outputs.version_changed == 'true' || inputs.workflow_call }}
-    steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20.x'
-          registry-url: 'https://registry.npmjs.org'
-      - run: npm ci
-        working-directory: tools/spectral/ipa
-      - run: npm publish --access public
-        working-directory: tools/spectral/ipa
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.IPA_VALIDATION_NPM_TOKEN }}
+#  publish:
+#    needs: check-version
+#    runs-on: ubuntu-latest
+#    permissions:
+#      contents: read
+#      id-token: write
+#    if: ${{ needs.check-version.outputs.version_changed == 'true' || inputs.workflow_call }}
+#    steps:
+#      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+#      - uses: actions/setup-node@v4
+#        with:
+#          node-version: '20.x'
+#          registry-url: 'https://registry.npmjs.org'
+#      - run: npm ci
+#        working-directory: tools/spectral/ipa
+#      - run: npm publish --access public
+#        working-directory: tools/spectral/ipa
+#        env:
+#          NODE_AUTH_TOKEN: ${{ secrets.IPA_VALIDATION_NPM_TOKEN }}
           

--- a/.github/workflows/ipa-release.yml
+++ b/.github/workflows/ipa-release.yml
@@ -62,31 +62,31 @@ jobs:
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
       - name: Test
         run: echo "creating tag ipa-validation-ruleset-v${{needs.check-version.outputs.current_version}} for sha ${{steps.get-sha.outputs.sha}}"
-#      - name: Create release tag
-#        uses: rickstaa/action-create-tag@a1c7777fcb2fee4f19b0f283ba888afa11678b72
-#        with:
-#          tag: 'ipa-validation-ruleset-v${{ needs.check-version.outputs.current_version }}'
-#          commit_sha: ${{ steps.get-sha.outputs.sha }}
-#          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-#          gpg_passphrase: ${{ secrets.PASSPHRASE }}
+      - name: Create release tag
+        uses: rickstaa/action-create-tag@a1c7777fcb2fee4f19b0f283ba888afa11678b72
+        with:
+          tag: 'ipa-validation-ruleset-v${{ needs.check-version.outputs.current_version }}'
+          commit_sha: ${{ steps.get-sha.outputs.sha }}
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg_passphrase: ${{ secrets.PASSPHRASE }}
 
-#  publish:
-#    needs: check-version
-#    runs-on: ubuntu-latest
-#    permissions:
-#      contents: read
-#      id-token: write
-#    if: ${{ needs.check-version.outputs.version_changed == 'true' || inputs.workflow_call }}
-#    steps:
-#      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
-#      - uses: actions/setup-node@v4
-#        with:
-#          node-version: '20.x'
-#          registry-url: 'https://registry.npmjs.org'
-#      - run: npm ci
-#        working-directory: tools/spectral/ipa
-#      - run: npm publish --access public
-#        working-directory: tools/spectral/ipa
-#        env:
-#          NODE_AUTH_TOKEN: ${{ secrets.IPA_VALIDATION_NPM_TOKEN }}
+  publish:
+    needs: check-version
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    if: ${{ needs.check-version.outputs.version_changed == 'true' || inputs.workflow_call }}
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+        working-directory: tools/spectral/ipa
+      - run: npm publish --access public
+        working-directory: tools/spectral/ipa
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.IPA_VALIDATION_NPM_TOKEN }}
           

--- a/.github/workflows/ipa-release.yml
+++ b/.github/workflows/ipa-release.yml
@@ -8,9 +8,9 @@ on:
         type: boolean
         required: false
         default: true
-#      use_existing_tag:
-#        description: 'Set value to `true` to use an existing tag for the release process, default is `false`'
-#        default: 'false'
+      use_existing_tag:
+        description: 'Set value to `true` to use an existing tag for the release process, default is `false`'
+        default: 'false'
   push: 
     branches:
       - main

--- a/.github/workflows/ipa-release.yml
+++ b/.github/workflows/ipa-release.yml
@@ -49,7 +49,7 @@ jobs:
     needs: check-version
     if: >-
       !cancelled()
-      && inputs.use_existing_tag == 'false'
+      && (!inputs.use_existing_tag || inputs.use_existing_tag == 'false')
     steps:
       - name: Validation of version format
         run: |

--- a/.github/workflows/ipa-release.yml
+++ b/.github/workflows/ipa-release.yml
@@ -49,7 +49,7 @@ jobs:
     needs: check-version
     if: >-
       !cancelled()
-      && (!inputs.use_existing_tag || inputs.use_existing_tag == 'false')
+      && (!inputs.use_existing_tag && needs.check-version.outputs.version_changed == 'true')
     steps:
       - name: Validation of version format
         run: |

--- a/.github/workflows/ipa-release.yml
+++ b/.github/workflows/ipa-release.yml
@@ -60,7 +60,7 @@ jobs:
         id: get-sha
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
       - name: Test
-        run: echo "creating tag ipa-validation-ruleset-v${needs.check-version.outputs.current_version} for sha ${steps.get-sha.outputs.sha}"
+        run: echo "creating tag ipa-validation-ruleset-v${{needs.check-version.outputs.current_version}} for sha ${{steps.get-sha.outputs.sha}}"
 #      - name: Create release tag
 #        uses: rickstaa/action-create-tag@a1c7777fcb2fee4f19b0f283ba888afa11678b72
 #        with:

--- a/.github/workflows/ipa-release.yml
+++ b/.github/workflows/ipa-release.yml
@@ -60,8 +60,6 @@ jobs:
       - name: Get the latest commit SHA
         id: get-sha
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-      - name: Test
-        run: echo "creating tag ipa-validation-ruleset-v${{needs.check-version.outputs.current_version}} for sha ${{steps.get-sha.outputs.sha}}"
       - name: Create release tag
         uses: rickstaa/action-create-tag@a1c7777fcb2fee4f19b0f283ba888afa11678b72
         with:

--- a/.github/workflows/ipa-release.yml
+++ b/.github/workflows/ipa-release.yml
@@ -8,9 +8,9 @@ on:
         type: boolean
         required: false
         default: true
-      use_existing_tag:
-        description: 'Set value to `true` to use an existing tag for the release process, default is `false`'
-        default: 'false'
+#      use_existing_tag:
+#        description: 'Set value to `true` to use an existing tag for the release process, default is `false`'
+#        default: 'false'
   push: 
     branches:
       - main

--- a/tools/spectral/ipa/package.json
+++ b/tools/spectral/ipa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mongodb-js/ipa-validation-ruleset",
-  "version": "1.1.0",
+  "version": "1.0.0",
   "description": "Custom validation rules for MongoDB API Standards (IPA).",
   "keywords": [
     "mongodb",

--- a/tools/spectral/ipa/package.json
+++ b/tools/spectral/ipa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mongodb-js/ipa-validation-ruleset",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Custom validation rules for MongoDB API Standards (IPA).",
   "keywords": [
     "mongodb",


### PR DESCRIPTION
## Proposed changes

Noticed the tag creation was skipped if the input for `use existing tag` is undefined.

Additionally, added requirement to only create release tag if the version changed. So we don't create tags for every commit to main.

_Jira ticket:_ [CLOUDP-307585](https://jira.mongodb.org/browse/CLOUDP-307585)