### PR TITLE
fix: revert: "chore: bump parquet-wasm from 0.6.1 to 0.7.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
                 "inflection": "^3.0.2",
                 "markdown-table": "^3.0.4",
                 "openapi-to-postmanv2": "5.2.0",
-                "parquet-wasm": "^0.7.0"
+                "parquet-wasm": "^0.6.1"
             },
             "devDependencies": {
                 "@babel/core": "^7.28.4",
@@ -10568,9 +10568,9 @@
             }
         },
         "node_modules/parquet-wasm": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/parquet-wasm/-/parquet-wasm-0.7.0.tgz",
-            "integrity": "sha512-BYFzpSNs/Rl++dWuNgwNZTggI8y4ABdO1zblumULrXy/gkC8qCqw4O2l5tfRQHgfAEls50jamqwCFUnWT10QiA==",
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/parquet-wasm/-/parquet-wasm-0.6.1.tgz",
+            "integrity": "sha512-wTM/9Y4EHny8i0qgcOlL9UHsTXftowwCqDsAD8axaZbHp0Opp3ue8oxexbzTVNhqBjFhyhLiU3MT0rnEYnYU0Q==",
             "license": "MIT OR Apache-2.0"
         },
         "node_modules/parse-json": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "inflection": "^3.0.2",
         "markdown-table": "^3.0.4",
         "openapi-to-postmanv2": "5.2.0",
-        "parquet-wasm": "^0.7.0"
+        "parquet-wasm": "^0.6.1"
     },
     "devDependencies": {
         "@babel/core": "^7.28.4",


### PR DESCRIPTION
Reverts mongodb/openapi#960

Related to issue https://github.com/mongodb/openapi/issues/964