### PR TITLE
fix(ipa): preserve resource scope in operation IDs for trailing /operations paths

### DIFF
--- a/tools/spectral/ipa/__tests__/utils/operationIdGeneration.test.js
+++ b/tools/spectral/ipa/__tests__/utils/operationIdGeneration.test.js
@@ -29,8 +29,8 @@ describe('tools/spectral/ipa/utils/operationIdGeneration.js', () => {
       expect(generateOperationID('grant', '/api/atlas/v2/groups/{groupId}/access')).toEqual('grantGroupAccess');
     });
 
-    it('should preserve the resource scope of trailing operations paths', () => {
-      // the collection-scoped path keeps the parent plural, the instance-scoped path keeps it singular,
+    it('should preserve the resource scope of operations paths', () => {
+      // the collection-scoped paths keep the parent plural, the instance-scoped paths keep it singular,
       // so that the two Operations resources do not share an operation ID
       expect(generateOperationID('list', '/api/atlas/v2/groups/{groupId}/clusters/operations')).toEqual(
         'listGroupClustersOperations'
@@ -38,23 +38,54 @@ describe('tools/spectral/ipa/utils/operationIdGeneration.js', () => {
       expect(generateOperationID('list', '/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/operations')).toEqual(
         'listGroupClusterOperations'
       );
+      expect(generateOperationID('get', '/api/atlas/v2/groups/{groupId}/clusters/operations/{operationId}')).toEqual(
+        'getGroupClustersOperation'
+      );
+      expect(
+        generateOperationID('get', '/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/operations/{operationId}')
+      ).toEqual('getGroupClusterOperation');
+    });
+
+    it('should generate distinct operation IDs for collection- and instance-scoped operations resources', () => {
       expect(generateOperationID('list', '/api/atlas/v2/groups/{groupId}/clusters/operations')).not.toEqual(
         generateOperationID('list', '/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/operations')
+      );
+      expect(
+        generateOperationID('get', '/api/atlas/v2/groups/{groupId}/clusters/operations/{operationId}')
+      ).not.toEqual(
+        generateOperationID('get', '/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/operations/{operationId}')
       );
     });
 
     it('should not preserve the parent plural for other operations paths', () => {
       // the parent is a single resource, so the existing singularization applies
       expect(generateOperationID('list', '/api/atlas/v2/groups/{groupId}/operations')).toEqual('listGroupOperations');
-      // 'operations' is not the trailing section
-      expect(generateOperationID('get', '/api/atlas/v2/groups/{groupId}/clusters/operations/{operationId}')).toEqual(
-        'getGroupClusterOperation'
+      // 'operations' is not the trailing resource section
+      expect(generateOperationID('list', '/api/atlas/v2/groups/{groupId}/clusters/operations/logs')).toEqual(
+        'listGroupClusterOperationLogs'
       );
       // no parent resource to scope to
       expect(generateOperationID('list', '/api/atlas/v2/operations')).toEqual('listOperations');
       // multi-word custom methods append their own trailing noun, so the parent is singularized as before
       expect(generateOperationID('listPending', '/api/atlas/v2/groups/{groupId}/clusters/operations')).toEqual(
         'listGroupClusterOperationPending'
+      );
+    });
+
+    it('should not affect operation IDs for non-operations paths', () => {
+      // nested resource collection
+      expect(generateOperationID('list', '/api/atlas/v2/groups/{groupId}/clusters')).toEqual('listGroupClusters');
+      // single resource
+      expect(generateOperationID('get', '/api/atlas/v2/groups/{groupId}/clusters/{clusterName}')).toEqual(
+        'getGroupCluster'
+      );
+      // multi-word custom method
+      expect(generateOperationID('addNode', '/api/atlas/v2/groups/{groupId}/clusters/{clusterName}')).toEqual(
+        'addGroupClusterNode'
+      );
+      // legacy custom method
+      expect(generateOperationID('', '/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries')).toEqual(
+        'restartGroupClusterPrimaries'
       );
     });
 

--- a/tools/spectral/ipa/__tests__/utils/operationIdGeneration.test.js
+++ b/tools/spectral/ipa/__tests__/utils/operationIdGeneration.test.js
@@ -29,6 +29,35 @@ describe('tools/spectral/ipa/utils/operationIdGeneration.js', () => {
       expect(generateOperationID('grant', '/api/atlas/v2/groups/{groupId}/access')).toEqual('grantGroupAccess');
     });
 
+    it('should preserve the resource scope of trailing operations paths', () => {
+      // the collection-scoped path keeps the parent plural, the instance-scoped path keeps it singular,
+      // so that the two Operations resources do not share an operation ID
+      expect(generateOperationID('list', '/api/atlas/v2/groups/{groupId}/clusters/operations')).toEqual(
+        'listGroupClustersOperations'
+      );
+      expect(generateOperationID('list', '/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/operations')).toEqual(
+        'listGroupClusterOperations'
+      );
+      expect(generateOperationID('list', '/api/atlas/v2/groups/{groupId}/clusters/operations')).not.toEqual(
+        generateOperationID('list', '/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/operations')
+      );
+    });
+
+    it('should not preserve the parent plural for other operations paths', () => {
+      // the parent is a single resource, so the existing singularization applies
+      expect(generateOperationID('list', '/api/atlas/v2/groups/{groupId}/operations')).toEqual('listGroupOperations');
+      // 'operations' is not the trailing section
+      expect(generateOperationID('get', '/api/atlas/v2/groups/{groupId}/clusters/operations/{operationId}')).toEqual(
+        'getGroupClusterOperation'
+      );
+      // no parent resource to scope to
+      expect(generateOperationID('list', '/api/atlas/v2/operations')).toEqual('listOperations');
+      // multi-word custom methods append their own trailing noun, so the parent is singularized as before
+      expect(generateOperationID('listPending', '/api/atlas/v2/groups/{groupId}/clusters/operations')).toEqual(
+        'listGroupClusterOperationPending'
+      );
+    });
+
     it('should split camelCase method names', () => {
       expect(generateOperationID('addNode', '/groups/{groupId}/clusters/{clusterName}')).toEqual('addGroupClusterNode');
       expect(generateOperationID('get', '/api/atlas/v2/groups/byName/{groupName}')).toEqual('getGroupByName');

--- a/tools/spectral/ipa/rulesets/IPA-104.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-104.yaml
@@ -104,6 +104,7 @@ rules:
       The Operation ID must start with the verb “get” and should be followed by a noun or compound noun.
       The noun(s) in the Operation ID should be the collection identifiers from the resource identifier in singular form.
       If the resource is a singleton resource, the last noun may be the plural form of the collection identifier.
+      For a collection-scoped Operations resource, such as '/clusters/operations/{operationId}', the parent noun is in plural form, so that the Operation ID differs from the one for the instance-scoped Operations resource, such as '/clusters/{clusterName}/operations/{operationId}'.
 
       ##### Implementation details
       Rule checks for the following conditions:

--- a/tools/spectral/ipa/rulesets/IPA-105.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-105.yaml
@@ -83,6 +83,7 @@ rules:
     description: |
       The Operation ID must start with the verb “list” and should be followed by a noun or compound noun.
       The noun(s) in the Operation ID should be the collection identifiers from the resource identifier in singular form, where the last noun is in plural form.
+      For a collection-scoped Operations resource, such as '/clusters/operations', the parent noun is also in plural form, so that the Operation ID differs from the one for the instance-scoped Operations resource, such as '/clusters/{clusterName}/operations'.
 
       ##### Implementation details
       Rule checks for the following conditions:

--- a/tools/spectral/ipa/rulesets/README.md
+++ b/tools/spectral/ipa/rulesets/README.md
@@ -242,6 +242,7 @@ The response body of the List method should consist of the same resource object 
  ![error](https://img.shields.io/badge/error-red) 
 The Operation ID must start with the verb “list” and should be followed by a noun or compound noun.
 The noun(s) in the Operation ID should be the collection identifiers from the resource identifier in singular form, where the last noun is in plural form.
+For a collection-scoped Operations resource, such as '/clusters/operations', the parent noun is also in plural form, so that the Operation ID differs from the one for the instance-scoped Operations resource, such as '/clusters/{clusterName}/operations'.
 
 ##### Implementation details
 Rule checks for the following conditions:

--- a/tools/spectral/ipa/rulesets/README.md
+++ b/tools/spectral/ipa/rulesets/README.md
@@ -152,6 +152,7 @@ Rule checks for the following conditions:
 The Operation ID must start with the verb “get” and should be followed by a noun or compound noun.
 The noun(s) in the Operation ID should be the collection identifiers from the resource identifier in singular form.
 If the resource is a singleton resource, the last noun may be the plural form of the collection identifier.
+For a collection-scoped Operations resource, such as '/clusters/operations/{operationId}', the parent noun is in plural form, so that the Operation ID differs from the one for the instance-scoped Operations resource, such as '/clusters/{clusterName}/operations/{operationId}'.
 
 ##### Implementation details
 Rule checks for the following conditions:

--- a/tools/spectral/ipa/rulesets/functions/utils/operationIdGeneration.js
+++ b/tools/spectral/ipa/rulesets/functions/utils/operationIdGeneration.js
@@ -99,10 +99,13 @@ function deriveActionVerb(method) {
 }
 
 /**
- * Checks if a resource identifier is a collection-scoped Operations resource, i.e. the trailing
- * 'operations' section is attached to a parent resource collection rather than to a single resource.
+ * Checks if a resource identifier is a collection-scoped Operations resource, i.e. the 'operations'
+ * section is attached to a parent resource collection rather than to a single resource. Applies to both
+ * the Operations resource collection and a single Operations resource.
  * '/groups/{groupId}/clusters/operations' returns true
+ * '/groups/{groupId}/clusters/operations/{operationId}' returns true
  * '/groups/{groupId}/clusters/{clusterName}/operations' returns false
+ * '/groups/{groupId}/clusters/{clusterName}/operations/{operationId}' returns false
  * '/operations' returns false
  *
  * @param {string} resourceIdentifier the resource identifier to evaluate, without prefix
@@ -110,6 +113,12 @@ function deriveActionVerb(method) {
  */
 function isCollectionScopedOperationsPath(resourceIdentifier) {
   const sections = resourceIdentifier.split('/').filter((section) => section.length > 0);
+
+  // a single Operations resource ends with the operation identifier, the resource collection does not
+  if (sections.length > 0 && isPathParam(sections[sections.length - 1])) {
+    sections.pop();
+  }
+
   if (sections.length < 2 || sections[sections.length - 1] !== OPERATIONS_SECTION) {
     return false;
   }

--- a/tools/spectral/ipa/rulesets/functions/utils/operationIdGeneration.js
+++ b/tools/spectral/ipa/rulesets/functions/utils/operationIdGeneration.js
@@ -3,6 +3,7 @@ import { isPathParam, removePrefix, isSingleResourceIdentifier } from './resourc
 
 const CAMEL_CASE = /[A-Z]?[a-z]+/g;
 export const CAMEL_CASE_WITH_ABBREVIATIONS = /[A-Z]+(?![a-z0-9])|[A-Z]*[a-z0-9]+/g;
+const OPERATIONS_SECTION = 'operations';
 
 /**
  * Returns IPA Compliant Operation ID.
@@ -39,9 +40,16 @@ export function generateOperationID(method, path, ignoreSingularizationList = []
     nouns.push(method.slice(verb.length));
   }
 
+  // a collection-scoped Operations resource keeps its parent's plural form, so that its operation ID
+  // does not collide with the instance-scoped Operations resource of the same parent
+  const keepParentPlural = isCollectionScopedOperationsPath(resourceIdentifier) && !camelCaseCustomMethod;
+
   let opID = verb;
   for (let i = 0; i < nouns.length - 1; i++) {
-    opID += upperCamelCase(singularize(nouns[i], ignoreSingularizationList));
+    const isParentOfOperations = i === nouns.length - 2;
+    opID += upperCamelCase(
+      keepParentPlural && isParentOfOperations ? nouns[i] : singularize(nouns[i], ignoreSingularizationList)
+    );
   }
 
   // singularize final noun, dependent on resource identifier - leave custom nouns alone
@@ -88,6 +96,24 @@ export function shortenOperationId(operationId) {
  */
 function deriveActionVerb(method) {
   return method.match(CAMEL_CASE)[0];
+}
+
+/**
+ * Checks if a resource identifier is a collection-scoped Operations resource, i.e. the trailing
+ * 'operations' section is attached to a parent resource collection rather than to a single resource.
+ * '/groups/{groupId}/clusters/operations' returns true
+ * '/groups/{groupId}/clusters/{clusterName}/operations' returns false
+ * '/operations' returns false
+ *
+ * @param {string} resourceIdentifier the resource identifier to evaluate, without prefix
+ * @returns {boolean}
+ */
+function isCollectionScopedOperationsPath(resourceIdentifier) {
+  const sections = resourceIdentifier.split('/').filter((section) => section.length > 0);
+  if (sections.length < 2 || sections[sections.length - 1] !== OPERATIONS_SECTION) {
+    return false;
+  }
+  return !isPathParam(sections[sections.length - 2]);
 }
 
 function capitalize(val) {


### PR DESCRIPTION
## Problem

Operations resources with different scopes under the same parent generate the same operationId, so the collection-scoped and instance-scoped variants cannot coexist. This affects both the resource collection and the single resource:

| Path | Before | After |
| --- | --- | --- |
| `/groups/{groupId}/clusters/operations` | `listGroupClusterOperations` | `listGroupClustersOperations` |
| `/groups/{groupId}/clusters/{clusterName}/operations` | `listGroupClusterOperations` | `listGroupClusterOperations` (unchanged) |
| `/groups/{groupId}/clusters/operations/{operationId}` | `getGroupClusterOperation` | `getGroupClustersOperation` |
| `/groups/{groupId}/clusters/{clusterName}/operations/{operationId}` | `getGroupClusterOperation` | `getGroupClusterOperation` (unchanged) |

## Root cause

Verified in `tools/spectral/ipa/rulesets/functions/utils/operationIdGeneration.js`. `generateOperationID` filters path parameters out of the path *before* building the noun list, so both scopes reduce to the same nouns (`groups`, `clusters`, `operations`). The loop over non-final nouns then singularizes `clusters` unconditionally, erasing the only thing that distinguished them. The scope information exists only in the raw path, which the noun list has already discarded.

## Fix

Keep the parent noun in plural form when the `operations` section is attached to a resource collection rather than to a single resource, following the generator's existing convention that plural versus singular parent nouns communicate collection versus instance scope. The existing singular form is retained for instance-scoped paths.

One helper, `isCollectionScopedOperationsPath`, covers both endpoints: it drops a trailing path parameter and then applies the same structural check. The noun index is unaffected by that strip because path parameters are already filtered out of the noun list.

## Why the fix is intentionally narrow

The helper requires all of:

- the trailing resource section is exactly `operations`, ignoring a single trailing path parameter (so `.../operations/logs` is untouched);
- the section preceding `operations` is not a path parameter (this is what distinguishes the two scopes);
- a parent section exists, so a bare `/operations` at the API root is unaffected;
- the method is not a multi-word custom method, which appends its own trailing noun and would shift the parent's index.

General singularization behaviour is unchanged, and no rule function, fixture, or snapshot was modified to accommodate it.

## Compatibility audit

**Zero change to existing operationIds.** I replayed `main`'s generator against this branch's generator over all 319 paths in `openapi/.raw/v2.yaml` × 10 method names (3190 combinations), including the legacy empty-method form, and diffed the results: no differences. The only changed operationIds are the two intended ones in the table above.

There are currently no paths ending in `/operations` in the spec, so this only affects operations being introduced. A repo-wide grep for `ClustersOperation` and `clusters/operations` found no other occurrence — no fixtures, snapshots, or generated documentation encode the affected IDs.

**Atlas CLI:** Atlas CLI derives command names from operationId, but it lives in `mongodb/mongodb-atlas-cli`, not this repo, and this repo owns no Atlas CLI fixtures. Since no existing operationId changes, there is no command rename for it to absorb. The Go CLI in `tools/cli` only splits specs and passes operationIds through verbatim; it is unaffected.

## IPA-104 / IPA-105 impact

Both `xgen-IPA-105-valid-operation-id` and `xgen-IPA-104-valid-operation-id` compare the spec's operationId against this shared generator, so they pick up the new behaviour automatically — no rule function or validation semantics changed.

Both published descriptions stated that only the last noun may be plural, which is now inaccurate for this case, so each gained one sentence documenting the exception (IPA-105 for the resource collection, IPA-104 for the single resource) and `rulesets/README.md` was regenerated via `npm run gen-ipa-docs`.

## Tests

`__tests__/utils/operationIdGeneration.test.js` covers all four paths, explicit assertions that each scoped pair differs, negative cases for every narrowing condition, and a guard that unrelated paths (nested collection, single resource, multi-word custom method, legacy custom method) keep their existing IDs.

| Command | Result |
| --- | --- |
| `npx jest .../operationIdGeneration.test.js` | 13 passed |
| `npx jest IPA104 IPA105` | 14 suites, 61 passed |
| `npx jest` (full suite) | 114 suites, 704 passed |
| `npm run lint-js` | clean |
| `npm run format-check` | clean |
| `npm run ipa-validation` | no errors |

## Note for reviewers

Unrelated and not addressed here: `generateOperationID` throws `TypeError: Cannot read properties of undefined` on paths that reduce to zero nouns (for example `/api/atlas/v2` itself), because `singularize` is called on `undefined`. This is pre-existing on `main` and my compatibility harness had to guard against it. Happy to file it separately.
