### PR TITLE
feat(cli): tag legacy 202 operations as legacy long-running operations

### DIFF
--- a/tools/cli/internal/cli/merge/merge.go
+++ b/tools/cli/internal/cli/merge/merge.go
@@ -25,6 +25,47 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const longRunningOperationExtension = "x-xgen-long-running-operation"
+
+// legacyLongRunningOperationIDs lists the operations that return HTTP 202 but predate IPA-132:
+// they do not follow the long-running operation contract (no Location header, no /operations
+// polling endpoint), so downstream tooling must not treat them as standard long-running
+// operations. They are tagged as legacy instead of being tagged as compliant.
+//
+// The raw spec holds no machine-readable signal that separates these operations from future
+// IPA-132 compliant ones: no response anywhere declares a Location header, no path uses an
+// /operations segment, and the 202 response schemas have nothing in common. Until the upstream
+// service specs mark these operations themselves, this hardcoded denylist is the source of truth.
+var legacyLongRunningOperationIDs = map[string]struct{}{
+	"acceptGroupStreamVpcPeeringConnection":      {},
+	"createGroupClusterIndexRollingIndex":        {},
+	"createGroupCustomDbRoleRole":                {},
+	"createGroupEncryptionAtRestPrivateEndpoint": {},
+	"createOrgBillingCostExplorerUsageProcess":   {},
+	"cutoverGroupLiveMigration":                  {},
+	"deleteGroupCluster":                         {},
+	"deleteGroupClusterOverloadSimulation":       {},
+	"deleteGroupPeer":                            {},
+	"deleteGroupStreamConnection":                {},
+	"deleteGroupStreamPrivateLinkConnection":     {},
+	"deleteGroupStreamVpcPeeringConnection":      {},
+	"deleteGroupStreamWorkspace":                 {},
+	"deleteGroupUserSecurityLdapUserToDnMapping": {},
+	"disableGroupUserSecurityCustomerX509":       {},
+	"rejectGroupStreamVpcPeeringConnection":      {},
+	"updateGroupUserSecurity":                    {},
+}
+
+// longRunningOperationExtensionValue returns the value to publish for an operation returning
+// HTTP 202: true for IPA-132 compliant operations and {"legacy": true} for the operations
+// listed in legacyLongRunningOperationIDs.
+func longRunningOperationExtensionValue(operationID string) any {
+	if _, isLegacy := legacyLongRunningOperationIDs[operationID]; isLegacy {
+		return map[string]any{"legacy": true}
+	}
+	return true
+}
+
 type Opts struct {
 	Merger              openapi.Merger
 	fs                  afero.Fs
@@ -40,6 +81,18 @@ func (o *Opts) Run() error {
 	federated, err := o.Merger.MergeOpenAPISpecs(o.externalPaths)
 	if err != nil {
 		return err
+	}
+
+	for _, pathItem := range federated.Paths.Map() {
+		for _, operation := range pathItem.Operations() {
+			if operation.Responses.Value("202") == nil {
+				continue
+			}
+			if operation.Extensions == nil {
+				operation.Extensions = map[string]any{}
+			}
+			operation.Extensions[longRunningOperationExtension] = longRunningOperationExtensionValue(operation.OperationID)
+		}
 	}
 
 	if o.gitSha != "" {

--- a/tools/cli/internal/cli/merge/merge_test.go
+++ b/tools/cli/internal/cli/merge/merge_test.go
@@ -88,6 +88,54 @@ func TestSuccessfulMergeYaml_Run(t *testing.T) {
 	}
 }
 
+func newOperationWithResponses(operationID string, codes ...string) *openapi3.Operation {
+	responses := openapi3.NewResponses()
+	for _, code := range codes {
+		responses.Set(code, &openapi3.ResponseRef{Value: openapi3.NewResponse().WithDescription("")})
+	}
+	return &openapi3.Operation{OperationID: operationID, Responses: responses}
+}
+
+func TestLongRunningOperationExtension_Run(t *testing.T) {
+	standard := newOperationWithResponses("createSomething", "202")
+	standardWithOtherCodes := newOperationWithResponses("updateSomething", "201", "202")
+	synchronous := newOperationWithResponses("getSomething", "200", "404")
+	legacy := newOperationWithResponses("deleteGroupCluster", "202")
+
+	paths := openapi3.NewPaths()
+	paths.Set("/accepted", &openapi3.PathItem{Post: standard})
+	paths.Set("/mixed", &openapi3.PathItem{Patch: standardWithOtherCodes, Delete: synchronous})
+	paths.Set("/legacy", &openapi3.PathItem{Delete: legacy})
+
+	ctrl := gomock.NewController(t)
+	mockMergerStore := openapi.NewMockMerger(ctrl)
+	opts := &Opts{
+		Merger:        mockMergerStore,
+		basePath:      "base.json",
+		outputPath:    "foas.json",
+		externalPaths: []string{"external.json"},
+		fs:            afero.NewMemMapFs(),
+	}
+
+	mockMergerStore.
+		EXPECT().
+		MergeOpenAPISpecs(opts.externalPaths).
+		Return(&openapi.Spec{
+			OpenAPI: "v3.0.1",
+			Info:    &openapi3.Info{},
+			Tags:    openapi3.Tags{},
+			Paths:   paths,
+		}, nil).
+		Times(1)
+
+	require.NoError(t, opts.Run())
+
+	require.Equal(t, true, standard.Extensions[longRunningOperationExtension])
+	require.Equal(t, true, standardWithOtherCodes.Extensions[longRunningOperationExtension])
+	require.NotContains(t, synchronous.Extensions, longRunningOperationExtension)
+	require.Equal(t, map[string]any{"legacy": true}, legacy.Extensions[longRunningOperationExtension])
+}
+
 func TestNoBaseSpecMerge_PreRun(t *testing.T) {
 	externalPaths := []string{"external.json"}
 	opts := &Opts{


### PR DESCRIPTION
## Summary

Draft. Alternative to #1425. Introduces `x-xgen-long-running-operation` tagging at merge
time and, instead of skipping the known legacy operations, publishes them under the same
extension with a `legacy` marker:

```yaml
# IPA-132 compliant
x-xgen-long-running-operation: true

# legacy pre-IPA-132 202 operation
x-xgen-long-running-operation:
  legacy: true
```

Behavior:

- non-`202` operation → no extension
- standard `202` → `true`
- legacy `202` → `{ legacy: true }`

## How legacy operations are identified

A hardcoded denylist of the 17 `operationId`s, kept in `merge.go`. I looked for a native
signal in the raw spec first and there isn't one:

- **No response anywhere in the spec declares a `Location` header.** The only response header
  names present are `RateLimit-Limit` and `RateLimit-Remaining` (542 responses each), so
  `Location` presence can't distinguish legacy from future-compliant operations.
- **No path contains an `/operations` segment.**
- **The 202 response schemas have nothing in common** — 11 of 17 are null, the rest point at
  6 unrelated schemas.
- Content-type version dates look promising but would misclassify any legacy operation that
  later gains a new version.

The cleaner long-term design is a marker in the upstream service specs
(`x-xgen-legacy-long-running-operation`), letting merge derive the value instead of hardcoding
it. That can't be done from this repo, which only holds generated output — the source specs
come from S3. The denylist decision is isolated in
`longRunningOperationExtensionValue()` so switching to an upstream marker later touches one
function.

## Verified published shape

Ran the built binary over the committed raw spec, then through `foascli filter --env prod`:

```
merged     {'{"legacy": true}': 17, 'true': 1}
filtered   {'{"legacy": true}': 17, 'true': 1}
```

The object-valued extension survives filtering intact in both JSON and YAML. The single
`true` is a synthetic probe operation, not a real one.

## Risk worth discussing

`{ legacy: true }` is **truthy** in JavaScript, Python and Go map-presence checks. A consumer
writing `if (op['x-xgen-long-running-operation'])` will read legacy operations as compliant
and poll them per a contract they don't implement. Since the spec currently contains 17
legacy and 0 compliant operations, a naive consumer would be wrong every time.

Options if that matters: document that the value is `true | { legacy: true }` before any
consumer is written, or emit `{ legacy: false }` for compliant operations so the value type
is uniform and presence can never be mistaken for compliance.

## Testing

`go test ./internal/cli/merge/` — asserts exact shapes for non-202 (absent), standard `202`
(`true`), `201`+`202` (`true`), and legacy `202` (`{legacy: true}`).