### PR TITLE
ci: push Go submodule tag on release

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -37,6 +37,13 @@ jobs:
           commit_sha: ${{ steps.get-sha.outputs.sha }}
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg_passphrase: ${{ secrets.PASSPHRASE }}
+      - name: Create Go submodule tag for tools/cli
+        uses: rickstaa/action-create-tag@a1c7777fcb2fee4f19b0f283ba888afa11678b72
+        with:
+          tag: tools/cli/${{ inputs.version_number }}
+          commit_sha: ${{ steps.get-sha.outputs.sha }}
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg_passphrase: ${{ secrets.PASSPHRASE }}
 
   run-tests:
     needs: [ create-tag ]


### PR DESCRIPTION
## Summary
- Adds a second tag (`tools/cli/vX.Y.Z`) during the cli release workflow so the Go module is resolvable from outside this repo.
- `tools/cli/v0.0.65` has already been backfilled manually so external consumers can pin the current latest version immediately.

Jira: CLOUDP-407910

## Test plan
- [x] `tools/cli/v0.0.65` resolves via the Go proxy (`go list -m github.com/mongodb/openapi/tools/cli@v0.0.65`).
- [ ] Next release run pushes both tags (verified on first post-merge release).