### PR TITLE
chore: revert bump @stoplight/spectral-cli from 6.16.2 to 6.16.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
             "name": "mongodb-openapi",
             "dependencies": {
                 "@aws-sdk/client-s3": "^3.1092.0",
-                "@stoplight/spectral-cli": "^6.16.2",
+                "@stoplight/spectral-cli": "^6.16.1",
                 "@stoplight/spectral-core": "^1.23.1",
                 "@stoplight/spectral-functions": "^1.10.5",
                 "@stoplight/spectral-ref-resolver": "^1.0.5",
@@ -4763,9 +4763,9 @@
             }
         },
         "node_modules/@stoplight/spectral-cli": {
-            "version": "6.16.2",
-            "resolved": "https://registry.npmjs.org/@stoplight/spectral-cli/-/spectral-cli-6.16.2.tgz",
-            "integrity": "sha512-1BwNCglpvCA2J+MpdXSPH56h69rARthf0QG/t2eeFbuqg12rcQEbGfAXs70mCRUAewiCzf1QqzeHF1tnabfS3A==",
+            "version": "6.16.1",
+            "resolved": "https://registry.npmjs.org/@stoplight/spectral-cli/-/spectral-cli-6.16.1.tgz",
+            "integrity": "sha512-6DdYx94d+BNVTdgJRkb1KJIcqYQsOxstAZtH7Kh63SDUsXFRkdfsBKsL7l6csxLRYYh5Qm6CSBF7AUFYBFJ23w==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@scarf/scarf": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     },
     "dependencies": {
         "@aws-sdk/client-s3": "^3.1092.0",
-        "@stoplight/spectral-cli": "^6.16.2",
+        "@stoplight/spectral-cli": "^6.16.1",
         "@stoplight/spectral-core": "^1.23.1",
         "@stoplight/spectral-functions": "^1.10.5",
         "@stoplight/spectral-ref-resolver": "^1.0.5",


### PR DESCRIPTION
Reverts mongodb/openapi#1405