### PR TITLE
ci: Fix openapi release retry and failure handlers

### DIFF
--- a/.github/workflows/optional-spec-validations.yml
+++ b/.github/workflows/optional-spec-validations.yml
@@ -69,7 +69,7 @@ jobs:
   failure-handler:
     name: Failure Handler
     needs: [ optional-validations,  retry-handler ]
-    if: ${{ always() && contains(needs.*.result, 'failure') && needs.retry-handler.result == 'skipped' }}
+    if: ${{ always() && contains(needs.*.result, 'failure') && needs.retry-handler.result != 'success' }}
     uses: ./.github/workflows/failure-handler.yml
     with:
       env: ${{ inputs.env }}

--- a/.github/workflows/release-spec-runner.yml
+++ b/.github/workflows/release-spec-runner.yml
@@ -152,7 +152,7 @@ jobs:
   failure-handler:
     name: Failure Handler
     needs: [release-preparation, retry-handler]
-    if: ${{ always() && contains(needs.*.result, 'failure') && needs.retry-handler.result == 'skipped' }}
+    if: ${{ always() && contains(needs.*.result, 'failure') && needs.retry-handler.result != 'success' }}
     uses: ./.github/workflows/failure-handler.yml
     with:
       env: ${{ inputs.env_to_release }}

--- a/.github/workflows/release-spec-v1.yml
+++ b/.github/workflows/release-spec-v1.yml
@@ -96,14 +96,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - env:
-          GH_REPO: ${{ inputs.branch }}
+          GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.api_bot_pat }}
         run: gh workflow run retry-handler.yml -F run_id=${{ github.run_id }}
 
   failure-handler:
     name: Failure Handler
     needs: [retry-handler, release-v1-oas-apis ]
-    if: ${{ always() && contains(needs.*.result, 'failure') && needs.retry-handler.result == 'skipped' }}
+    if: ${{ always() && contains(needs.*.result, 'failure') && needs.retry-handler.result != 'success' }}
     uses: ./.github/workflows/failure-handler.yml
     with:
       env: ${{ inputs.env }}

--- a/.github/workflows/release-spec.yml
+++ b/.github/workflows/release-spec.yml
@@ -243,7 +243,7 @@ jobs:
   failure-handler:
     name: Failure Handler
     needs: [retry-handler, release, release-postman, release-changelog]
-    if: ${{ always() && contains(needs.*.result, 'failure') && needs.retry-handler.result == 'skipped' }}
+    if: ${{ always() && contains(needs.*.result, 'failure') && needs.retry-handler.result != 'success' }}
     uses: ./.github/workflows/failure-handler.yml
     with:
       env: ${{ inputs.env }}


### PR DESCRIPTION
## Proposed changes

OpenAPI release started failing last night due to a secret expiry. This also revealed a few bugs in the retry and failure handlers we have. This PR addresses those:

1. V1 release runner retry handler never succeeded, because the GH_REPO was set to branch instead of repo. Fixed to refer to repo
2. All failure handlers were skipped in case the retry handler itself failed, the failure handler was only set to run if it skipped at attempt >=3. Fixed to run in case retry attempt >=3 OR the retry handler itself was not successful

Secret rotation is handled separately.

_Jira ticket:_ [CLOUDP-437777](https://jira.mongodb.org/browse/CLOUDP-437777)
