### PR TITLE
ci(ipa): release new version 8.0.0

### DIFF
--- a/tools/spectral/ipa/CHANGELOG.md
+++ b/tools/spectral/ipa/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 All notable changes to this project will be documented in this file. Dates are displayed in UTC.
 
-#### [7.0.0](https://github.com/mongodb/openapi/compare/ipa-validation-ruleset-v6.0.0...7.0.0)
+#### [8.0.0](https://github.com/mongodb/openapi/compare/ipa-validation-ruleset-v7.0.0...8.0.0)
+
+- fix(ipa): Support read-only standard and singleton resources [`#1057`](https://github.com/mongodb/openapi/pull/1057)
+
+### [ipa-validation-ruleset-v7.0.0](https://github.com/mongodb/openapi/compare/ipa-validation-ruleset-v6.0.0...ipa-validation-ruleset-v7.0.0)
+
+> 16 December 2025
 
 - fix(ipa): Update inline tables regex to handle whitespaces [`#1046`](https://github.com/mongodb/openapi/pull/1046)
 - chore(ipa): remove temp overrides [`#1047`](https://github.com/mongodb/openapi/pull/1047)

--- a/tools/spectral/ipa/package.json
+++ b/tools/spectral/ipa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mongodb-js/ipa-validation-ruleset",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "description": "Custom validation rules for MongoDB API Standards (IPA).",
   "keywords": [
     "mongodb",


### PR DESCRIPTION
## Proposed changes

[8.0.0](https://github.com/mongodb/openapi/compare/ipa-validation-ruleset-v7.0.0...8.0.0)

- fix(ipa): Support read-only standard and singleton resources [`#1057`](https://github.com/mongodb/openapi/pull/1057)


## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works

### Changes to Spectral
- [ ] I have read the [README](../tools/spectral/README.md) file for Spectral Updates

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
