### PR TITLE
chore: Enable automatic warning-level IPA violation detection

### DIFF
--- a/.github/workflows/release-IPA-metrics.yml
+++ b/.github/workflows/release-IPA-metrics.yml
@@ -43,6 +43,7 @@ jobs:
         working-directory: tools/spectral/ipa/metrics/scripts
         run: |
           node runMetricCollection.js "${{ github.workspace }}/v2.json"
+          echo "WARNING_COUNT=$(cat ../outputs/warning-count.txt)" >> "$GITHUB_ENV"
 
       - name: aws configure
         uses: aws-actions/configure-aws-credentials@v5
@@ -58,9 +59,7 @@ jobs:
         run: node dataDump.js
 
       - name: Handle Warning Violations
-        if: ${{ steps.metric-collection.outputs.warning_count > 0 }}
         env:
-          WARNING_COUNT: ${{ steps.metric-collection.outputs.warning_count }}
           TEAM_ID: ${{ vars.JIRA_TEAM_ID_APIX_PLATFORM }}
           JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
           SLACK_BEARER_TOKEN: ${{ secrets.SLACK_BEARER_TOKEN }}


### PR DESCRIPTION
## Proposed changes

Enable automatic capture of warning-level IPA violations as part of the IPA metrics collection workflow.

_Jira ticket:_ CLOUDP-339852

<!--
What issue does this PR address? (for example, #1234), remove this section if none.
-->



## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works

### Changes to Spectral
- [ ] I have read the [README](../tools/spectral/README.md) file for Spectral Updates

## Testing
IPA validation metrics release job is [run](https://github.com/mongodb/openapi/actions/runs/20266626154) with the changes
<img width="619" height="102" alt="Screenshot 2025-12-16 at 11 47 57" src="https://github.com/user-attachments/assets/8450653c-51d0-41c6-9223-fc9915273b2f" />


<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
