### PR TITLE
feat(ipa): add MCP to acronym ignore lists

### DIFF
--- a/tools/spectral/ipa/rulesets/IPA-117.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-117.yaml
@@ -285,6 +285,7 @@ rules:
           - 'M5'
           - 'RAM'
           - 'LTS'
+          - 'MCP'
           - 'VPC'
           - 'DN'
           - 'CSV'

--- a/tools/spectral/ipa/rulesets/IPA-126.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-126.yaml
@@ -31,6 +31,7 @@ rules:
           - 'DNS'
           - 'API'
           - 'IP'
+          - 'MCP'
           - 'MongoDB'
           - 'LDAP'
           - 'GCP'


### PR DESCRIPTION
## Summary
- Adds `MCP` to the `ignoreList` in IPA-117 (operation summary format) and IPA-126 (tag names title case) so the acronym is not flagged by casing rules.

## Test plan
- [x] Verify spectral rules pass on specs using `MCP` in operation summaries and tag names