### PR TITLE
fix(ipa): handle delete request bodies in IPA-117

### DIFF
--- a/tools/spectral/ipa/__tests__/IPA117RequestResponseBodiesMustBeWellDefined.test.js
+++ b/tools/spectral/ipa/__tests__/IPA117RequestResponseBodiesMustBeWellDefined.test.js
@@ -151,6 +151,65 @@ testRule('xgen-IPA-117-request-response-bodies-must-be-well-defined', [
     errors: [],
   },
   {
+    name: 'delete request body with schema does not crash',
+    document: {
+      paths: {
+        '/resource/{id}': {
+          delete: {
+            requestBody: {
+              content: {
+                'application/vnd.atlas.2024-08-05+json': {
+                  schema: {
+                    type: 'object',
+                  },
+                },
+              },
+            },
+            responses: {
+              204: {
+                content: {
+                  'application/vnd.atlas.2024-08-05+json': {},
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+  {
+    name: 'delete request body without schema is still validated',
+    document: {
+      paths: {
+        '/resource/{id}': {
+          delete: {
+            requestBody: {
+              content: {
+                'application/vnd.atlas.2024-08-05+json': {},
+              },
+            },
+            responses: {
+              204: {
+                content: {
+                  'application/vnd.atlas.2024-08-05+json': {},
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    errors: [
+      {
+        code: 'xgen-IPA-117-request-response-bodies-must-be-well-defined',
+        message: 'Request and response bodies must have a schema.',
+        path: ['paths', '/resource/{id}', 'delete', 'requestBody', 'content', 'application/vnd.atlas.2024-08-05+json'],
+        severity: DiagnosticSeverity.Error,
+      },
+    ],
+  },
+  {
     name: 'invalid requests and responses',
     document: {
       paths: {

--- a/tools/spectral/ipa/rulesets/functions/IPA117RequestResponseBodiesMustBeWellDefined.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA117RequestResponseBodiesMustBeWellDefined.js
@@ -31,7 +31,7 @@ export default (input, opts, { path, documentInventory, rule }) => {
   // Custom POST method 2xx responses
   if (
     httpResponseCode === '202' ||
-    (httpMethod === 'delete' && httpResponseCode.startsWith('2')) ||
+    (httpMethod === 'delete' && httpResponseCode?.startsWith('2')) ||
     (operationIsCustomMethod && httpMethod === 'post' && httpResponseCode?.startsWith('2'))
   ) {
     return;


### PR DESCRIPTION
Fix IPA-117 DELETE request body crash

Steps to reproduce:
- Add a DELETE operation with `requestBody.content[*]`.
- Run Spectral with the IPA ruleset.
- Before this change, IPA-117 threw: `Cannot read properties of null (reading startsWith)`.

Failing fixture before:
```yaml
paths:
  /resource/{id}:
    delete:
      requestBody:
        content:
          application/vnd.atlas.2024-08-05+json:
            schema:
              type: object
      responses:
        "204":
          content:
            application/vnd.atlas.2024-08-05+json: {}
```

Why it failed:
- IPA-117 evaluates both request body content and response content.
- Request body paths do not have a response code, so `httpResponseCode` was null.
- The DELETE response exemption called `httpResponseCode.startsWith("2")` anyway.

After this change:
- The same fixture no longer produces an internal error.
- A DELETE request body with a schema passes IPA-117.
- A DELETE request body without a schema is still reported by IPA-117.

What changed:
- Guard the DELETE 2xx response-code check with optional chaining.
- Add regression tests for valid and invalid DELETE request bodies.