### PR TITLE
ci(ipa): release new version 11.1.0

### DIFF
--- a/tools/spectral/ipa/CHANGELOG.md
+++ b/tools/spectral/ipa/CHANGELOG.md
@@ -2,7 +2,18 @@
 
 All notable changes to this project will be documented in this file. Dates are displayed in UTC.
 
-#### [11.0.0](https://github.com/mongodb/openapi/compare/ipa-validation-ruleset-v10.1.1...11.0.0)
+#### [11.1.0](https://github.com/mongodb/openapi/compare/ipa-validation-ruleset-v11.0.0...11.1.0)
+
+- fix(ipa): allow Operations endpoint paths in IPA-102 alternation check [`#1406`](https://github.com/mongodb/openapi/pull/1406)
+- chore(ipa): bump @stoplight/spectral-cli from 6.16.1 to 6.16.2 in /tools/spectral/ipa [`#1391`](https://github.com/mongodb/openapi/pull/1391)
+- fix(ipa): clarify endpoint version lifecycle entries [`#1370`](https://github.com/mongodb/openapi/pull/1370)
+- chore(ipa): bump @stoplight/spectral-core from 1.23.0 to 1.23.1 in /tools/spectral/ipa [`#1350`](https://github.com/mongodb/openapi/pull/1350)
+- chore(ipa): bump @stoplight/spectral-cli from 6.16.0 to 6.16.1 in /tools/spectral/ipa [`#1349`](https://github.com/mongodb/openapi/pull/1349)
+- chore(ipa): bump @stoplight/spectral-functions from 1.10.3 to 1.10.5 in /tools/spectral/ipa [`#1352`](https://github.com/mongodb/openapi/pull/1352)
+
+### [ipa-validation-ruleset-v11.0.0](https://github.com/mongodb/openapi/compare/ipa-validation-ruleset-v10.1.1...ipa-validation-ruleset-v11.0.0)
+
+> 24 June 2026
 
 - feat(ipa): Promote warning rules to error [`#1329`](https://github.com/mongodb/openapi/pull/1329)
 - fix(ipa): Update ipa-spectral to include mongoDBEmployeeAccessGrant [`#1328`](https://github.com/mongodb/openapi/pull/1328)

--- a/tools/spectral/ipa/package-lock.json
+++ b/tools/spectral/ipa/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mongodb-js/ipa-validation-ruleset",
-  "version": "11.0.0",
+  "version": "11.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mongodb-js/ipa-validation-ruleset",
-      "version": "11.0.0",
+      "version": "11.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@stoplight/spectral-cli": "6.16.2",

--- a/tools/spectral/ipa/package.json
+++ b/tools/spectral/ipa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mongodb-js/ipa-validation-ruleset",
-  "version": "11.0.0",
+  "version": "11.1.0",
   "description": "Custom validation rules for MongoDB API Standards (IPA).",
   "keywords": [
     "mongodb",
@@ -19,8 +19,8 @@
   "author": "MongoDB",
   "main": "ipa-spectral.yaml",
   "type": "module",
-  "scripts" : {
-    "gen-ipa-changelog" : "npx auto-changelog"
+  "scripts": {
+    "gen-ipa-changelog": "npx auto-changelog"
   },
   "dependencies": {
     "@stoplight/spectral-cli": "6.16.2",
@@ -36,7 +36,7 @@
   "devDependencies": {
     "auto-changelog": "2.6.0"
   },
-  "auto-changelog" : {
+  "auto-changelog": {
     "package": true,
     "commitPattern": "[a-z]+\\(ipa\\):",
     "startingVersion": "ipa-validation-ruleset-v1.0.0",
@@ -44,7 +44,7 @@
     "tagPattern": "ipa-validation-ruleset-v\\d+\\.\\d+\\.\\d+",
     "tagPrefix": "ipa-validation-ruleset-v",
     "ignoreCommitPattern": "^ci.*$",
-    "hideEmptyReleases" : true,
+    "hideEmptyReleases": true,
     "contributors": false
   }
 }


### PR DESCRIPTION
Releases IPA validation ruleset `11.1.0`.

- Bumps `tools/spectral/ipa/package.json` to `11.1.0` (minor)
- Regenerates `CHANGELOG.md` via `npm run gen-ipa-changelog`

Changes included since `11.0.0`:

- fix(ipa): allow Operations endpoint paths in IPA-102 alternation check (#1406)
- chore(ipa): bump @stoplight/spectral-cli from 6.16.1 to 6.16.2 (#1391)
- fix(ipa): clarify endpoint version lifecycle entries (#1370)
- chore(ipa): bump @stoplight/spectral-core from 1.23.0 to 1.23.1 (#1350)
- chore(ipa): bump @stoplight/spectral-cli from 6.16.0 to 6.16.1 (#1349)
- chore(ipa): bump @stoplight/spectral-functions from 1.10.3 to 1.10.5 (#1352)

Merging publishes the package to NPM.