### PR TITLE
ci(ipa): release new version 2.0.0

### DIFF
--- a/tools/spectral/ipa/CHANGELOG.md
+++ b/tools/spectral/ipa/CHANGELOG.md
@@ -2,7 +2,14 @@
 
 All notable changes to this project will be documented in this file. Dates are displayed in UTC.
 
-#### [1.1.0](https://github.com/mongodb/openapi/compare/ipa-validation-ruleset-v1.0.0...1.1.0)
+#### [2.0.0](https://github.com/mongodb/openapi/compare/ipa-validation-ruleset-v1.1.0...2.0.0)
+
+- feat(ipa): new IPA rule xgen-IPA-125-discriminator-must-accompany-oneOf-anyOf-allOf [`#893`](https://github.com/mongodb/openapi/pull/893)
+- fix(ipa): include schema descriptions in IPA117 rules [`#895`](https://github.com/mongodb/openapi/pull/895)
+
+#### [ipa-validation-ruleset-v1.1.0](https://github.com/mongodb/openapi/compare/ipa-validation-ruleset-v1.0.0...ipa-validation-ruleset-v1.1.0)
+
+> 14 August 2025
 
 - feat(ipa): New rule xgen-IPA-125-oneOf-schema-property-same-type [`#873`](https://github.com/mongodb/openapi/pull/873)
 

--- a/tools/spectral/ipa/package.json
+++ b/tools/spectral/ipa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mongodb-js/ipa-validation-ruleset",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Custom validation rules for MongoDB API Standards (IPA).",
   "keywords": [
     "mongodb",


### PR DESCRIPTION
## Proposed changes

New IPA validation version:
- feat(ipa): new IPA rule xgen-IPA-125-discriminator-must-accompany-oneOf-anyOf-allOf [`#893`](https://github.com/mongodb/openapi/pull/893)
- fix(ipa): include schema descriptions in IPA117 rules [`#895`](https://github.com/mongodb/openapi/pull/895)
  - Breaking change

_Jira ticket:_ CLOUDP-308542
