### PR TITLE
CLOUDP-347212: Update release-IPA-metrics.yml to run once per week

### DIFF
--- a/.github/workflows/release-IPA-metrics.yml
+++ b/.github/workflows/release-IPA-metrics.yml
@@ -3,7 +3,7 @@
 name: IPA Validation Metrics Release
 on:
   schedule:
-    - cron: '0 11 * * *'  # Runs daily at 11:00 UTC (11 AM UTC)
+    - cron: '0 11 * * 0'  # Runs every Sunday at 11:00 UTC (11 AM UTC)
   workflow_dispatch:
 permissions:
   issues: write


### PR DESCRIPTION
## Proposed changes

Updating the IPA Metric collection job to run once a week rather than once a day

The OpenAPI spec isn't updated that regularly, so running every day creates a lot of unnecessary data redundancy

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-347212

<!--
What issue does this PR address? (for example, #1234), remove this section if none.
-->

Closes #[issue number]

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works

### Changes to Spectral
- [ ] I have read the [README](../tools/spectral/README.md) file for Spectral Updates

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
