### PR TITLE
ci: cap `GITHUB_TOKEN` to `contents: read`

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - "**/**.sh"
 
+permissions:
+  contents: read
+
 jobs:
   shellcheck:
     name: shellcheck


### PR DESCRIPTION
The `shellcheck` workflow only lints shell scripts. No GitHub API writes, so a workflow-level `contents: read` is the right ceiling for the default `GITHUB_TOKEN`.

Same post-CVE-2025-30066 hardening (`tj-actions/changed-files`). YAML validated locally.