### PR TITLE
ci: ensure JS test runs on package update

### DIFF
--- a/.github/workflows/code-health-tools.yml
+++ b/.github/workflows/code-health-tools.yml
@@ -6,12 +6,16 @@ on:
     paths: 
       - 'tools/postman/**'
       - 'tools/spectral/**'
+      - 'package.json'
+      - 'tools/spectral/ipa/package.json'
   pull_request:
     branches:
       - main
     paths:
       - 'tools/postman/**'
       - 'tools/spectral/**'
+      - 'package.json'
+      - 'tools/spectral/ipa/package.json'
   workflow_dispatch: {}
   workflow_call: {}
 


### PR DESCRIPTION
## Proposed changes

We had a failure for IPA metrics collection due to package update. This ensures JS tests are run on package updates so we see the failures in the dependabot PRs before merging. 

Also useful to run the tests when IPA validation ruleset package version is updated for release.

_Jira ticket:_ [CLOUDP-347188](https://jira.mongodb.org/browse/CLOUDP-347188)
