### PR TITLE
ci: Revert temp disable automatic OAS release

### DIFF
--- a/.github/workflows/release-spec-runner.yml
+++ b/.github/workflows/release-spec-runner.yml
@@ -15,8 +15,8 @@ on:
           - dev,qa
         default: 'dev'
         required: false
-#  schedule: # Temporarily disabled to avoid automatic runs for op ID release, will be re-enabled after the 20250827 release (CLOUDP-304020)
-#    - cron: '0 */2 * * 1-5' # Run every 2 hours from Monday to Friday
+  schedule:
+    - cron: '0 */2 * * 1-5' # Run every 2 hours from Monday to Friday
 permissions:
   contents: write
   pull-requests: write


### PR DESCRIPTION
This reverts commit df29191d92152f083c276f2ae99940e4606fc28b.

Re-enables automatic OAS releases.
