### PR TITLE
feat(ipa): new rules for operation summaries starting with specific words

### DIFF
--- a/tools/spectral/ipa/__tests__/IPA117OperationSummaryCreateStartsWith.test.js
+++ b/tools/spectral/ipa/__tests__/IPA117OperationSummaryCreateStartsWith.test.js
@@ -1,0 +1,93 @@
+import testRule from './__helpers__/testRule';
+import { DiagnosticSeverity } from '@stoplight/types';
+
+testRule('xgen-IPA-117-create-operation-summary-starts-with', [
+  {
+    name: 'valid summary',
+    document: {
+      paths: {
+        '/resource': {
+          post: {
+            summary: 'Create One Resource',
+          },
+        },
+        '/projects/{id}/users': {
+          post: {
+            summary: 'Add One User to One Project',
+          },
+        },
+        '/projects/{id}/users:invite': {
+          // Ignores custom method
+          post: {
+            summary: 'Invite One User to One Project',
+          },
+        },
+        '/projects/{id}/users/invite': {
+          // Ignores legacy custom method
+          post: {
+            summary: 'Invite One User to One Project',
+            'x-xgen-method-verb-override': {
+              customMethod: true,
+            },
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+  {
+    name: 'invalid summaries',
+    document: {
+      paths: {
+        '/resource': {
+          post: {
+            summary: 'Creating One Resource',
+          },
+        },
+        '/projects/{id}/users': {
+          post: {
+            summary: 'Adds One User to One Project',
+          },
+        },
+      },
+    },
+    errors: [
+      {
+        code: 'xgen-IPA-117-create-operation-summary-starts-with',
+        message: 'Operation summary must start with one of the words [Create,Add].',
+        path: ['paths', '/resource', 'post'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        code: 'xgen-IPA-117-create-operation-summary-starts-with',
+        message: 'Operation summary must start with one of the words [Create,Add].',
+        path: ['paths', '/projects/{id}/users', 'post'],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
+  {
+    name: 'invalid summary with exceptions',
+    document: {
+      paths: {
+        '/resource': {
+          post: {
+            summary: 'Creating One Resource',
+            'x-xgen-IPA-exception': {
+              'xgen-IPA-117-create-operation-summary-starts-with': 'reason',
+            },
+          },
+        },
+        '/projects/{id}/users': {
+          post: {
+            summary: 'Adds One User to One Project',
+            'x-xgen-IPA-exception': {
+              'xgen-IPA-117-create-operation-summary-starts-with': 'reason',
+            },
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+]);

--- a/tools/spectral/ipa/__tests__/IPA117OperationSummaryDeleteStartsWith.test.js
+++ b/tools/spectral/ipa/__tests__/IPA117OperationSummaryDeleteStartsWith.test.js
@@ -1,0 +1,78 @@
+import testRule from './__helpers__/testRule';
+import { DiagnosticSeverity } from '@stoplight/types';
+
+testRule('xgen-IPA-117-delete-operation-summary-starts-with', [
+  {
+    name: 'valid summary',
+    document: {
+      paths: {
+        '/resource': {
+          delete: {
+            summary: 'Delete One Resource',
+          },
+        },
+        '/projects/{id}/users': {
+          delete: {
+            summary: 'Remove One User from One Project',
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+  {
+    name: 'invalid summaries',
+    document: {
+      paths: {
+        '/resource': {
+          delete: {
+            summary: 'Destroy One Resource',
+          },
+        },
+        '/projects/{id}/users': {
+          delete: {
+            summary: 'Deletes One User from One Project',
+          },
+        },
+      },
+    },
+    errors: [
+      {
+        code: 'xgen-IPA-117-delete-operation-summary-starts-with',
+        message: 'Operation summary must start with one of the words [Delete,Remove].',
+        path: ['paths', '/resource', 'delete'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        code: 'xgen-IPA-117-delete-operation-summary-starts-with',
+        message: 'Operation summary must start with one of the words [Delete,Remove].',
+        path: ['paths', '/projects/{id}/users', 'delete'],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
+  {
+    name: 'invalid summary with exceptions',
+    document: {
+      paths: {
+        '/resource': {
+          delete: {
+            summary: 'Destroy One Resource',
+            'x-xgen-IPA-exception': {
+              'xgen-IPA-117-delete-operation-summary-starts-with': 'reason',
+            },
+          },
+        },
+        '/projects/{id}/users': {
+          delete: {
+            summary: 'Deletes One User from One Project',
+            'x-xgen-IPA-exception': {
+              'xgen-IPA-117-delete-operation-summary-starts-with': 'reason',
+            },
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+]);

--- a/tools/spectral/ipa/__tests__/IPA117OperationSummaryUpdateStartsWith.test.js
+++ b/tools/spectral/ipa/__tests__/IPA117OperationSummaryUpdateStartsWith.test.js
@@ -1,0 +1,78 @@
+import testRule from './__helpers__/testRule';
+import { DiagnosticSeverity } from '@stoplight/types';
+
+testRule('xgen-IPA-117-update-operation-summary-starts-with', [
+  {
+    name: 'valid summary',
+    document: {
+      paths: {
+        '/resource': {
+          patch: {
+            summary: 'Update One Resource',
+          },
+        },
+        '/projects/{id}/users': {
+          put: {
+            summary: 'Update One User in One Project',
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+  {
+    name: 'invalid summaries',
+    document: {
+      paths: {
+        '/resource': {
+          patch: {
+            summary: 'Modify One Resource',
+          },
+        },
+        '/projects/{id}/users': {
+          put: {
+            summary: 'Change One User to One Project',
+          },
+        },
+      },
+    },
+    errors: [
+      {
+        code: 'xgen-IPA-117-update-operation-summary-starts-with',
+        message: 'Operation summary must start with the word "Update".',
+        path: ['paths', '/resource', 'patch'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        code: 'xgen-IPA-117-update-operation-summary-starts-with',
+        message: 'Operation summary must start with the word "Update".',
+        path: ['paths', '/projects/{id}/users', 'put'],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
+  {
+    name: 'invalid summary with exceptions',
+    document: {
+      paths: {
+        '/resource': {
+          patch: {
+            summary: 'Modify One Resource',
+            'x-xgen-IPA-exception': {
+              'xgen-IPA-117-update-operation-summary-starts-with': 'reason',
+            },
+          },
+        },
+        '/projects/{id}/users': {
+          put: {
+            summary: 'Change One User to One Project',
+            'x-xgen-IPA-exception': {
+              'xgen-IPA-117-update-operation-summary-starts-with': 'reason',
+            },
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+]);

--- a/tools/spectral/ipa/rulesets/IPA-117.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-117.yaml
@@ -12,7 +12,7 @@ functions:
   - IPA117ObjectsMustBeWellDefined
   - IPA117ParameterHasExamplesOrSchema
   - IPA117OperationSummaryFormat
-  - IPA117OperationSummaryGetStartsWith
+  - IPA117OperationSummaryStartsWith
 
 aliases:
   OperationObject:
@@ -298,7 +298,66 @@ rules:
     given:
       - '$.paths[*][get].summary'
     then:
-      function: 'IPA117OperationSummaryGetStartsWith'
+      function: 'IPA117OperationSummaryStartsWith'
       functionOptions:
         allowedStartVerbs:
           - Return
+  xgen-IPA-117-update-operation-summary-starts-with:
+    description: |
+      In operation summaries, use 'Update' instead of 'Modify' or 'Change'. For example "Update One Identity Provider".
+
+      ##### Implementation details
+      - The rule checks that the `summary` property of update operations use the word 'Update' as the first word.
+      - The rule only applies to update methods and ignores custom methods
+      ##### Configuration
+      This rule includes a configuration option:
+        - `allowedStartVerbs`: Allow list of verb that the operation summary can start with, defaults to `['Update']`
+    message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-117-update-operation-summary-starts-with'
+    severity: warn
+    given:
+      - '$.paths[*][put,patch].summary'
+    then:
+      function: 'IPA117OperationSummaryStartsWith'
+      functionOptions:
+        allowedStartVerbs:
+          - Update
+  xgen-IPA-117-create-operation-summary-starts-with:
+    description: |
+      In operation summaries, use 'Create' when the operation is creating a resource, and use 'Add' when the resource itself isn't being created. For example "Create One Identity Provider" or "Add One MongoDB Cloud User to One Project".
+
+      ##### Implementation details
+      - The rule checks that the `summary` property of create operations use the word 'Create' or 'Add' as the first word.
+      - The rule only applies to create methods and ignores custom methods
+      ##### Configuration
+      This rule includes a configuration option:
+        - `allowedStartVerbs`: Allow list of verb that the operation summary can start with, defaults to `['Create', 'Add']`
+    message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-117-create-operation-summary-starts-with'
+    severity: warn
+    given:
+      - '$.paths[*][post].summary'
+    then:
+      function: 'IPA117OperationSummaryStartsWith'
+      functionOptions:
+        allowedStartVerbs:
+          - Create
+          - Add
+  xgen-IPA-117-delete-operation-summary-starts-with:
+    description: |
+      In operation summaries, use 'Delete' when the operation is destroying a resource, and use 'Remove' when the resource itself isn't being destroyed. For example "Delete One Identity Provider" or "Remove One MongoDB Cloud User from One Project".
+
+      ##### Implementation details
+      - The rule checks that the `summary` property of delete operations use the word 'Delete' or 'Remove' as the first word.
+      - The rule only applies to delete methods and ignores custom methods
+      ##### Configuration
+      This rule includes a configuration option:
+        - `allowedStartVerbs`: Allow list of verb that the operation summary can start with, defaults to `['Delete', 'Remove']`
+    message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-117-delete-operation-summary-starts-with'
+    severity: warn
+    given:
+      - '$.paths[*][delete].summary'
+    then:
+      function: 'IPA117OperationSummaryStartsWith'
+      functionOptions:
+        allowedStartVerbs:
+          - Delete
+          - Remove

--- a/tools/spectral/ipa/rulesets/README.md
+++ b/tools/spectral/ipa/rulesets/README.md
@@ -876,6 +876,42 @@ In operation summaries, use 'Return' instead of 'Get' or 'List'. For example "Re
 This rule includes a configuration option:
   - `allowedStartVerbs`: Allow list of verb that the operation summary can start with, defaults to `['Return']`
 
+#### xgen-IPA-117-update-operation-summary-starts-with
+
+ ![warn](https://img.shields.io/badge/warning-yellow) 
+In operation summaries, use 'Update' instead of 'Modify' or 'Change'. For example "Update One Identity Provider".
+
+##### Implementation details
+- The rule checks that the `summary` property of update operations use the word 'Update' as the first word.
+- The rule only applies to update methods and ignores custom methods
+##### Configuration
+This rule includes a configuration option:
+  - `allowedStartVerbs`: Allow list of verb that the operation summary can start with, defaults to `['Update']`
+
+#### xgen-IPA-117-create-operation-summary-starts-with
+
+ ![warn](https://img.shields.io/badge/warning-yellow) 
+In operation summaries, use 'Create' when the operation is creating a resource, and use 'Add' when the resource itself isn't being created. For example "Create One Identity Provider" or "Add One MongoDB Cloud User to One Project".
+
+##### Implementation details
+- The rule checks that the `summary` property of create operations use the word 'Create' or 'Add' as the first word.
+- The rule only applies to create methods and ignores custom methods
+##### Configuration
+This rule includes a configuration option:
+  - `allowedStartVerbs`: Allow list of verb that the operation summary can start with, defaults to `['Create', 'Add']`
+
+#### xgen-IPA-117-delete-operation-summary-starts-with
+
+ ![warn](https://img.shields.io/badge/warning-yellow) 
+In operation summaries, use 'Delete' when the operation is destroying a resource, and use 'Remove' when the resource itself isn't being destroyed. For example "Delete One Identity Provider" or "Remove One MongoDB Cloud User from One Project".
+
+##### Implementation details
+- The rule checks that the `summary` property of delete operations use the word 'Delete' or 'Remove' as the first word.
+- The rule only applies to delete methods and ignores custom methods
+##### Configuration
+This rule includes a configuration option:
+  - `allowedStartVerbs`: Allow list of verb that the operation summary can start with, defaults to `['Delete', 'Remove']`
+
 
 
 ### IPA-118

--- a/tools/spectral/ipa/rulesets/functions/IPA117OperationSummaryStartsWith.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA117OperationSummaryStartsWith.js
@@ -31,7 +31,6 @@ function checkViolationsAndReturnErrors(summary, allowedStartVerbs, path, ruleNa
     const firstWord = summary.split(' ')[0];
 
     if (!allowedStartVerbs.includes(firstWord)) {
-      console.log(summary, '\n');
       if (allowedStartVerbs.length === 1) {
         return [
           {
@@ -40,7 +39,6 @@ function checkViolationsAndReturnErrors(summary, allowedStartVerbs, path, ruleNa
           },
         ];
       } else {
-        console.log(summary, '\n');
         return [
           {
             path,

--- a/tools/spectral/ipa/rulesets/functions/IPA117OperationSummaryStartsWith.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA117OperationSummaryStartsWith.js
@@ -5,7 +5,7 @@ import { hasCustomMethodOverride } from './utils/extensions.js';
 
 /**
  * Checks if the operation summary starts with one of the allowed verbs in the 'allowedStartVerbs' list. The rule ignores custom methods.
- * Note: This rule is used by multiple rules evaluating get/list, update, delete and create.
+ * Note: This function is used by multiple rules evaluating get/list, update, delete and create.
  * @param input the operation summary to evaluate
  * @param allowedStartVerbs the list of allowed verbs that the operation summary must start with
  * @param path the path to the operation object summary in the document

--- a/tools/spectral/ipa/rulesets/functions/IPA117OperationSummaryStartsWith.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA117OperationSummaryStartsWith.js
@@ -3,6 +3,16 @@ import { resolveObject } from './utils/componentUtils.js';
 import { isCustomMethodIdentifier } from './utils/resourceEvaluation.js';
 import { hasCustomMethodOverride } from './utils/extensions.js';
 
+/**
+ * Checks if the operation summary starts with one of the allowed verbs in the 'allowedStartVerbs' list. The rule ignores custom methods.
+ * Note: This rule is used by multiple rules evaluating get/list, update, delete and create.
+ * @param input the operation summary to evaluate
+ * @param allowedStartVerbs the list of allowed verbs that the operation summary must start with
+ * @param path the path to the operation object summary in the document
+ * @param rule the rule object containing the rule name and other metadata
+ * @param documentInventory the document inventory containing the resolved OAS document
+ * @returns {Array<{path: Array<string>, message: string}>|undefined} error if the summary does not start with one of the allowed verbs, or undefined if there are no errors
+ */
 export default (input, { allowedStartVerbs }, { path, rule, documentInventory }) => {
   const resourcePath = path[1];
   const operationObjectPath = path.slice(0, -1);
@@ -21,6 +31,7 @@ function checkViolationsAndReturnErrors(summary, allowedStartVerbs, path, ruleNa
     const firstWord = summary.split(' ')[0];
 
     if (!allowedStartVerbs.includes(firstWord)) {
+      console.log(summary, '\n');
       if (allowedStartVerbs.length === 1) {
         return [
           {
@@ -29,6 +40,7 @@ function checkViolationsAndReturnErrors(summary, allowedStartVerbs, path, ruleNa
           },
         ];
       } else {
+        console.log(summary, '\n');
         return [
           {
             path,


### PR DESCRIPTION
## Proposed changes

Adds new rules to check that operation summaries start with specific words:
- `xgen-IPA-117-create-operation-summary-starts-with`
- `xgen-IPA-117-update-operation-summary-starts-with`
- `xgen-IPA-117-delete-operation-summary-starts-with`

Reuses the same function as for the previously introduced `xgen-IPA-117-get-operation-summary-starts-with` with configurable allowed words.

13 new violations, will update OAS as follow-up.

_Jira ticket:_ [CLOUDP-319114](https://jira.mongodb.org/browse/CLOUDP-319114)
