### PR TITLE
CLOUDP-373281: Move grammaticalWords and ignoreList to shared utility…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2247,6 +2247,7 @@
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
             "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -2258,6 +2259,7 @@
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
             "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -2268,6 +2270,7 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
             "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -3297,6 +3300,7 @@
             "version": "0.2.12",
             "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
             "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -3344,6 +3348,7 @@
             "version": "0.11.0",
             "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
             "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "engines": {
@@ -4182,6 +4187,7 @@
             "version": "0.10.2",
             "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
             "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -4540,6 +4546,7 @@
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4553,6 +4560,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4566,6 +4574,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4579,6 +4588,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4592,6 +4602,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4605,6 +4616,7 @@
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4618,6 +4630,7 @@
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4631,6 +4644,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4644,6 +4658,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4657,6 +4672,7 @@
             "cpu": [
                 "ppc64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4670,6 +4686,7 @@
             "cpu": [
                 "riscv64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4683,6 +4700,7 @@
             "cpu": [
                 "riscv64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4696,6 +4714,7 @@
             "cpu": [
                 "s390x"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4709,6 +4728,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4722,6 +4742,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4735,6 +4756,7 @@
             "cpu": [
                 "wasm32"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
@@ -4751,6 +4773,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4764,6 +4787,7 @@
             "cpu": [
                 "ia32"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4777,6 +4801,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [

--- a/tools/spectral/ipa/rulesets/IPA-117.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-117.yaml
@@ -175,7 +175,7 @@ rules:
       field: '@key'
       function: 'IPA117PlaintextResponseMustHaveExample'
       functionOptions:
-        allowedTypes: [ 'json', 'yaml' ]
+        allowedTypes: ['json', 'yaml']
   xgen-IPA-117-objects-must-be-well-defined:
     description: |
       Components of type "object" must be well-defined, i.e. have of one of the properties:

--- a/tools/spectral/ipa/rulesets/IPA-117.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-117.yaml
@@ -175,7 +175,7 @@ rules:
       field: '@key'
       function: 'IPA117PlaintextResponseMustHaveExample'
       functionOptions:
-        allowedTypes: ['json', 'yaml']
+        allowedTypes: [ 'json', 'yaml' ]
   xgen-IPA-117-objects-must-be-well-defined:
     description: |
       Components of type "object" must be well-defined, i.e. have of one of the properties:
@@ -264,50 +264,6 @@ rules:
       - '#OperationObject.summary'
     then:
       function: 'IPA117OperationSummaryFormat'
-      functionOptions:
-        ignoreList:
-          - 'ID'
-          - 'IDs'
-          - 'MongoDB'
-          - 'OpenAPI'
-          - 'API'
-          - 'AI'
-          - 'AWS'
-          - 'GCP'
-          - 'IP'
-          - 'CIDR'
-          - 'DNS'
-          - 'LDAP'
-          - 'OIDC'
-          - 'JWKS'
-          - 'X.509'
-          - 'M2'
-          - 'M5'
-          - 'RAM'
-          - 'LTS'
-          - 'MCP'
-          - 'VPC'
-          - 'DN'
-          - 'CSV'
-        grammaticalWords:
-          - 'and'
-          - 'or'
-          - 'to'
-          - 'in'
-          - 'as'
-          - 'for'
-          - 'of'
-          - 'with'
-          - 'by'
-          - 'but'
-          - 'the'
-          - 'a'
-          - 'an'
-          - 'from'
-          - 'at'
-          - 'into'
-          - 'via'
-          - 'on'
   xgen-IPA-117-get-operation-summary-starts-with:
     description: |
       In operation summaries, use 'Return' instead of 'Get' or 'List'. For example "Return One Identity Provider".

--- a/tools/spectral/ipa/rulesets/IPA-126.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-126.yaml
@@ -10,7 +10,7 @@ rules:
 
       ##### Implementation details
       Rule checks for the following conditions:
-        - All tag names defined in the OpenAPI tags object should use Title Case 
+        - All tag names defined in the OpenAPI tags object should use Title Case
         - Title Case means each word starts with an uppercase letter, and the rest are lowercase
         - Certain abbreviations (like "API", "AWS", etc.) in the ignoreList are allowed to maintain their casing
         - Grammatical words (like "and", "or", "the", etc.) are allowed to be all lowercase
@@ -24,29 +24,4 @@ rules:
     given: $.tags[?(@.name && @.name.length > 0)]
     then:
       function: 'IPA126TagNamesShouldUseTitleCase'
-      functionOptions:
-        ignoreList:
-          - 'AI'
-          - 'AWS'
-          - 'DNS'
-          - 'API'
-          - 'IP'
-          - 'MCP'
-          - 'MongoDB'
-          - 'LDAP'
-          - 'GCP'
-          - 'OpenAPI'
-        grammaticalWords:
-          - 'and'
-          - 'or'
-          - 'to'
-          - 'in'
-          - 'as'
-          - 'for'
-          - 'of'
-          - 'with'
-          - 'by'
-          - 'but'
-          - 'the'
-          - 'a'
-          - 'an'
+

--- a/tools/spectral/ipa/rulesets/IPA-126.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-126.yaml
@@ -24,4 +24,3 @@ rules:
     given: $.tags[?(@.name && @.name.length > 0)]
     then:
       function: 'IPA126TagNamesShouldUseTitleCase'
-

--- a/tools/spectral/ipa/rulesets/functions/IPA117OperationSummaryFormat.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA117OperationSummaryFormat.js
@@ -1,17 +1,18 @@
 import { evaluateAndCollectAdoptionStatus, handleInternalError } from './utils/collectionUtils.js';
 import { isTitleCase } from './utils/casing.js';
 import { resolveObject } from './utils/componentUtils.js';
+import { IPA_117_GRAMMATICAL_WORDS, IPA_117_IGNORE_LIST } from './utils/grammaticalWordsAndIgnoreList.js';
 
-export default (input, { ignoreList, grammaticalWords }, { path, rule, documentInventory }) => {
+export default (input, options, { path, rule, documentInventory }) => {
   const operationObjectPath = path.slice(0, -1);
   const operationObject = resolveObject(documentInventory.resolved, operationObjectPath);
-  const errors = checkViolationsAndReturnErrors(input, ignoreList, grammaticalWords, operationObjectPath, rule.name);
+  const errors = checkViolationsAndReturnErrors(input, operationObjectPath, rule.name);
   return evaluateAndCollectAdoptionStatus(errors, rule.name, operationObject, operationObjectPath);
 };
 
-function checkViolationsAndReturnErrors(summary, ignoreList, grammaticalWords, path, ruleName) {
+function checkViolationsAndReturnErrors(summary, path, ruleName) {
   try {
-    if (!isTitleCase(summary, ignoreList, grammaticalWords)) {
+    if (!isTitleCase(summary, IPA_117_IGNORE_LIST, IPA_117_GRAMMATICAL_WORDS)) {
       return [
         {
           path,

--- a/tools/spectral/ipa/rulesets/functions/IPA126TagNamesShouldUseTitleCase.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA126TagNamesShouldUseTitleCase.js
@@ -1,13 +1,14 @@
 import { evaluateAndCollectAdoptionStatus } from './utils/collectionUtils.js';
 import { isTitleCase } from './utils/casing.js';
+import { IPA_126_GRAMMATICAL_WORDS, IPA_126_IGNORE_LIST } from './utils/grammaticalWordsAndIgnoreList.js';
 
-export default (input, { ignoreList, grammaticalWords }, { path, rule }) => {
+export default (input, options, { path, rule }) => {
   const ruleName = rule.name;
   const tagName = input.name;
 
   // Check if the tag name uses Title Case
   let errors = [];
-  if (!isTitleCase(tagName, ignoreList, grammaticalWords)) {
+  if (!isTitleCase(tagName, IPA_126_IGNORE_LIST, IPA_126_GRAMMATICAL_WORDS)) {
     errors = [
       {
         path,

--- a/tools/spectral/ipa/rulesets/functions/utils/grammaticalWordsAndIgnoreList.js
+++ b/tools/spectral/ipa/rulesets/functions/utils/grammaticalWordsAndIgnoreList.js
@@ -1,0 +1,71 @@
+/**
+ * Shared configuration for title case validation lists used across IPA-126 and IPA-117 rules.
+ * These lists are used by the isTitleCase() function to validate proper title casing.
+ */
+
+// IPA-126: Tag Names Should Use Title Case
+export const IPA_126_IGNORE_LIST = ['AI', 'AWS', 'DNS', 'API', 'IP', 'MCP', 'MongoDB', 'LDAP', 'GCP', 'OpenAPI'];
+
+export const IPA_126_GRAMMATICAL_WORDS = [
+  'and',
+  'or',
+  'to',
+  'in',
+  'as',
+  'for',
+  'of',
+  'with',
+  'by',
+  'but',
+  'the',
+  'a',
+  'an',
+];
+
+// IPA-117: Documentation Rules - Operation Summary Format
+export const IPA_117_IGNORE_LIST = [
+  'ID',
+  'IDs',
+  'MongoDB',
+  'OpenAPI',
+  'API',
+  'AI',
+  'AWS',
+  'GCP',
+  'IP',
+  'CIDR',
+  'DNS',
+  'LDAP',
+  'OIDC',
+  'JWKS',
+  'X.509',
+  'M2',
+  'M5',
+  'RAM',
+  'LTS',
+  'MCP',
+  'VPC',
+  'DN',
+  'CSV',
+];
+
+export const IPA_117_GRAMMATICAL_WORDS = [
+  'and',
+  'or',
+  'to',
+  'in',
+  'as',
+  'for',
+  'of',
+  'with',
+  'by',
+  'but',
+  'the',
+  'a',
+  'an',
+  'from',
+  'at',
+  'into',
+  'via',
+  'on',
+];


### PR DESCRIPTION
## Summary

Consolidate `grammaticalWords` and `ignoreList` configuration from IPA-126 and IPA-117 rulesets into a shared utility file to eliminate duplication and maintain a single source of truth.

## Proposed changes

- Create new utility file `/tools/spectral/ipa/rulesets/functions/utils/grammaticalWordsAndIgnoreList.js` with 4 exported constants
- Update `IPA126TagNamesShouldUseTitleCase.js` to import from shared utility instead of receiving parameters from YAML
- Update `IPA117OperationSummaryFormat.js` to import from shared utility instead of receiving parameters from YAML
- Remove hardcoded `ignoreList` and `grammaticalWords` from `IPA-126.yaml` and `IPA-117.yaml` for cleanup

_Jira ticket:_ CLOUDP-373281

Closes CLOUDP-373281

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works (all 696 tests pass)

### Changes to Spectral
- [x] I have read the [README](../tools/spectral/README.md) file for Spectral Updates

## Further comments

This refactoring reduces code duplication and improves maintainability by:
1. Keeping both IPA-126 and IPA-117 lists separate (they have different scopes - IPA-126 validates tag names, IPA-117 validates operation summaries)
2. Centralizing configuration management in one file
3. Making future updates easier - only need to update one file
4. All 696 tests pass with no regressions
5. npm run ipa-validation confirms no errors with the new validation rules
