### PR TITLE
ci: fix FOASCLI goreleaser

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -71,6 +71,7 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GOWORK: off
 
   failure-handler: 
     name: Failure Handler

--- a/tools/cli/.goreleaser.yml
+++ b/tools/cli/.goreleaser.yml
@@ -4,6 +4,7 @@ project_name: foascli
 version: 2
 before:
   hooks:
+    # this is just an example and not a requirement for provider building/publishing
     - go mod tidy
 builds:
   - <<: &build_defaults
@@ -27,6 +28,10 @@ gomod: # https://goreleaser.com/customization/verifiable_builds/
   # this setting.
   # Notice: for this to work your `build.main` must be a package, not a `.go` file.
   proxy: false
+  # Sets the `-mod` flag value.
+  #
+  # Since: v1.7
+  mod: mod
 
 archives:
 - id: linux_archives

--- a/tools/go.work
+++ b/tools/go.work
@@ -1,6 +1,6 @@
 go 1.26
 
 use (
-	mcp-server
 	cli
+	mcp-server
 )

--- a/tools/mcp-server/go.mod
+++ b/tools/mcp-server/go.mod
@@ -7,10 +7,12 @@ require (
 	github.com/modelcontextprotocol/go-sdk v1.5.0
 	github.com/mongodb/openapi/tools/cli v0.0.0
 	github.com/spf13/afero v1.15.0
+	github.com/stretchr/testify v1.11.1
 )
 
 require (
 	cloud.google.com/go v0.123.0 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/go-openapi/jsonpointer v0.22.5 // indirect
 	github.com/go-openapi/swag/jsonname v0.25.5 // indirect
 	github.com/google/jsonschema-go v0.4.2 // indirect
@@ -23,9 +25,9 @@ require (
 	github.com/oasdiff/yaml v0.0.9 // indirect
 	github.com/oasdiff/yaml3 v0.0.9 // indirect
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/segmentio/asm v1.1.3 // indirect
 	github.com/segmentio/encoding v0.5.4 // indirect
-	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/tidwall/gjson v1.18.0 // indirect
 	github.com/tidwall/match v1.2.0 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect


### PR DESCRIPTION
_Jira ticket:_ [CLOUDP-400608](https://jira.mongodb.org/browse/CLOUDP-400608)

<!--
What issue does this PR address? (for example, #1234), remove this section if none.
-->

Fixes #1246 

## Proposed changes

The [previous fix](https://github.com/mongodb/openapi/pull/1245) of removing `mod: mod` from the goreleaser config did not resolve the release failure. The same error persisted:

```
• loading go mod information
  ⨯ release failed after 3s                         
    error=
    │ failed to get module path: exit status 1: go: -mod may only be set to readonly or vendor when in workspace mode, but it is set to “mod”
    │ 	Remove the -mod flag to use the default readonly value, 
    │ 	or set GOWORK=off to disable workspace mode.
```

Reverting previous change and falling back to the other suggested option from the error log, disabling workspace mode for the gorelease runner. Workspace mode is mostly a local development convenience for developing modules depending on each other. Since the FOASCLI does not depend on the mcp-server module, releasing with workspace mode disabled should be safe.

Drive-by: Ran `go work sync` which reordered the `go.work` file and updated some deps.

### Testing

[Release run successful](https://github.com/mongodb/openapi/actions/runs/25058798808)
