### PR TITLE
feat(ipa): forbid custom methods on Operations endpoints

### DIFF
--- a/tools/spectral/ipa/__tests__/IPA132OperationsEndpointMustNotDefineCustomMethods.test.js
+++ b/tools/spectral/ipa/__tests__/IPA132OperationsEndpointMustNotDefineCustomMethods.test.js
@@ -1,0 +1,104 @@
+import testRule from './__helpers__/testRule';
+import { DiagnosticSeverity } from '@stoplight/types';
+
+const ERROR_MESSAGE =
+  'Operations endpoints must not define custom methods. Control actions require mutating methods, which the read-only Operations resource does not allow.';
+
+testRule('xgen-IPA-132-operations-endpoint-must-not-define-custom-methods', [
+  {
+    name: 'valid Operations endpoints without custom methods',
+    document: {
+      paths: {
+        '/api/atlas/v2/resourceName/operations': {
+          get: {},
+        },
+        '/api/atlas/v2/resourceName/operations/{operationId}': {
+          get: {},
+        },
+      },
+    },
+    errors: [],
+  },
+  {
+    name: 'custom methods on other resources are ignored',
+    document: {
+      paths: {
+        '/api/atlas/v2/resourceName/{pathParam}:customMethod': {
+          post: {},
+        },
+        '/api/atlas/v2/resourceName:search': {
+          post: {},
+        },
+      },
+    },
+    errors: [],
+  },
+  {
+    name: 'invalid custom method on the Operations collection',
+    document: {
+      paths: {
+        '/api/atlas/v2/resourceName/operations:purge': {
+          post: {},
+        },
+      },
+    },
+    errors: [
+      {
+        code: 'xgen-IPA-132-operations-endpoint-must-not-define-custom-methods',
+        message: ERROR_MESSAGE,
+        path: ['paths', '/api/atlas/v2/resourceName/operations:purge'],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
+  {
+    name: 'invalid custom method on a single Operation',
+    document: {
+      paths: {
+        '/api/atlas/v2/resourceName/operations/{operationId}:cancel': {
+          post: {},
+        },
+      },
+    },
+    errors: [
+      {
+        code: 'xgen-IPA-132-operations-endpoint-must-not-define-custom-methods',
+        message: ERROR_MESSAGE,
+        path: ['paths', '/api/atlas/v2/resourceName/operations/{operationId}:cancel'],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
+  {
+    name: 'invalid custom method on an instance-scoped Operations endpoint',
+    document: {
+      paths: {
+        '/api/atlas/v2/resourceName/{pathParam}/operations/{operationId}:cancel': {
+          post: {},
+        },
+      },
+    },
+    errors: [
+      {
+        code: 'xgen-IPA-132-operations-endpoint-must-not-define-custom-methods',
+        message: ERROR_MESSAGE,
+        path: ['paths', '/api/atlas/v2/resourceName/{pathParam}/operations/{operationId}:cancel'],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
+  {
+    name: 'invalid custom methods with exceptions',
+    document: {
+      paths: {
+        '/api/atlas/v2/resourceName/operations/{operationId}:cancel': {
+          post: {},
+          'x-xgen-IPA-exception': {
+            'xgen-IPA-132-operations-endpoint-must-not-define-custom-methods': 'reason',
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+]);

--- a/tools/spectral/ipa/rulesets/IPA-132.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-132.yaml
@@ -14,6 +14,7 @@ functions:
   - IPA132OperationsShouldExposeStatusFields
   - IPA132GetMethodMustNotBeLro
   - IPA132ListMethodMustNotBeLro
+  - IPA132OperationsEndpointMustNotDefineCustomMethods
 
 aliases:
   OperationResponseSchema:
@@ -325,3 +326,25 @@ rules:
     given: '#GetOperationObject'
     then:
       function: IPA132ListMethodMustNotBeLro
+
+  xgen-IPA-132-operations-endpoint-must-not-define-custom-methods:
+    description: |
+      Operations endpoints must not define custom methods. Control actions require mutating
+      methods, which the read-only Operations resource does not allow.
+
+      ##### Implementation details
+      Rule checks for the following conditions:
+
+        - Applies to custom method paths (`:customMethod`) whose resource identifier, the part
+          before the colon, is an Operations endpoint, i.e. ends with an `operations` segment or
+          an `operations/{operationId}` suffix
+        - Any custom method attached to the Operations collection or to a single Operation is a
+          violation
+        - Paths with `x-xgen-IPA-exception` for this rule are excluded from validation
+
+    message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-132-operations-endpoint-must-not-define-custom-methods'
+    severity: warn
+    given: $.paths
+    then:
+      field: '@key'
+      function: IPA132OperationsEndpointMustNotDefineCustomMethods

--- a/tools/spectral/ipa/rulesets/README.md
+++ b/tools/spectral/ipa/rulesets/README.md
@@ -1614,6 +1614,22 @@ Rule checks for the following conditions:
     data, so the response is returned within the request cycle
   - Operations with `x-xgen-IPA-exception` for this rule are excluded from validation
 
+#### xgen-IPA-132-operations-endpoint-must-not-define-custom-methods
+
+ ![warn](https://img.shields.io/badge/warning-yellow) 
+Operations endpoints must not define custom methods. Control actions require mutating
+methods, which the read-only Operations resource does not allow.
+
+##### Implementation details
+Rule checks for the following conditions:
+
+  - Applies to custom method paths (`:customMethod`) whose resource identifier, the part
+    before the colon, is an Operations endpoint, i.e. ends with an `operations` segment or
+    an `operations/{operationId}` suffix
+  - Any custom method attached to the Operations collection or to a single Operation is a
+    violation
+  - Paths with `x-xgen-IPA-exception` for this rule are excluded from validation
+
 
 
 

--- a/tools/spectral/ipa/rulesets/functions/IPA132OperationsEndpointMustNotDefineCustomMethods.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA132OperationsEndpointMustNotDefineCustomMethods.js
@@ -1,0 +1,30 @@
+import { evaluateAndCollectAdoptionStatus } from './utils/collectionUtils.js';
+import { isCustomMethodIdentifier, stripCustomMethodName } from './utils/resourceEvaluation.js';
+import { isOperationsPath } from './utils/longRunningOperations.js';
+
+const ERROR_MESSAGE =
+  'Operations endpoints must not define custom methods. Control actions require mutating methods, which the read-only Operations resource does not allow.';
+
+/**
+ * Checks that Operations endpoints defined by IPA-132 do not define custom methods, i.e. no
+ * custom method path is attached to the Operations collection or to a single Operation.
+ *
+ * @param {string} input - The path key from the OpenAPI spec
+ * @param {object} _ - Unused
+ * @param {object} context - The context object containing the path, documentInventory and rule
+ */
+export default (input, _, { path, documentInventory, rule }) => {
+  const ruleName = rule.name;
+  const oas = documentInventory.resolved;
+
+  if (!isCustomMethodIdentifier(input)) {
+    return;
+  }
+
+  const resourceIdentifier = stripCustomMethodName(input);
+  if (!isOperationsPath(resourceIdentifier)) {
+    return;
+  }
+
+  return evaluateAndCollectAdoptionStatus([{ path, message: ERROR_MESSAGE }], ruleName, oas.paths[input], path);
+};


### PR DESCRIPTION
## Proposed changes

This PR adds the IPA-132 rule forbidding custom methods on Operations endpoints. The Operations resource is read-only, and control actions require mutating methods, so any `:customMethod` path attached to an Operations endpoint is a violation.

_Jira ticket:_ CLOUDP-435356

### Rules added

At `warn` severity, given `$.paths` with `@key`:

| Rule | Checks |
| --- | --- |
| `xgen-IPA-132-operations-endpoint-must-not-define-custom-methods` | Any custom method path (`:customMethod`) whose resource identifier is an Operations endpoint — the Operations collection (`.../operations`) or a single Operation (`.../operations/{operationId}`) — is a violation |

Paths with `x-xgen-IPA-exception` for the rule are excluded from validation. The rule name matches the guideline added in mongodb/ipa#126.

### Testing

- Valid Operations endpoints, custom methods on non-Operations resources (ignored), custom methods on the Operations collection and on a single Operation in both the collection-scoped and instance-scoped forms (flagged with exact message and path), and violation-with-exception (suppressed). There is no compliant-with-exception case: every path the rule selects is a violation by definition.
- Full suite: 129 suites / 811 tests pass. `gen-ipa-docs`, prettier and eslint clean.
- `spectral lint openapi/.raw/v2.yaml` with the full ruleset: 0 `xgen-IPA-132-*` findings — no custom methods exist on Operations endpoints in the current spec.

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
