### PR TITLE
ci(ipa): make IPA metrics collection more efficient

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 *.vscode
 *.DS_Store
 
+/tools/spectral/**/outputs/*
 *.out
 **/*ipa-collector-results-combined.log
 **/*metric-collection-results.parquet


### PR DESCRIPTION
## Proposed changes

Adjusted metrics collection logic to run faster/be more efficient. Now it runs in ~8 seconds locally. Previous GH action runs have been taking ~50 mins.

_Jira ticket:_ [CLOUDP-347215](https://jira.mongodb.org/browse/CLOUDP-347215)
