### PR TITLE
fix(ipa): Fix IPA005 rule to allow camel case and numbers in rule name

### DIFF
--- a/tools/spectral/ipa/__tests__/IPA005ExceptionExtensionFormat.test.js
+++ b/tools/spectral/ipa/__tests__/IPA005ExceptionExtensionFormat.test.js
@@ -16,11 +16,22 @@ testRule('xgen-IPA-005-exception-extension-format', [
             'xgen-IPA-100': 'Exception.',
           },
         },
+        '/path-camelCase': {
+          'x-xgen-IPA-exception': {
+            'xgen-IPA-125-rule-name-camelCase': 'Exception.',
+          },
+        },
+        '/path-numbers': {
+          'x-xgen-IPA-exception': {
+            'xgen-IPA-117-rule-name-1': 'Exception.',
+          },
+        },
         '/nested': {
           post: {
             'x-xgen-IPA-exception': {
               'xgen-IPA-100-rule-name': 'Exception.',
               'xgen-IPA-005': 'Short format exception.',
+              'xgen-IPA-112-camelCase': 'CamelCase exception.',
             },
           },
         },

--- a/tools/spectral/ipa/rulesets/IPA-005.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-005.yaml
@@ -11,8 +11,9 @@ rules:
 
       ##### Implementation details
       Rule checks for the following conditions:
-        - Exception rule names must start with 'xgen-IPA-' prefix
+        - Exception rule names must start with 'xgen-IPA-' prefix followed by exactly 3 digits
         - Exception rule names can be either short format (xgen-IPA-XXX) or full format (xgen-IPA-XXX-rule-name)
+        - Rule names in full format can use letters (upper/lowercase), numbers, and hyphens
         - Each exception must include a non-empty reason as a string that starts with uppercase and ends with a full stop
         - This rule itself does not allow exceptions
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-005-exception-extension-format'

--- a/tools/spectral/ipa/rulesets/README.md
+++ b/tools/spectral/ipa/rulesets/README.md
@@ -19,8 +19,9 @@ IPA exception extensions must follow the correct format.
 
 ##### Implementation details
 Rule checks for the following conditions:
-  - Exception rule names must start with 'xgen-IPA-' prefix
+  - Exception rule names must start with 'xgen-IPA-' prefix followed by exactly 3 digits
   - Exception rule names can be either short format (xgen-IPA-XXX) or full format (xgen-IPA-XXX-rule-name)
+  - Rule names in full format can use letters (upper/lowercase), numbers, and hyphens
   - Each exception must include a non-empty reason as a string that starts with uppercase and ends with a full stop
   - This rule itself does not allow exceptions
 

--- a/tools/spectral/ipa/rulesets/functions/IPA005ExceptionExtensionFormat.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA005ExceptionExtensionFormat.js
@@ -1,7 +1,4 @@
-import {
-  evaluateAndCollectAdoptionStatusWithoutExceptions,
-  handleInternalError,
-} from './utils/collectionUtils.js';
+import { evaluateAndCollectAdoptionStatusWithoutExceptions, handleInternalError } from './utils/collectionUtils.js';
 
 const ERROR_MESSAGE_RULENAME_FORMAT =
   'IPA exceptions must have a valid key following xgen-IPA-XXX or xgen-IPA-XXX-{rule-name} format.';

--- a/tools/spectral/ipa/rulesets/functions/IPA005ExceptionExtensionFormat.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA005ExceptionExtensionFormat.js
@@ -1,10 +1,13 @@
-import { evaluateAndCollectAdoptionStatusWithoutExceptions, handleInternalError } from './utils/collectionUtils.js';
+import {
+  evaluateAndCollectAdoptionStatusWithoutExceptions,
+  handleInternalError,
+} from './utils/collectionUtils.js';
 
 const ERROR_MESSAGE_RULENAME_FORMAT =
   'IPA exceptions must have a valid key following xgen-IPA-XXX or xgen-IPA-XXX-{rule-name} format.';
 const ERROR_MESSAGE_REASON_FORMAT =
   'IPA exceptions must have a non-empty reason that starts with uppercase and ends with a full stop.';
-const RULE_NAME_PATTERN = /^xgen-IPA-\d{3}(?:-[a-z-]+)?$/;
+const RULE_NAME_PATTERN = /^xgen-IPA-\d{3}(?:-[a-zA-Z0-9-]+)?$/;
 
 // Note: This rule does not allow exceptions
 export default (input, _, { path, rule }) => {


### PR DESCRIPTION
## Proposed changes

Allow camelCase and numbers in rule name

_Jira ticket:_ CLOUDP-342534

<!--
What issue does this PR address? (for example, #1234), remove this section if none.
-->


## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works

### Changes to Spectral
- [ ] I have read the [README](../tools/spectral/README.md) file for Spectral Updates

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
