### PR TITLE
fix(ipa): Add AI to tags ignore list

### DIFF
--- a/tools/spectral/ipa/rulesets/IPA-126.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-126.yaml
@@ -26,6 +26,7 @@ rules:
       function: 'IPA126TagNamesShouldUseTitleCase'
       functionOptions:
         ignoreList:
+          - 'AI'
           - 'AWS'
           - 'DNS'
           - 'API'


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-373279

Update the `xgen-IPA-126-tag-names-should-use-title-case` rule configuration to include "AI" in the ignoreList, allowing it to maintain uppercase formatting in tags.

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works

### Changes to Spectral
- [x] I have read the [README](../tools/spectral/README.md) file for Spectral Updates

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
