### PR TITLE
chore: wire up CI and release workflows for foas module

### DIFF
--- a/.github/workflows/code-health-foas-lib.yml
+++ b/.github/workflows/code-health-foas-lib.yml
@@ -1,4 +1,4 @@
-name: 'Code Health Foas Library'
+name: 'Code Health FOAS Library'
 on:
   push:
     branches:

--- a/.github/workflows/code-health-foascli.yml
+++ b/.github/workflows/code-health-foascli.yml
@@ -3,14 +3,16 @@ on:
   push:
     branches:
       - main
-    paths: 
+    paths:
       - 'tools/cli/**'
+      - 'tools/foas/**'
       - '.github/workflows/code-health-foascli.yml'
   pull_request:
     branches:
       - main
     paths:
       - 'tools/cli/**'
+      - 'tools/foas/**'
       - '.github/workflows/code-health-foascli.yml'
   workflow_dispatch: {}
   workflow_call: {}

--- a/.github/workflows/release-foas-lib.yml
+++ b/.github/workflows/release-foas-lib.yml
@@ -1,11 +1,7 @@
-name: 'Foas Library New Release'
+name: 'FOAS Library New Release'
 run-name: 'Release foas ${{ inputs.version_number }} (skip tests: ${{ inputs.skip_tests }})'
 
-# Used for releasing the tools/foas Go library module. The module is consumed as
-# source by tools/cli (via go.work/replace), so a "release" is simply a Go
-# submodule tag (tools/foas/vX.Y.Z) that external repos can `go get`.
-# Tests run before the tag is created: the tag is immutable on the Go module
-# proxy once published, so we validate the candidate commit first.
+# Used for releasing the tools/foas Go library module.
 on:
   workflow_dispatch:
     inputs:
@@ -17,19 +13,20 @@ on:
         default: 'false'
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   run-tests:
     if: >-
       !cancelled()
       && inputs.skip_tests == 'false'
-    secrets: inherit
     uses: ./.github/workflows/code-health-foas-lib.yml
 
   create-tag:
     runs-on: ubuntu-latest
     needs: [ run-tests ]
+    permissions:
+      contents: write # required to push the release tag
     # Tag is created only when tests pass (or are explicitly skipped).
     if: >-
       !cancelled()
@@ -53,12 +50,12 @@ jobs:
 
   failure-handler:
     name: Failure Handler
-    needs: [ create-tag ]
+    needs: [ run-tests, create-tag ]
     if: ${{ always() && contains(needs.*.result, 'failure') }}
     uses: ./.github/workflows/failure-handler.yml
     with:
       env: "prod"
-      release_name: "Foas Library"
+      release_name: "FOAS Library"
       team_id: ${{ vars.JIRA_TEAM_ID_APIX_PLATFORM }}
     secrets:
       jira_api_token: ${{ secrets.JIRA_API_TOKEN }}

--- a/.github/workflows/release-foas-lib.yml
+++ b/.github/workflows/release-foas-lib.yml
@@ -1,0 +1,64 @@
+name: 'Foas Library New Release'
+run-name: 'Release foas ${{ inputs.version_number }} (skip tests: ${{ inputs.skip_tests }})'
+
+# Used for releasing the tools/foas Go library module. The module is consumed as
+# source by tools/cli (via go.work/replace), so a "release" is simply a Go
+# submodule tag (tools/foas/vX.Y.Z) that external repos can `go get`.
+# Tests run before the tag is created: the tag is immutable on the Go module
+# proxy once published, so we validate the candidate commit first.
+on:
+  workflow_dispatch:
+    inputs:
+      version_number:
+        description: 'Version number (e.g., v1.0.0, v1.0.0-pre, v1.0.0-pre1)'
+        required: true
+      skip_tests:
+        description: 'Set value to `true` to skip tests, default is `false`'
+        default: 'false'
+
+permissions:
+  contents: write
+
+jobs:
+  run-tests:
+    if: >-
+      !cancelled()
+      && inputs.skip_tests == 'false'
+    secrets: inherit
+    uses: ./.github/workflows/code-health-foas-lib.yml
+
+  create-tag:
+    runs-on: ubuntu-latest
+    needs: [ run-tests ]
+    # Tag is created only when tests pass (or are explicitly skipped).
+    if: >-
+      !cancelled()
+      && !contains(needs.*.result, 'failure')
+    steps:
+      - name: Validation of version format
+        run: |
+          echo "${{ inputs.version_number }}" | grep -P '^v\d+\.\d+\.\d+(-pre[A-Za-z0-9-]*)?$'
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - name: Get the latest commit SHA
+        id: get-sha
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+      - name: Create Go submodule tag for tools/foas
+        uses: rickstaa/action-create-tag@a1c7777fcb2fee4f19b0f283ba888afa11678b72
+        with:
+          tag: tools/foas/${{ inputs.version_number }}
+          commit_sha: ${{ steps.get-sha.outputs.sha }}
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg_passphrase: ${{ secrets.PASSPHRASE }}
+
+  failure-handler:
+    name: Failure Handler
+    needs: [ create-tag ]
+    if: ${{ always() && contains(needs.*.result, 'failure') }}
+    uses: ./.github/workflows/failure-handler.yml
+    with:
+      env: "prod"
+      release_name: "Foas Library"
+      team_id: ${{ vars.JIRA_TEAM_ID_APIX_PLATFORM }}
+    secrets:
+      jira_api_token: ${{ secrets.JIRA_API_TOKEN }}


### PR DESCRIPTION
## Summary

Step 4 (final) of the `tools/cli` → `tools/foas` module split. Wires up CI and release for the new library module.

### Previous steps
- Step 1 — scaffold `tools/foas` library module: #1308 (merged)
- Step 2 — pilot move of `apiversion`: #1309 (merged)
- Step 3 — move remaining packages: #1310
- **Step 4 — this PR**: CI & release wiring

## Changes

- **Add a `tools/foas/**` path trigger to `code-health-foascli.yml`.** The CLI depends on foas, so its build/test/lint/e2e pipeline should also re-run when the library changes.
- **Add `release-foas-lib.yml`** — a manual-dispatch workflow that releases the foas library. Since foas is a Go library (no binaries) and is consumed as source by the CLI via Go workspaces, a "release" is simply the Go submodule tag `tools/foas/vX.Y.Z`. External repos (e.g. `ipa-skills`) then consume it with:

  ```
  go get github.com/mongodb/openapi/tools/foas@vX.Y.Z
  ```

## Follow-up after merge

Once merged, I'll cut the first library tag by running the release workflow. The resulting tag `tools/foas/v0.1.0` will appear under the repo's Tags - not Releases, since the library has no binary artifact.