### PR TITLE
ci: fix node version mismatch in required spec validations

### DIFF
--- a/.github/workflows/required-spec-validations.yml
+++ b/.github/workflows/required-spec-validations.yml
@@ -25,7 +25,7 @@ jobs:
         - name: Setup Node
           uses: actions/setup-node@v6
           with:
-            node-version: '20.x'
+            node-version: '22.x'
             cache: 'npm'
         - name: Install npm dependencies
           run: npm install


### PR DESCRIPTION
## Proposed changes

OpenAPI release started failing on "Validate the FOAS can be used with the Go SDK" step due to:
```
npm error code EBADENGINE
npm error engine Unsupported engine
npm error engine Not compatible with your version of node/npm: openapi-generation-tools@0.1.0
npm error notsup Not compatible with your version of node/npm: openapi-generation-tools@0.1.0
npm error notsup Required: {"node":">= 22","npm":">= 8"}
npm error notsup Actual:   {"npm":"10.8.2","node":"v20.20.2"}
```

This started after a [change](https://github.com/mongodb/atlas-sdk-go/pull/809) in the Go SDK to bump node version from v20 to v22. Since we used v20 in the workflow setup, it started failing.

Fix: Bump workflow setup to use node v22.

Testing:
Ran openapi release for dev manually against this branch successfully: https://github.com/mongodb/openapi/actions/runs/27685139038

_Jira ticket:_ [CLOUDP-414595](https://jira.mongodb.org/browse/CLOUDP-414595)

<!--
What issue does this PR address? (for example, #1234), remove this section if none.
-->

Closes #1315
Closes #1314
Closes #1313
Closes #1312
