### PR TITLE
fix(ipa): Skip read-only validation for resources without GET method

### DIFF
--- a/tools/spectral/ipa/__tests__/utils/resourceEvaluation.test.js
+++ b/tools/spectral/ipa/__tests__/utils/resourceEvaluation.test.js
@@ -523,6 +523,22 @@ describe('tools/spectral/ipa/rulesets/functions/utils/resourceEvaluation.js', ()
         resourcePathItems: readOnlySingleton,
         expected: true,
       },
+      {
+        description: 'resource with xgen-IPA-104-resource-has-GET exception',
+        resourcePathItems: {
+          '/resource': {
+            post: {},
+            'x-xgen-IPA-exception': {
+              'xgen-IPA-104-resource-has-GET': 'Legacy API without GET method.',
+            },
+          },
+          '/resource/{id}': {
+            patch: {},
+            delete: {},
+          },
+        },
+        expected: false,
+      },
     ];
 
     testCases.forEach((testCase) => {

--- a/tools/spectral/ipa/ipa-spectral.yaml
+++ b/tools/spectral/ipa/ipa-spectral.yaml
@@ -107,17 +107,11 @@ overrides:
     rules:
       xgen-IPA-117-description-should-not-use-inline-tables: 'off'
   - files:
-      - '**#/paths/~1api~1atlas~1v2~1groups~1%7BgroupId%7D~1apiKeys/post'
-      - '**#/paths/~1api~1atlas~1v2~1groups~1%7BgroupId%7D~1databaseUsers/post'
-      - '**#/paths/~1api~1atlas~1v2~1groups~1%7BgroupId%7D~1databaseUsers~1%7Busername%7D~1certs/post'
       - '**#/paths/~1api~1atlas~1v2~1groups~1%7BgroupId%7D~1liveMigrations/post'
       - '**#/paths/~1api~1atlas~1v2~1groups~1%7BgroupId%7D~1privateEndpoint~1%7BcloudProvider%7D~1endpointService~1%7BendpointServiceId%7D~1endpoint/post'
       - '**#/paths/~1api~1atlas~1v2~1groups~1%7BgroupId%7D~1privateEndpoint~1serverless~1instance~1%7BinstanceName%7D~1endpoint/post'
-      - '**#/paths/~1api~1atlas~1v2~1groups~1%7BgroupId%7D~1serviceAccounts~1%7BclientId%7D~1accessList/post'
       - '**#/paths/~1api~1atlas~1v2~1groups~1%7BgroupId%7D~1users/post'
       - '**#/paths/~1api~1atlas~1v2~1orgs~1%7BorgId%7D~1resourcePolicies/post'
-      - '**#/paths/~1api~1atlas~1v2~1orgs~1%7BorgId%7D~1serviceAccounts~1%7BclientId%7D~1accessList/post'
-      - '**#/paths/~1api~1atlas~1v2~1orgs~1%7BorgId%7D~1teams~1%7BteamId%7D~1users/post'
       - '**#/paths/~1api~1atlas~1v2~1orgs~1%7BorgId%7D~1users/post'
     rules:
       xgen-IPA-106-readonly-resource-should-not-have-create-method: 'off'

--- a/tools/spectral/ipa/rulesets/IPA-106.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-106.yaml
@@ -122,6 +122,7 @@ rules:
       Rule checks for the following conditions:
         - Applies to POST methods on resource collection paths
         - Checks if the resource is a read-only resource (all properties in GET response have readOnly:true)
+        - If a resource does not have a standard GET method, it is not considered read-only (cannot determine the resource schema)
         - Fails if a Create method is defined on a read-only resource
         - Operation objects with `x-xgen-IPA-exception` for this rule are excluded from validation
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-106-readonly-resource-should-not-have-create-method'

--- a/tools/spectral/ipa/rulesets/IPA-107.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-107.yaml
@@ -122,6 +122,7 @@ rules:
       Rule checks for the following conditions:
         - Applies to PUT/PATCH methods on all resource paths
         - Checks if the resource is a read-only resource (all properties in GET response have readOnly:true)
+        - If a resource does not have a standard GET method, it is not considered read-only (cannot determine the resource schema)
         - Fails if an Update method is defined on a read-only resource
         - Operation objects with `x-xgen-IPA-exception` for this rule are excluded from validation
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-107-readonly-resource-should-not-have-update-method'

--- a/tools/spectral/ipa/rulesets/IPA-108.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-108.yaml
@@ -63,6 +63,7 @@ rules:
       Rule checks for the following conditions:
         - Applies to DELETE methods on single resource paths and singleton resources
         - Checks if the resource is a read-only resource (all properties in GET response have readOnly:true)
+        - If a resource does not have a standard GET method, it is not considered read-only (cannot determine the resource schema)
         - Fails if a Delete method is defined on a read-only resource
         - Operation objects with `x-xgen-IPA-exception` for this rule are excluded from validation
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-108-readonly-resource-should-not-have-delete-method'

--- a/tools/spectral/ipa/rulesets/README.md
+++ b/tools/spectral/ipa/rulesets/README.md
@@ -321,6 +321,7 @@ Read-only resources must not define the Create method.
 Rule checks for the following conditions:
   - Applies to POST methods on resource collection paths
   - Checks if the resource is a read-only resource (all properties in GET response have readOnly:true)
+  - If a resource does not have a standard GET method, it is not considered read-only (cannot determine the resource schema)
   - Fails if a Create method is defined on a read-only resource
   - Operation objects with `x-xgen-IPA-exception` for this rule are excluded from validation
 
@@ -420,6 +421,7 @@ Read-only resources must not define the Update method.
 Rule checks for the following conditions:
   - Applies to PUT/PATCH methods on all resource paths
   - Checks if the resource is a read-only resource (all properties in GET response have readOnly:true)
+  - If a resource does not have a standard GET method, it is not considered read-only (cannot determine the resource schema)
   - Fails if an Update method is defined on a read-only resource
   - Operation objects with `x-xgen-IPA-exception` for this rule are excluded from validation
 
@@ -493,6 +495,7 @@ Read-only resources must not define the Delete method.
 Rule checks for the following conditions:
   - Applies to DELETE methods on single resource paths and singleton resources
   - Checks if the resource is a read-only resource (all properties in GET response have readOnly:true)
+  - If a resource does not have a standard GET method, it is not considered read-only (cannot determine the resource schema)
   - Fails if a Delete method is defined on a read-only resource
   - Operation objects with `x-xgen-IPA-exception` for this rule are excluded from validation
 

--- a/tools/spectral/ipa/rulesets/functions/utils/resourceEvaluation.js
+++ b/tools/spectral/ipa/rulesets/functions/utils/resourceEvaluation.js
@@ -1,3 +1,5 @@
+import { hasException } from './exceptions.js';
+
 export const AUTH_PREFIX = '/api/atlas/v2';
 export const UNAUTH_PREFIX = '/api/atlas/v2/unauth';
 
@@ -252,6 +254,14 @@ export function allPropertiesAreReadOnly(schema) {
  */
 export function isReadOnlyResource(resourcePathItems) {
   const resourcePaths = Object.keys(resourcePathItems);
+
+  // Check if any path has an exception for xgen-IPA-104-resource-has-GET
+  // If so, we cannot determine if the resource is read-only
+  for (const path of resourcePaths) {
+    if (hasException(resourcePathItems[path], 'xgen-IPA-104-resource-has-GET')) {
+      return false;
+    }
+  }
 
   // First, look for a standard Get method
   let getPathItem = null;


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-345756

If a resource does not have a standard GET method, it is not considered read-only (cannot determine the resource schema)

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works

### Changes to Spectral
- [ ] I have read the [README](../tools/spectral/README.md) file for Spectral Updates

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
