### PR TITLE
feat(prod): Add support for custom budges for preview APIs

### DIFF
--- a/tools/cli/internal/openapi/filter/bump.go
+++ b/tools/cli/internal/openapi/filter/bump.go
@@ -35,7 +35,7 @@ const (
 	stateFieldName              = "x-state"
 	stateFieldValueUpcoming     = "UPCOMING"
 	stateFieldValuePreview      = "PREVIEW"
-	stateFieldValuePreviewColor = "#F2FF35" // Yellow
+	stateFieldValuePreviewColor = "#D5B60A" // Yellow
 	betaFieldName               = "x-beta"
 	description                 = `This API is in preview. Breaking changes might be introduced ` +
 		`before it is released. Don't use preview APIs in production.

--- a/tools/cli/internal/openapi/filter/bump.go
+++ b/tools/cli/internal/openapi/filter/bump.go
@@ -26,12 +26,19 @@ type BumpFilter struct {
 	metadata *Metadata
 }
 
+type state struct {
+	label string
+	color string
+}
+
 const (
-	stateFieldName          = "x-state"
-	stateFieldValueUpcoming = "UPCOMING"
-	stateFieldValuePreview  = "PREVIEW"
-	betaFieldName           = "x-beta"
-	description             = `This API is in preview. Breaking changes might be introduced before it is released. Don't use preview APIs in production.
+	stateFieldName              = "x-state"
+	stateFieldValueUpcoming     = "UPCOMING"
+	stateFieldValuePreview      = "PREVIEW"
+	stateFieldValuePreviewColor = "#F2FF35" // Yellow
+	betaFieldName               = "x-beta"
+	description                 = `This API is in preview. Breaking changes might be introduced ` +
+		`before it is released. Don't use preview APIs in production.
 
 `
 )
@@ -71,7 +78,10 @@ func (f *BumpFilter) includeBumpFieldForPreview() error {
 			if op.Extensions == nil {
 				op.Extensions = map[string]any{}
 			}
-			op.Extensions[stateFieldName] = stateFieldValuePreview
+			op.Extensions[stateFieldName] = state{
+				label: stateFieldValuePreview,
+				color: stateFieldValuePreviewColor,
+			}
 			op.Extensions[betaFieldName] = true
 			op.Description = description + " " + op.Description
 		}

--- a/tools/cli/internal/openapi/filter/bump.go
+++ b/tools/cli/internal/openapi/filter/bump.go
@@ -26,9 +26,9 @@ type BumpFilter struct {
 	metadata *Metadata
 }
 
-type state struct {
-	label string
-	color string
+type State struct {
+	Label string `json:"label"`
+	Color string `json:"color"`
 }
 
 const (
@@ -78,9 +78,9 @@ func (f *BumpFilter) includeBumpFieldForPreview() error {
 			if op.Extensions == nil {
 				op.Extensions = map[string]any{}
 			}
-			op.Extensions[stateFieldName] = state{
-				label: stateFieldValuePreview,
-				color: stateFieldValuePreviewColor,
+			op.Extensions[stateFieldName] = State{
+				Label: stateFieldValuePreview,
+				Color: stateFieldValuePreviewColor,
 			}
 			op.Extensions[betaFieldName] = true
 			op.Description = description + " " + op.Description

--- a/tools/cli/internal/openapi/filter/bump.go
+++ b/tools/cli/internal/openapi/filter/bump.go
@@ -35,7 +35,7 @@ const (
 	stateFieldName              = "x-state"
 	stateFieldValueUpcoming     = "UPCOMING"
 	stateFieldValuePreview      = "PREVIEW"
-	stateFieldValuePreviewColor = "#D5B60A" // Yellow
+	stateFieldValuePreviewColor = "#B89D09" // Yellow
 	betaFieldName               = "x-beta"
 	description                 = `This API is in preview. Breaking changes might be introduced ` +
 		`before it is released. Don't use preview APIs in production.

--- a/tools/cli/internal/openapi/filter/bump_test.go
+++ b/tools/cli/internal/openapi/filter/bump_test.go
@@ -67,7 +67,9 @@ func TestBumpFilter_Apply_Preview(t *testing.T) {
 
 	op := testPath.Get
 	assert.Contains(t, op.Extensions, "x-state")
-	assert.Equal(t, stateFieldValuePreview, op.Extensions["x-state"])
+	stateProp := op.Extensions["x-state"].(state)
+	assert.Equal(t, stateFieldValuePreview, stateProp.label)
+	assert.Equal(t, stateFieldValuePreviewColor, stateProp.color)
 	assert.Contains(t, op.Extensions, "x-beta")
 	assert.Equal(t, true, op.Extensions["x-beta"])
 	assert.Contains(t, op.Description, description)

--- a/tools/cli/internal/openapi/filter/bump_test.go
+++ b/tools/cli/internal/openapi/filter/bump_test.go
@@ -67,9 +67,9 @@ func TestBumpFilter_Apply_Preview(t *testing.T) {
 
 	op := testPath.Get
 	assert.Contains(t, op.Extensions, "x-state")
-	stateProp := op.Extensions["x-state"].(state)
-	assert.Equal(t, stateFieldValuePreview, stateProp.label)
-	assert.Equal(t, stateFieldValuePreviewColor, stateProp.color)
+	stateProp := op.Extensions["x-state"].(State)
+	assert.Equal(t, stateFieldValuePreview, stateProp.Label)
+	assert.Equal(t, stateFieldValuePreviewColor, stateProp.Color)
 	assert.Contains(t, op.Extensions, "x-beta")
 	assert.Equal(t, true, op.Extensions["x-beta"])
 	assert.Contains(t, op.Description, description)


### PR DESCRIPTION
## Proposed changes
CLOUDP-348863
<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

Add support for custom color (yellow) for preview APIs. https://docs.bump.sh/help/specification-support/doc-badges/#custom-color
<img width="805" height="82" alt="Screenshot 2025-10-06 at 16 11 04" src="https://github.com/user-attachments/assets/64842a0e-f12e-4e2a-b59d-80f4980f4a3d" />

<img width="769" height="77" alt="Screenshot 2025-10-06 at 16 11 16" src="https://github.com/user-attachments/assets/db5cf6f4-bedf-4197-ade9-30480882e222" />


