### PR TITLE
fix: add optional --run-date flag for deterministic changelog tests

### DIFF
--- a/tools/cli/internal/changelog/changelog.go
+++ b/tools/cli/internal/changelog/changelog.go
@@ -108,6 +108,11 @@ type Change struct {
 // The returned entries includes all the changes between the base and revision specs included the one
 // marked as hidden.
 func NewEntries(basePath, revisionPath, exceptionFilePath string) ([]*Entry, error) {
+	return NewEntriesWithRunDate(basePath, revisionPath, exceptionFilePath, time.Now().Format("2006-01-02"))
+}
+
+// NewEntriesWithRunDate generates the changelog entries with a specific run date.
+func NewEntriesWithRunDate(basePath, revisionPath, exceptionFilePath, runDate string) ([]*Entry, error) {
 	baseMetadata, err := newMetadataFromFile(basePath)
 	if err != nil {
 		return nil, err
@@ -120,7 +125,7 @@ func NewEntries(basePath, revisionPath, exceptionFilePath string) ([]*Entry, err
 	}
 	log.Printf("Revision Metadata: %s", newStringFromStruct(revisionMetadata))
 
-	revisionMetadata.RunDate = time.Now().Format("2006-01-02")
+	revisionMetadata.RunDate = runDate
 
 	baseActiveVersionOnPreviousRunDate, err := latestVersionActiveOnDate(baseMetadata.RunDate, baseMetadata.Versions)
 	if err != nil {
@@ -208,7 +213,12 @@ func NewEntries(basePath, revisionPath, exceptionFilePath string) ([]*Entry, err
 // The returned entries includes the changes between the base and revision specs that are not
 // marked as hidden.
 func NewEntriesWithoutHidden(basePath, revisionPath, exceptionFilePath string) ([]*Entry, error) {
-	entries, err := NewEntries(basePath, revisionPath, exceptionFilePath)
+	return NewEntriesWithoutHiddenWithRunDate(basePath, revisionPath, exceptionFilePath, time.Now().Format("2006-01-02"))
+}
+
+// NewEntriesWithoutHiddenWithRunDate generates the changelog entries with a specific run date.
+func NewEntriesWithoutHiddenWithRunDate(basePath, revisionPath, exceptionFilePath, runDate string) ([]*Entry, error) {
+	entries, err := NewEntriesWithRunDate(basePath, revisionPath, exceptionFilePath, runDate)
 	if err != nil {
 		return nil, err
 	}
@@ -218,6 +228,11 @@ func NewEntriesWithoutHidden(basePath, revisionPath, exceptionFilePath string) (
 
 // NewEntriesBetweenRevisionVersions generates the changelog entries between the revision versions.
 func NewEntriesBetweenRevisionVersions(revisionPath, exceptionFilePath string) ([]*Entry, error) {
+	return NewEntriesBetweenRevisionVersionsWithRunDate(revisionPath, exceptionFilePath, time.Now().Format("2006-01-02"))
+}
+
+// NewEntriesBetweenRevisionVersionsWithRunDate generates the changelog entries between the revision versions with a specific run date.
+func NewEntriesBetweenRevisionVersionsWithRunDate(revisionPath, exceptionFilePath, runDate string) ([]*Entry, error) {
 	revisionMetadata, err := newMetadataFromFile(revisionPath)
 	if err != nil {
 		return nil, err
@@ -231,7 +246,7 @@ func NewEntriesBetweenRevisionVersions(revisionPath, exceptionFilePath string) (
 				continue
 			}
 
-			entry, err := newEntriesBetweenVersion(revisionMetadata, fromVersion, toVersion, exceptionFilePath)
+			entry, err := newEntriesBetweenVersionWithRunDate(revisionMetadata, fromVersion, toVersion, exceptionFilePath, runDate)
 			if err != nil {
 				return nil, err
 			}
@@ -242,11 +257,11 @@ func NewEntriesBetweenRevisionVersions(revisionPath, exceptionFilePath string) (
 	return newVersionEntries(entries), nil
 }
 
-func newEntriesBetweenVersion(metadata *Metadata, fromVersion, toVersion, exceptionFilePath string) (*Entry, error) {
+func newEntriesBetweenVersionWithRunDate(metadata *Metadata, fromVersion, toVersion, exceptionFilePath, runDate string) (*Entry, error) {
 	baseMetadata := &Metadata{
 		Path:          metadata.Path,
 		ActiveVersion: fromVersion,
-		RunDate:       time.Now().Format("2006-01-02"),
+		RunDate:       runDate,
 		SpecRevision:  metadata.SpecRevision,
 		Versions:      metadata.Versions,
 	}
@@ -254,7 +269,7 @@ func newEntriesBetweenVersion(metadata *Metadata, fromVersion, toVersion, except
 	revisionMetadata := &Metadata{
 		Path:          metadata.Path,
 		ActiveVersion: toVersion,
-		RunDate:       time.Now().Format("2006-01-02"),
+		RunDate:       runDate,
 		SpecRevision:  metadata.SpecRevision,
 		Versions:      metadata.Versions,
 	}

--- a/tools/cli/test/e2e/cli/changelog_test.go
+++ b/tools/cli/test/e2e/cli/changelog_test.go
@@ -140,6 +140,8 @@ func TestChangelog(t *testing.T) {
 			exemptions,
 			"-o",
 			commandOut,
+			"--run-date",
+			"2025-06-15", // Fixed date after base run date but before sunset date
 		)
 
 		var o, e bytes.Buffer


### PR DESCRIPTION
## Proposed changes

Added optional `--run-date` parameter to `changelog create` command to allow fixed dates in tests. 
Fixes e2e test failure where sunset endpoints were incorrectly detected due to current date vs test data mismatch.

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-346601

<!--
What issue does this PR address? (for example, #1234), remove this section if none.
-->

Closes #[issue number]

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works

### Changes to Spectral
- [ ] I have read the [README](../tools/spectral/README.md) file for Spectral Updates

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
