### PR TITLE
fix: add actions to the warning violation jira ticket

### DIFF
--- a/.github/scripts/handle_warning_violations.sh
+++ b/.github/scripts/handle_warning_violations.sh
@@ -35,14 +35,29 @@ fi
 
 
 # Create detailed description
-DESCRIPTION="Warning-level violations were found during IPA validation. Please review and add exceptions if valid, or address false positives.
+DESCRIPTION="
+h2. Context
+Warning-level violations were found during IPA validation. Please review and add exceptions if valid, or address false positives.
+
 These warning-level checks are part of the rule rollout process. See the IPA Validation Technical Documentation for details:
 https://wiki.corp.mongodb.com/spaces/MMS/pages/315003555/IPA+Validation+Technical+Documentation+Runbook#IPAValidationTechnicalDocumentation%26Runbook-RolloutofNewRule
 
 Violation Summary:
 ${VIOLATION_DETAILS}
 
-Total violations: ${WARNING_COUNT}"
+Total violations: ${WARNING_COUNT}
+
+h2. Actions
+
+Triage new violations
+ * Verify that the violations are not false-positives
+ ** Inspect the OpenAPI component that violates the rule
+ ** Inspect the source code
+ * If the violations are correct:
+ ** File a ticket for the owning team to address the violation, or add a new exception to the component if the violation has been approved by the APIx Platform team.
+ * If the violations are false-positives:
+ ** Create a ticket to fix the rule's implementation, correcting any bugs or adjusting the validation approach.
+"
 
 echo "Jira ticket does not exist. Creating..."
 # Create new Jira ticket with properly escaped JSON (matching create_jira_ticket.sh format)


### PR DESCRIPTION
Ticket: CLOUDP-407644

This pull request improves the clarity and guidance provided in the warning violation description generated by the `.github/scripts/handle_warning_violations.sh` script. The main change is the restructuring and expansion of the `DESCRIPTION` variable to include clearer context and actionable steps for handling IPA validation warnings.

Summary of most important changes:

**Improved violation description structure:**

* Added a "Context" section to the `DESCRIPTION` to clearly explain the purpose of the warning-level violations and provide a direct link to the IPA Validation Technical Documentation.
* Added an "Actions" section with a step-by-step triage process, detailing how to verify, address, or escalate new violations, including guidance for handling both valid violations and false positives.

These changes make it easier for engineers to understand and act on IPA validation warnings by providing structured information and explicit instructions.