### PR TITLE
fix: grant failure-handler write permissions in foas release workflow

### DIFF
--- a/.github/workflows/release-foas-lib.yml
+++ b/.github/workflows/release-foas-lib.yml
@@ -52,6 +52,9 @@ jobs:
     name: Failure Handler
     needs: [ run-tests, create-tag ]
     if: ${{ always() && contains(needs.*.result, 'failure') }}
+    permissions:
+      contents: write # failure-handler.yml requires these to open a Jira ticket / issue
+      issues: write
     uses: ./.github/workflows/failure-handler.yml
     with:
       env: "prod"

--- a/.github/workflows/release-foas-lib.yml
+++ b/.github/workflows/release-foas-lib.yml
@@ -27,7 +27,6 @@ jobs:
     needs: [ run-tests ]
     permissions:
       contents: write # required to push the release tag
-    # Tag is created only when tests pass (or are explicitly skipped).
     if: >-
       !cancelled()
       && !contains(needs.*.result, 'failure')
@@ -53,7 +52,7 @@ jobs:
     needs: [ run-tests, create-tag ]
     if: ${{ always() && contains(needs.*.result, 'failure') }}
     permissions:
-      contents: write # failure-handler.yml requires these to open a Jira ticket / issue
+      contents: write #required to open a Jira ticket / issue
       issues: write
     uses: ./.github/workflows/failure-handler.yml
     with:


### PR DESCRIPTION
## Summary

Follow-up fix to #1311. The merged `release-foas-lib.yml` is currently **invalid** and won't run:

```
Error calling workflow '.../failure-handler.yml'. The workflow is requesting
'contents: write, issues: write', but is only allowed 'contents: read, issues: none'
```

## Fix

Grant the required permissions on the `failure-handler` job:

```yaml
  failure-handler:
    ...
    permissions:
      contents: write
      issues: write
    uses: ./.github/workflows/failure-handler.yml
```

`run-tests` (needs `contents: read`) and `create-tag` (`contents: write`) are unaffected.