### PR TITLE
fix: Latest API version points to preview

### DIFF
--- a/.github/scripts/generateSpecMapping.js
+++ b/.github/scripts/generateSpecMapping.js
@@ -32,6 +32,7 @@ function handleAdminAPIv2() {
     return;
   }
 
+  let latestStableVersion = null;
   for (const [index, version] of versions.entries()) {
     const openapiFilename = `openapi-${version}.json`;
     const openapiFilePath = path.join(path.dirname(filePath), openapiFilename);
@@ -48,14 +49,21 @@ function handleAdminAPIv2() {
       branch: version,
     });
 
-    // We want the latest version to have its own version AND be the latest/default branch
-    if (index === versions.length - 1) {
-      SPEC_MAPPING.push({
+    // last non-preview/non-upcoming is treated as latest stable (versions must be already chronologically ordered)
+    const isPreview = version.includes('preview');
+    const isUpcoming = version.includes('upcoming');
+    if (!isPreview && !isUpcoming) {
+      latestStableVersion = {
         doc: docId,
         file,
         branch: 'latest',
-      });
+      };
     }
+  }
+
+  // last non-preview/non-upcoming is treated as latest stable (versions must be already chronologically ordered)
+  if (latestStableVersion) {
+    SPEC_MAPPING.push(latestStableVersion);
   }
 }
 

--- a/.github/workflows/generate-bump-pages.yml
+++ b/.github/workflows/generate-bump-pages.yml
@@ -53,6 +53,7 @@ jobs:
           BRANCH_NAME: ${{ inputs.branch}}
         run: |
           spec_mapping=$(node release-scripts/generateSpecMapping.js)
+          echo ${spec_mapping}
           echo "matrix=${spec_mapping}" >> "${GITHUB_OUTPUT}"
 
   deploy-doc:


### PR DESCRIPTION
## Proposed changes
Ticket: https://jira.mongodb.org/browse/CLOUDP-373248

This PR updates the admin API spec mapping logic and CI workflow to improve how the latest stable API version is identified and surfaced. The main changes ensure that only the last non-preview/non-upcoming version is marked as the latest stable, and the output of the spec mapping script is now echoed in the workflow for easier debugging.

**Admin API spec mapping improvements:**

* Updated the logic in `handleAdminAPIv2()` within `.github/scripts/generateSpecMapping.js` to treat the last non-preview/non-upcoming version as the latest stable, ensuring only one version is marked as `'latest'` even if preview/upcoming versions exist. [[1]](diffhunk://#diff-67614485fb9ce315103904d12c590c2130d48d854d78450549d6c393e8ad9787R35) [[2]](diffhunk://#diff-67614485fb9ce315103904d12c590c2130d48d854d78450549d6c393e8ad9787L51-R67)

**CI workflow enhancements:**

* Added an explicit echo of the spec mapping output in `.github/workflows/generate-bump-pages.yml` for better visibility during workflow runs.