### PR TITLE
feat: add to and from flags to FOASCLI sunset diff command

### DIFF
--- a/tools/cli/internal/cli/sunset/diff.go
+++ b/tools/cli/internal/cli/sunset/diff.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/mongodb/openapi/tools/cli/internal/cli/flag"
 	"github.com/mongodb/openapi/tools/cli/internal/cli/usage"
@@ -35,6 +36,10 @@ type DiffOpts struct {
 	specPath   string
 	outputPath string
 	format     string
+	from       string
+	to         string
+	toDate     *time.Time
+	fromDate   *time.Time
 }
 
 type Diff struct {
@@ -68,7 +73,10 @@ func (o *DiffOpts) Run() error {
 	specSunsets := sunset.NewListFromSpec(specInfo)
 
 	// Find differences
-	var diffs = findDiffs(baseSunsets, specSunsets, o.basePath, o.specPath)
+	diffs, err := o.findDiffs(baseSunsets, specSunsets)
+	if err != nil {
+		return err
+	}
 
 	// Write to output
 	bytes, err := o.newSunsetDiffBytes(diffs)
@@ -84,7 +92,7 @@ func (o *DiffOpts) Run() error {
 	return nil
 }
 
-func findDiffs(baseSunsets, specSunsets []*sunset.Sunset, baseSpecPath, specPath string) []*Diff {
+func (o *DiffOpts) findDiffs(baseSunsets, specSunsets []*sunset.Sunset) ([]*Diff, error) {
 	// Create maps for easy lookup
 	baseMap := make(map[string]*sunset.Sunset)
 	for _, s := range baseSunsets {
@@ -106,15 +114,14 @@ func findDiffs(baseSunsets, specSunsets []*sunset.Sunset, baseSpecPath, specPath
 		if specSunset, exists := specMap[key]; exists {
 			// Endpoint exists in both specs
 			if baseSunset.SunsetDate != specSunset.SunsetDate {
-				// Different sunset dates
 				diffs = append(diffs, &Diff{
 					Operation:      baseSunset.Operation,
 					Path:           baseSunset.Path,
 					Version:        baseSunset.Version,
 					BaseSunsetDate: baseSunset.SunsetDate,
 					SpecSunsetDate: specSunset.SunsetDate,
-					BaseSpec:       baseSpecPath,
-					Spec:           specPath,
+					BaseSpec:       o.basePath,
+					Spec:           o.specPath,
 					Team:           baseSunset.Team,
 				})
 			}
@@ -126,8 +133,8 @@ func findDiffs(baseSunsets, specSunsets []*sunset.Sunset, baseSpecPath, specPath
 				Version:        baseSunset.Version,
 				BaseSunsetDate: baseSunset.SunsetDate,
 				SpecSunsetDate: "",
-				BaseSpec:       baseSpecPath,
-				Spec:           specPath,
+				BaseSpec:       o.basePath,
+				Spec:           o.specPath,
 				Team:           baseSunset.Team,
 			})
 		}
@@ -142,8 +149,8 @@ func findDiffs(baseSunsets, specSunsets []*sunset.Sunset, baseSpecPath, specPath
 				Version:        specSunset.Version,
 				BaseSunsetDate: "",
 				SpecSunsetDate: specSunset.SunsetDate,
-				BaseSpec:       baseSpecPath,
-				Spec:           specPath,
+				BaseSpec:       o.basePath,
+				Spec:           o.specPath,
 				Team:           specSunset.Team,
 			})
 		}
@@ -156,7 +163,39 @@ func findDiffs(baseSunsets, specSunsets []*sunset.Sunset, baseSpecPath, specPath
 		return iKey < jKey
 	})
 
-	return diffs
+	// Filter diffs by date range if specified
+	filteredDiffs, err := o.diffsInRange(diffs)
+	if err != nil {
+		return nil, err
+	}
+
+	return filteredDiffs, nil
+}
+
+func (o *DiffOpts) diffsInRange(diffs []*Diff) ([]*Diff, error) {
+	var out []*Diff
+
+	if o.from == "" && o.to == "" {
+		return diffs, nil
+	}
+
+	for _, d := range diffs {
+		baseSunsetDate, err := time.Parse("2006-01-02", d.BaseSunsetDate)
+		if err != nil {
+			baseSunsetDate = time.Time{} // zero value for time if parsing fails
+		}
+
+		specSunsetDate, err := time.Parse("2006-01-02", d.SpecSunsetDate)
+		if err != nil {
+			specSunsetDate = time.Time{} // zero value for time if parsing fails
+		}
+
+		if isDateInRange(&baseSunsetDate, o.fromDate, o.toDate) || isDateInRange(&specSunsetDate, o.fromDate, o.toDate) {
+			out = append(out, d)
+		}
+	}
+
+	return out, nil
 }
 
 func makeKey(path, operation, version string) string {
@@ -186,6 +225,26 @@ func (o *DiffOpts) newSunsetDiffBytes(diffs []*Diff) ([]byte, error) {
 	return yamlData, nil
 }
 
+func (o *DiffOpts) validate() error {
+	if o.from != "" {
+		value, err := time.Parse("2006-01-02", o.from)
+		if err != nil {
+			return err
+		}
+		o.fromDate = &value
+	}
+
+	if o.to != "" {
+		value, err := time.Parse("2006-01-02", o.to)
+		if err != nil {
+			return err
+		}
+		o.toDate = &value
+	}
+
+	return nil
+}
+
 // DiffBuilder builds the diff command with the following signature:
 // sunset diff --base base-spec.json --spec spec.json.
 func DiffBuilder() *cobra.Command {
@@ -197,6 +256,9 @@ func DiffBuilder() *cobra.Command {
 		Use:   "diff --base spec1.json --spec spec2.json",
 		Short: "List API endpoints with different sunset dates between two OpenAPI specs.",
 		Args:  cobra.NoArgs,
+		PreRunE: func(_ *cobra.Command, _ []string) error {
+			return opts.validate()
+		},
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return opts.Run()
 		},
@@ -206,6 +268,8 @@ func DiffBuilder() *cobra.Command {
 	cmd.Flags().StringVarP(&opts.specPath, flag.Spec, flag.SpecShort, "", usage.Spec)
 	cmd.Flags().StringVarP(&opts.outputPath, flag.Output, flag.OutputShort, "", usage.Output)
 	cmd.Flags().StringVarP(&opts.format, flag.Format, flag.FormatShort, "json", usage.Format)
+	cmd.Flags().StringVar(&opts.from, flag.From, "", usage.From)
+	cmd.Flags().StringVar(&opts.to, flag.To, "", usage.To)
 
 	_ = cmd.MarkFlagRequired(flag.Base)
 	_ = cmd.MarkFlagRequired(flag.Spec)

--- a/tools/cli/internal/cli/sunset/diff.go
+++ b/tools/cli/internal/cli/sunset/diff.go
@@ -180,22 +180,33 @@ func (o *DiffOpts) diffsInRange(diffs []*Diff) ([]*Diff, error) {
 	}
 
 	for _, d := range diffs {
-		baseSunsetDate, err := time.Parse("2006-01-02", d.BaseSunsetDate)
+		baseSunsetDate, err := parseSunsetDate(d.BaseSunsetDate)
 		if err != nil {
-			baseSunsetDate = time.Time{} // zero value for time if parsing fails
+			return nil, err
 		}
 
-		specSunsetDate, err := time.Parse("2006-01-02", d.SpecSunsetDate)
+		specSunsetDate, err := parseSunsetDate(d.SpecSunsetDate)
 		if err != nil {
-			specSunsetDate = time.Time{} // zero value for time if parsing fails
+			return nil, err
 		}
 
-		if isDateInRange(&baseSunsetDate, o.fromDate, o.toDate) || isDateInRange(&specSunsetDate, o.fromDate, o.toDate) {
+		if isDateInRange(baseSunsetDate, o.fromDate, o.toDate) || isDateInRange(specSunsetDate, o.fromDate, o.toDate) {
 			out = append(out, d)
 		}
 	}
 
 	return out, nil
+}
+
+func parseSunsetDate(dateStr string) (*time.Time, error) {
+	if dateStr == "" {
+		return nil, nil
+	}
+	parsedDate, err := time.Parse("2006-01-02", dateStr)
+	if err != nil {
+		return nil, err
+	}
+	return &parsedDate, err
 }
 
 func makeKey(path, operation, version string) string {
@@ -240,6 +251,10 @@ func (o *DiffOpts) validate() error {
 			return err
 		}
 		o.toDate = &value
+	}
+
+	if o.from != "" && o.to != "" && o.fromDate.After(*o.toDate) {
+		return fmt.Errorf("%s date cannot be after %s date", flag.From, flag.To)
 	}
 
 	return nil

--- a/tools/cli/internal/cli/sunset/diff_test.go
+++ b/tools/cli/internal/cli/sunset/diff_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/mongodb/openapi/tools/cli/internal/openapi/sunset"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFindDiffsEmpty(t *testing.T) {
@@ -39,7 +40,7 @@ func TestFindDiffsEmpty(t *testing.T) {
 	}
 
 	diff, err := opts.findDiffs(baseSpecSunsets, baseSpecSunsets)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Empty(t, diff)
 }
 
@@ -126,7 +127,7 @@ func TestFindDiffsNotEmpty(t *testing.T) {
 
 	diff, err := opts.findDiffs(baseSpecSunsets, specSunsets)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, diff, 5)
 
 	assert.Equal(t, "GET", diff[0].Operation)
@@ -251,7 +252,7 @@ func TestFindDiffsFiltersByDate(t *testing.T) {
 
 	diff, err := opts.findDiffs(baseSpecSunsets, specSunsets)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, diff, 3)
 
 	assert.Equal(t, "GET", diff[0].Operation)

--- a/tools/cli/internal/cli/sunset/diff_test.go
+++ b/tools/cli/internal/cli/sunset/diff_test.go
@@ -15,10 +15,10 @@
 package sunset
 
 import (
-	"testing"
-
 	"github.com/mongodb/openapi/tools/cli/internal/openapi/sunset"
 	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
 )
 
 func TestFindDiffsEmpty(t *testing.T) {
@@ -32,7 +32,13 @@ func TestFindDiffsEmpty(t *testing.T) {
 		},
 	}
 
-	diff := findDiffs(baseSpecSunsets, baseSpecSunsets, "base.json", "spec.json")
+	opts := &DiffOpts{
+		basePath: "base.json",
+		specPath: "spec.json",
+	}
+
+	diff, err := opts.findDiffs(baseSpecSunsets, baseSpecSunsets)
+	assert.Nil(t, err)
 	assert.Empty(t, diff)
 }
 
@@ -112,7 +118,14 @@ func TestFindDiffsNotEmpty(t *testing.T) {
 		},
 	}
 
-	diff := findDiffs(baseSpecSunsets, specSunsets, "base.json", "spec.json")
+	opts := &DiffOpts{
+		basePath: "base.json",
+		specPath: "spec.json",
+	}
+
+	diff, err := opts.findDiffs(baseSpecSunsets, specSunsets)
+
+	assert.Nil(t, err)
 	assert.Len(t, diff, 5)
 
 	assert.Equal(t, "GET", diff[0].Operation)
@@ -159,6 +172,113 @@ func TestFindDiffsNotEmpty(t *testing.T) {
 	assert.Equal(t, "base.json", diff[4].BaseSpec)
 	assert.Equal(t, "spec.json", diff[4].Spec)
 	assert.Equal(t, "APIx", diff[4].Team)
+}
+
+func TestFindDiffsFiltersByDate(t *testing.T) {
+	baseSpecSunsets := []*sunset.Sunset{
+		{
+			Operation:  "GET",
+			Path:       "/api/atlas/v2/versions",
+			Version:    "2023-01-01",
+			SunsetDate: "2025-06-01",
+			Team:       "APIx",
+		},
+		{
+			Operation:  "GET",
+			Path:       "/api/atlas/v2/test",
+			Version:    "2023-01-01",
+			SunsetDate: "2025-07-01",
+			Team:       "Test",
+		},
+		{
+			Operation:  "GET",
+			Path:       "/api/atlas/v2/groups",
+			Version:    "2023-01-01",
+			SunsetDate: "2025-06-01",
+			Team:       "Groups",
+		},
+		{
+			Operation:  "GET",
+			Path:       "/api/atlas/v2/groups",
+			Version:    "2023-02-01",
+			SunsetDate: "2025-07-01",
+			Team:       "Groups",
+		},
+	}
+	specSunsets := []*sunset.Sunset{
+		{
+			Operation:  "GET",
+			Path:       "/api/atlas/v2/versions",
+			Version:    "2023-01-01",
+			SunsetDate: "2025-06-02",
+			Team:       "APIx",
+		},
+		{
+			Operation:  "GET",
+			Path:       "/api/atlas/v2/users",
+			Version:    "2023-01-01",
+			SunsetDate: "2025-06-01",
+			Team:       "Users",
+		},
+		{
+			Operation:  "GET",
+			Path:       "/api/atlas/v2/groups",
+			Version:    "2023-01-01",
+			SunsetDate: "2025-07-03",
+			Team:       "Groups",
+		},
+		{
+			Operation:  "GET",
+			Path:       "/api/atlas/v2/groups",
+			Version:    "2023-02-01",
+			SunsetDate: "2025-07-03",
+			Team:       "Groups",
+		},
+	}
+
+	fromDate := time.Date(2025, time.June, 1, 0, 0, 0, 0, time.UTC)
+	toDate := time.Date(2025, time.June, 15, 0, 0, 0, 0, time.UTC)
+
+	opts := &DiffOpts{
+		basePath: "base.json",
+		specPath: "spec.json",
+		from:     "2025-06-01",
+		to:       "2025-06-15",
+		fromDate: &fromDate,
+		toDate:   &toDate,
+	}
+
+	diff, err := opts.findDiffs(baseSpecSunsets, specSunsets)
+
+	assert.Nil(t, err)
+	assert.Len(t, diff, 3)
+
+	assert.Equal(t, "GET", diff[0].Operation)
+	assert.Equal(t, "/api/atlas/v2/groups", diff[0].Path)
+	assert.Equal(t, "2023-01-01", diff[0].Version)
+	assert.Equal(t, "2025-06-01", diff[0].BaseSunsetDate)
+	assert.Equal(t, "2025-07-03", diff[0].SpecSunsetDate)
+	assert.Equal(t, "base.json", diff[0].BaseSpec)
+	assert.Equal(t, "spec.json", diff[0].Spec)
+	assert.Equal(t, "Groups", diff[0].Team)
+
+	assert.Equal(t, "GET", diff[1].Operation)
+	assert.Equal(t, "/api/atlas/v2/users", diff[1].Path)
+	assert.Equal(t, "2023-01-01", diff[1].Version)
+	assert.Empty(t, diff[1].BaseSunsetDate)
+	assert.Equal(t, "2025-06-01", diff[1].SpecSunsetDate)
+	assert.Equal(t, "base.json", diff[1].BaseSpec)
+	assert.Equal(t, "spec.json", diff[1].Spec)
+	assert.Equal(t, "Users", diff[1].Team)
+
+	assert.Equal(t, "GET", diff[2].Operation)
+	assert.Equal(t, "/api/atlas/v2/versions", diff[2].Path)
+	assert.Equal(t, "2023-01-01", diff[2].Version)
+	assert.Equal(t, "2025-06-01", diff[2].BaseSunsetDate)
+	assert.Equal(t, "2025-06-02", diff[2].SpecSunsetDate)
+	assert.Equal(t, "base.json", diff[2].BaseSpec)
+	assert.Equal(t, "spec.json", diff[2].Spec)
+	assert.Equal(t, "APIx", diff[2].Team)
 }
 
 func TestMakeKey(t *testing.T) {

--- a/tools/cli/internal/cli/sunset/diff_test.go
+++ b/tools/cli/internal/cli/sunset/diff_test.go
@@ -287,3 +287,216 @@ func TestMakeKey(t *testing.T) {
 	key := makeKey("/api/atlas/v2/groups", "GET", "2023-01-01")
 	assert.Equal(t, "GET-/api/atlas/v2/groups-2023-01-01", key)
 }
+
+func TestDiffsInRangeToAndFrom(t *testing.T) {
+	fromDate := time.Date(2025, time.June, 3, 0, 0, 0, 0, time.UTC)
+	toDate := time.Date(2025, time.June, 21, 0, 0, 0, 0, time.UTC)
+
+	opts := &DiffOpts{
+		from:     "2025-06-03",
+		to:       "2025-06-21",
+		fromDate: &fromDate,
+		toDate:   &toDate,
+	}
+
+	diffs := []*Diff{
+		{
+			Operation:      "GET",
+			Path:           "/api/atlas/v2/versions",
+			Version:        "2023-01-01",
+			BaseSunsetDate: "2025-05-02",
+			SpecSunsetDate: "2025-05-04",
+		},
+		{
+			Operation:      "GET",
+			Path:           "/api/atlas/v2/versions",
+			Version:        "2024-01-01",
+			BaseSunsetDate: "2025-06-02",
+			SpecSunsetDate: "2025-06-04",
+		},
+		{
+			Operation:      "GET",
+			Path:           "/api/atlas/v2/versions",
+			Version:        "2025-01-01",
+			BaseSunsetDate: "2025-06-10",
+			SpecSunsetDate: "2025-06-12",
+		},
+		{
+			Operation:      "GET",
+			Path:           "/api/atlas/v2/versions",
+			Version:        "2026-01-01",
+			BaseSunsetDate: "2025-06-20",
+			SpecSunsetDate: "2025-06-22",
+		},
+		{
+			Operation:      "GET",
+			Path:           "/api/atlas/v2/versions",
+			Version:        "2027-01-01",
+			BaseSunsetDate: "2025-07-02",
+			SpecSunsetDate: "2025-07-04",
+		},
+	}
+
+	result, err := opts.diffsInRange(diffs)
+
+	require.NoError(t, err)
+	assert.Len(t, result, 3)
+
+	assert.Equal(t, "GET", result[0].Operation)
+	assert.Equal(t, "/api/atlas/v2/versions", result[0].Path)
+	assert.Equal(t, "2024-01-01", result[0].Version)
+	assert.Equal(t, "2025-06-02", result[0].BaseSunsetDate)
+	assert.Equal(t, "2025-06-04", result[0].SpecSunsetDate)
+
+	assert.Equal(t, "GET", result[1].Operation)
+	assert.Equal(t, "/api/atlas/v2/versions", result[1].Path)
+	assert.Equal(t, "2025-01-01", result[1].Version)
+	assert.Equal(t, "2025-06-10", result[1].BaseSunsetDate)
+	assert.Equal(t, "2025-06-12", result[1].SpecSunsetDate)
+
+	assert.Equal(t, "GET", result[2].Operation)
+	assert.Equal(t, "/api/atlas/v2/versions", result[2].Path)
+	assert.Equal(t, "2026-01-01", result[2].Version)
+	assert.Equal(t, "2025-06-20", result[2].BaseSunsetDate)
+	assert.Equal(t, "2025-06-22", result[2].SpecSunsetDate)
+}
+
+func TestDiffsInRangeOnlyTo(t *testing.T) {
+	toDate := time.Date(2025, time.June, 11, 0, 0, 0, 0, time.UTC)
+
+	opts := &DiffOpts{
+		to:     "2025-06-11",
+		toDate: &toDate,
+	}
+
+	diffs := []*Diff{
+		{
+			Operation:      "GET",
+			Path:           "/api/atlas/v2/versions",
+			Version:        "2023-01-01",
+			BaseSunsetDate: "",
+			SpecSunsetDate: "2025-05-04",
+		},
+		{
+			Operation:      "GET",
+			Path:           "/api/atlas/v2/versions",
+			Version:        "2024-01-01",
+			BaseSunsetDate: "2025-06-02",
+			SpecSunsetDate: "2025-06-04",
+		},
+		{
+			Operation:      "GET",
+			Path:           "/api/atlas/v2/versions",
+			Version:        "2025-01-01",
+			BaseSunsetDate: "2025-06-10",
+			SpecSunsetDate: "2025-06-12",
+		},
+		{
+			Operation:      "GET",
+			Path:           "/api/atlas/v2/versions",
+			Version:        "2026-01-01",
+			BaseSunsetDate: "2025-06-20",
+			SpecSunsetDate: "2025-06-22",
+		},
+		{
+			Operation:      "GET",
+			Path:           "/api/atlas/v2/versions",
+			Version:        "2027-01-01",
+			BaseSunsetDate: "",
+			SpecSunsetDate: "2025-07-04",
+		},
+	}
+
+	result, err := opts.diffsInRange(diffs)
+
+	require.NoError(t, err)
+	assert.Len(t, result, 3)
+
+	assert.Equal(t, "GET", result[0].Operation)
+	assert.Equal(t, "/api/atlas/v2/versions", result[0].Path)
+	assert.Equal(t, "2023-01-01", result[0].Version)
+	assert.Empty(t, result[0].BaseSunsetDate)
+	assert.Equal(t, "2025-05-04", result[0].SpecSunsetDate)
+
+	assert.Equal(t, "GET", result[1].Operation)
+	assert.Equal(t, "/api/atlas/v2/versions", result[1].Path)
+	assert.Equal(t, "2024-01-01", result[1].Version)
+	assert.Equal(t, "2025-06-02", result[1].BaseSunsetDate)
+	assert.Equal(t, "2025-06-04", result[1].SpecSunsetDate)
+
+	assert.Equal(t, "GET", result[2].Operation)
+	assert.Equal(t, "/api/atlas/v2/versions", result[2].Path)
+	assert.Equal(t, "2025-01-01", result[2].Version)
+	assert.Equal(t, "2025-06-10", result[2].BaseSunsetDate)
+	assert.Equal(t, "2025-06-12", result[2].SpecSunsetDate)
+}
+
+func TestDiffsInRangeOnlyFrom(t *testing.T) {
+	fromDate := time.Date(2025, time.June, 11, 0, 0, 0, 0, time.UTC)
+
+	opts := &DiffOpts{
+		from:     "2025-06-11",
+		fromDate: &fromDate,
+	}
+
+	diffs := []*Diff{
+		{
+			Operation:      "GET",
+			Path:           "/api/atlas/v2/versions",
+			Version:        "2023-01-01",
+			BaseSunsetDate: "2025-05-02",
+			SpecSunsetDate: "",
+		},
+		{
+			Operation:      "GET",
+			Path:           "/api/atlas/v2/versions",
+			Version:        "2024-01-01",
+			BaseSunsetDate: "2025-06-02",
+			SpecSunsetDate: "2025-06-04",
+		},
+		{
+			Operation:      "GET",
+			Path:           "/api/atlas/v2/versions",
+			Version:        "2025-01-01",
+			BaseSunsetDate: "2025-06-10",
+			SpecSunsetDate: "2025-06-12",
+		},
+		{
+			Operation:      "GET",
+			Path:           "/api/atlas/v2/versions",
+			Version:        "2026-01-01",
+			BaseSunsetDate: "2025-06-20",
+			SpecSunsetDate: "2025-06-22",
+		},
+		{
+			Operation:      "GET",
+			Path:           "/api/atlas/v2/versions",
+			Version:        "2027-01-01",
+			BaseSunsetDate: "2025-07-02",
+			SpecSunsetDate: "",
+		},
+	}
+
+	result, err := opts.diffsInRange(diffs)
+
+	require.NoError(t, err)
+	assert.Len(t, result, 3)
+
+	assert.Equal(t, "GET", result[0].Operation)
+	assert.Equal(t, "/api/atlas/v2/versions", result[0].Path)
+	assert.Equal(t, "2025-01-01", result[0].Version)
+	assert.Equal(t, "2025-06-10", result[0].BaseSunsetDate)
+	assert.Equal(t, "2025-06-12", result[0].SpecSunsetDate)
+
+	assert.Equal(t, "GET", result[1].Operation)
+	assert.Equal(t, "/api/atlas/v2/versions", result[1].Path)
+	assert.Equal(t, "2026-01-01", result[1].Version)
+	assert.Equal(t, "2025-06-20", result[1].BaseSunsetDate)
+	assert.Equal(t, "2025-06-22", result[1].SpecSunsetDate)
+
+	assert.Equal(t, "GET", result[2].Operation)
+	assert.Equal(t, "/api/atlas/v2/versions", result[2].Path)
+	assert.Equal(t, "2027-01-01", result[2].Version)
+	assert.Equal(t, "2025-07-02", result[2].BaseSunsetDate)
+	assert.Empty(t, result[2].SpecSunsetDate)
+}

--- a/tools/cli/internal/cli/sunset/diff_test.go
+++ b/tools/cli/internal/cli/sunset/diff_test.go
@@ -361,6 +361,33 @@ func TestDiffsInRangeToAndFrom(t *testing.T) {
 	assert.Equal(t, "2025-06-22", result[2].SpecSunsetDate)
 }
 
+func TestDiffsInRangeToAndFromInvalidSunsetDate(t *testing.T) {
+	fromDate := time.Date(2025, time.June, 3, 0, 0, 0, 0, time.UTC)
+	toDate := time.Date(2025, time.June, 21, 0, 0, 0, 0, time.UTC)
+
+	opts := &DiffOpts{
+		from:     "2025-06-03",
+		to:       "2025-06-21",
+		fromDate: &fromDate,
+		toDate:   &toDate,
+	}
+
+	diffs := []*Diff{
+		{
+			Operation:      "GET",
+			Path:           "/api/atlas/v2/versions",
+			Version:        "2023-01-01",
+			BaseSunsetDate: "2025-05", // Invalid date format
+			SpecSunsetDate: "2025-05-04",
+		},
+	}
+
+	result, err := opts.diffsInRange(diffs)
+
+	require.Error(t, err)
+	require.Empty(t, result)
+}
+
 func TestDiffsInRangeOnlyTo(t *testing.T) {
 	toDate := time.Date(2025, time.June, 11, 0, 0, 0, 0, time.UTC)
 
@@ -499,4 +526,26 @@ func TestDiffsInRangeOnlyFrom(t *testing.T) {
 	assert.Equal(t, "2027-01-01", result[2].Version)
 	assert.Equal(t, "2025-07-02", result[2].BaseSunsetDate)
 	assert.Empty(t, result[2].SpecSunsetDate)
+}
+
+func TestValidate(t *testing.T) {
+	opts := &DiffOpts{
+		from: "2025-06-01",
+		to:   "2025-06-15",
+	}
+
+	err := opts.validate()
+	require.NoError(t, err)
+	assert.Equal(t, time.Date(2025, time.June, 1, 0, 0, 0, 0, time.UTC), *opts.fromDate)
+	assert.Equal(t, time.Date(2025, time.June, 15, 0, 0, 0, 0, time.UTC), *opts.toDate)
+}
+
+func TestValidateToIsAfterFrom(t *testing.T) {
+	opts := &DiffOpts{
+		from: "2025-06-15",
+		to:   "2025-06-01",
+	}
+
+	err := opts.validate()
+	require.Error(t, err)
 }

--- a/tools/cli/internal/cli/sunset/diff_test.go
+++ b/tools/cli/internal/cli/sunset/diff_test.go
@@ -15,10 +15,11 @@
 package sunset
 
 import (
-	"github.com/mongodb/openapi/tools/cli/internal/openapi/sunset"
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
+
+	"github.com/mongodb/openapi/tools/cli/internal/openapi/sunset"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestFindDiffsEmpty(t *testing.T) {
@@ -38,7 +39,7 @@ func TestFindDiffsEmpty(t *testing.T) {
 	}
 
 	diff, err := opts.findDiffs(baseSpecSunsets, baseSpecSunsets)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Empty(t, diff)
 }
 
@@ -125,7 +126,7 @@ func TestFindDiffsNotEmpty(t *testing.T) {
 
 	diff, err := opts.findDiffs(baseSpecSunsets, specSunsets)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Len(t, diff, 5)
 
 	assert.Equal(t, "GET", diff[0].Operation)
@@ -250,7 +251,7 @@ func TestFindDiffsFiltersByDate(t *testing.T) {
 
 	diff, err := opts.findDiffs(baseSpecSunsets, specSunsets)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Len(t, diff, 3)
 
 	assert.Equal(t, "GET", diff[0].Operation)

--- a/tools/cli/internal/cli/sunset/list.go
+++ b/tools/cli/internal/cli/sunset/list.go
@@ -94,7 +94,7 @@ func (o *ListOpts) newSunsetInRange(sunsets []*sunset.Sunset) ([]*sunset.Sunset,
 }
 
 func isDateInRange(date, from, to *time.Time) bool {
-	if date == nil || date.IsZero() {
+	if date == nil {
 		return false
 	}
 

--- a/tools/cli/internal/cli/sunset/list.go
+++ b/tools/cli/internal/cli/sunset/list.go
@@ -94,7 +94,7 @@ func (o *ListOpts) newSunsetInRange(sunsets []*sunset.Sunset) ([]*sunset.Sunset,
 }
 
 func isDateInRange(date, from, to *time.Time) bool {
-	if date == nil {
+	if date == nil || date.IsZero() {
 		return false
 	}
 

--- a/tools/cli/test/e2e/cli/sunset_test.go
+++ b/tools/cli/test/e2e/cli/sunset_test.go
@@ -13,9 +13,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDiff_NoChanges(t *testing.T) {
+func TestSunsetDiff_NoChanges(t *testing.T) {
 	baseSpecPath := "../../data/base_spec.json"
-	outputPath := "diff.json"
+	outputPath := getOutputFolder(t, "sunset") + "/diff.json"
 
 	cliPath := NewBin(t)
 	cmd := exec.CommandContext(context.Background(), cliPath,
@@ -43,10 +43,10 @@ func TestDiff_NoChanges(t *testing.T) {
 	assert.Empty(t, results)
 }
 
-func TestDiff_WithChanges(t *testing.T) {
+func TestSunsetDiff_WithChanges(t *testing.T) {
 	baseSpecPath := "../../data/base_spec.json"
 	specPath := "../../data/base_spec_with_mismatching_sunset_dates.json"
-	outputPath := "diff.json"
+	outputPath := getOutputFolder(t, "sunset") + "/diff.json"
 
 	cliPath := NewBin(t)
 	cmd := exec.CommandContext(context.Background(), cliPath,
@@ -103,4 +103,47 @@ func TestDiff_WithChanges(t *testing.T) {
 	assert.Empty(t, results[2].SpecSunsetDate)
 	assert.Equal(t, baseSpecPath, results[2].BaseSpec)
 	assert.Equal(t, specPath, results[2].Spec)
+}
+
+func TestSunsetDiff_WithFilteredChanges(t *testing.T) {
+	baseSpecPath := "../../data/base_spec.json"
+	specPath := "../../data/base_spec_with_mismatching_sunset_dates.json"
+	outputPath := getOutputFolder(t, "sunset") + "/diff.json"
+
+	cliPath := NewBin(t)
+	cmd := exec.CommandContext(context.Background(), cliPath,
+		"sunset",
+		"diff",
+		"-b",
+		baseSpecPath,
+		"-s",
+		specPath,
+		"-o",
+		outputPath,
+		"--from",
+		"2026-02-20",
+		"--to",
+		"2026-03-03",
+	)
+
+	var o, e bytes.Buffer
+	cmd.Stdout = &o
+	cmd.Stderr = &e
+	require.NoError(t, cmd.Run(), e.String())
+
+	b, err := os.ReadFile(outputPath)
+	require.NoError(t, err)
+	assert.NotEmpty(t, b)
+	var results []*sunset.Diff
+	require.NoError(t, json.Unmarshal(b, &results))
+
+	assert.Len(t, results, 1)
+
+	assert.Equal(t, "GET", results[0].Operation)
+	assert.Equal(t, "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment", results[0].Path)
+	assert.Equal(t, "2023-01-01", results[0].Version)
+	assert.Equal(t, "2026-03-01", results[0].BaseSunsetDate)
+	assert.Empty(t, results[0].SpecSunsetDate)
+	assert.Equal(t, baseSpecPath, results[0].BaseSpec)
+	assert.Equal(t, specPath, results[0].Spec)
 }

--- a/tools/cli/test/e2e/cli/sunset_test.go
+++ b/tools/cli/test/e2e/cli/sunset_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"os"
 	"os/exec"
+	"path"
 	"testing"
 
 	"github.com/mongodb/openapi/tools/cli/internal/cli/sunset"
@@ -15,7 +16,7 @@ import (
 
 func TestSunsetDiff_NoChanges(t *testing.T) {
 	baseSpecPath := "../../data/base_spec.json"
-	outputPath := getOutputFolder(t, "sunset") + "/diff.json"
+	outputPath := path.Join(getOutputFolder(t, "sunset"), "diff.json")
 
 	cliPath := NewBin(t)
 	cmd := exec.CommandContext(context.Background(), cliPath,
@@ -46,7 +47,7 @@ func TestSunsetDiff_NoChanges(t *testing.T) {
 func TestSunsetDiff_WithChanges(t *testing.T) {
 	baseSpecPath := "../../data/base_spec.json"
 	specPath := "../../data/base_spec_with_mismatching_sunset_dates.json"
-	outputPath := getOutputFolder(t, "sunset") + "/diff.json"
+	outputPath := path.Join(getOutputFolder(t, "sunset"), "diff.json")
 
 	cliPath := NewBin(t)
 	cmd := exec.CommandContext(context.Background(), cliPath,
@@ -108,7 +109,7 @@ func TestSunsetDiff_WithChanges(t *testing.T) {
 func TestSunsetDiff_WithFilteredChanges(t *testing.T) {
 	baseSpecPath := "../../data/base_spec.json"
 	specPath := "../../data/base_spec_with_mismatching_sunset_dates.json"
-	outputPath := getOutputFolder(t, "sunset") + "/diff.json"
+	outputPath := path.Join(getOutputFolder(t, "sunset"), "diff.json")
 
 	cliPath := NewBin(t)
 	cmd := exec.CommandContext(context.Background(), cliPath,


### PR DESCRIPTION
## Proposed changes

Adds `to` and `from` flags to the `foascli sunset diff` command to filter out endpoints with sunset dates that are outside the range. The flags can also be provided alone/independently. 

The output contains the endpoint and it's sunset date for the base spec and the comparison spec. The endpoint is included in the output if _one of_ the sunset dates are within the provided range.

Adding this feature to be able to create a GH action diff report for sunset drifts where one of the dates are set to "within 3 weeks from now".

_Jira ticket:_ [CLOUDP-397437](https://jira.mongodb.org/browse/CLOUDP-397437)
