### PR TITLE
ci: temp disable automatic OAS release

### DIFF
--- a/.github/workflows/release-spec-runner.yml
+++ b/.github/workflows/release-spec-runner.yml
@@ -15,8 +15,8 @@ on:
           - dev,qa
         default: 'dev'
         required: false
-  schedule:
-    - cron: '0 */2 * * 1-5' # Run every 2 hours from Monday to Friday
+#  schedule: # Temporarily disabled to avoid automatic runs for op ID release, will be re-enabled after the 20250827 release (CLOUDP-304020)
+#    - cron: '0 */2 * * 1-5' # Run every 2 hours from Monday to Friday
 permissions:
   contents: write
   pull-requests: write


### PR DESCRIPTION
## Proposed changes

Temp disable automatic OAS release for tomorrows prod release, will run it manually and then re-enable the cron again.

_Jira ticket:_ [CLOUDP-304020](https://jira.mongodb.org/browse/CLOUDP-304020)
