### PR TITLE
ci: fix FOASCLI goreleaser

### DIFF
--- a/tools/cli/.goreleaser.yml
+++ b/tools/cli/.goreleaser.yml
@@ -4,7 +4,6 @@ project_name: foascli
 version: 2
 before:
   hooks:
-    # this is just an example and not a requirement for provider building/publishing
     - go mod tidy
 builds:
   - <<: &build_defaults
@@ -28,10 +27,6 @@ gomod: # https://goreleaser.com/customization/verifiable_builds/
   # this setting.
   # Notice: for this to work your `build.main` must be a package, not a `.go` file.
   proxy: false
-  # Sets the `-mod` flag value.
-  #
-  # Since: v1.7
-  mod: mod
 
 archives:
 - id: linux_archives


### PR DESCRIPTION
## Proposed changes

Fixes #1244 

FOASCLI release failed with:
```
  • loading go mod information
  ⨯ release failed after 3s                         
    error=
    │ failed to get module path: exit status 1: go: -mod may only be set to readonly or vendor when in workspace mode, but it is set to “mod”
    │ 	Remove the -mod flag to use the default readonly value, 
    │ 	or set GOWORK=off to disable workspace mode.
```

Since introducing `mcp-server` Go module, we're now using workspace mode, and setting `mod=mod` in goreleaser is invalid.

Solution: Remove `mod=mod` and fall back to default `mod=readonly` (the releaser will not update go.mod/sum and will fail if dependencies are missing/invalid). We already run `go mod tidy` before the release step, so any dep issues should be caught before the release tries to run.

_Jira ticket:_ [CLOUDP-400244](https://jira.mongodb.org/browse/CLOUDP-400244)
