### PR TITLE
ci: require IPA validation for FOAS releases

### DIFF
--- a/.github/workflows/optional-spec-validations.yml
+++ b/.github/workflows/optional-spec-validations.yml
@@ -56,10 +56,6 @@ jobs:
           name: openapi-foas-${{ inputs.env }}
           github-token: ${{ secrets.api_bot_pat }}
           run-id: ${{ github.run_id }}
-      - name: Run IPA validation
-        id: ipa-spectral-validation
-        run: |
-          npx spectral lint openapi-foas.json --ruleset=./tools/spectral/ipa/ipa-spectral.yaml
       - name: Validate the FOAS can be used to generate Postman collection
         id: spectral-validation
         env:

--- a/.github/workflows/required-spec-validations.yml
+++ b/.github/workflows/required-spec-validations.yml
@@ -35,6 +35,10 @@ jobs:
             name: openapi-foas-${{ inputs.env }}
             github-token: ${{ secrets.api_bot_pat }}
             run-id: ${{ github.run_id }}
+        - name: Run IPA validation
+          id: ipa-spectral-validation
+          run: |
+            npx spectral lint openapi-foas.json --ruleset=./tools/spectral/ipa/ipa-spectral.yaml
         - name: Run 
           id: spectral-validation
           env:


### PR DESCRIPTION
## Ticket: 
[CLOUDP-310537](https://jira.mongodb.org/browse/CLOUDP-310537)

## Summary
- Move IPA validation from optional spec validations to required spec validations
- Block FOAS releases when IPA validation fails\