### PR TITLE
fix(ipa): correct parent-resource check in resourceBelongsToSingleParent

### DIFF
--- a/tools/spectral/ipa/__tests__/utils/resourceEvaluation.test.js
+++ b/tools/spectral/ipa/__tests__/utils/resourceEvaluation.test.js
@@ -7,6 +7,7 @@ import {
   isRootLevelResource,
   isSingleResourceIdentifier,
   isSingletonResource,
+  resourceBelongsToSingleParent,
 } from '../../rulesets/functions/utils/resourceEvaluation';
 
 const resource = {
@@ -606,6 +607,40 @@ describe('tools/spectral/ipa/rulesets/functions/utils/resourceEvaluation.js', ()
       expect(isRootLevelResource('/api/atlas/v2/resourceName/childResource/{id}')).toBe(false);
       expect(isRootLevelResource('/api/atlas/v2/resourceName/operations')).toBe(false);
       expect(isRootLevelResource('/api/atlas/v2/resourceName/{pathParam}/operations/{operationId}')).toBe(false);
+    });
+  });
+
+  describe('resourceBelongsToSingleParent', () => {
+    it('recognizes nested collection paths', () => {
+      expect(resourceBelongsToSingleParent('/groups/{groupId}/clusters')).toBe(true);
+      expect(resourceBelongsToSingleParent('/api/atlas/v2/groups/{groupId}/clusters')).toBe(true);
+      expect(resourceBelongsToSingleParent('/api/atlas/v2/unauth/groups/{groupId}/clusters')).toBe(true);
+      expect(resourceBelongsToSingleParent('/groups/{groupId}/clusters/{clusterName}/processArgs')).toBe(true);
+    });
+
+    it('recognizes nested instance paths', () => {
+      expect(resourceBelongsToSingleParent('/groups/{groupId}/clusters/{clusterId}')).toBe(true);
+      expect(resourceBelongsToSingleParent('/groups/{g}/clusters/{c}/processes/{p}')).toBe(true);
+    });
+
+    it('rejects root-level resources', () => {
+      expect(resourceBelongsToSingleParent('/groups')).toBe(false);
+      expect(resourceBelongsToSingleParent('/groups/{groupId}')).toBe(false);
+      expect(resourceBelongsToSingleParent('/api/atlas/v2/groups/{groupId}')).toBe(false);
+    });
+
+    it('rejects resources nested under a non-parameterized segment', () => {
+      expect(resourceBelongsToSingleParent('/groups/settings')).toBe(false);
+      expect(resourceBelongsToSingleParent('/groups/settings/{settingId}')).toBe(false);
+    });
+
+    it('handles paths that are only the API prefix', () => {
+      expect(resourceBelongsToSingleParent('/api/atlas/v2')).toBe(true);
+      expect(resourceBelongsToSingleParent('/api/atlas/v2/unauth')).toBe(true);
+    });
+
+    it('rejects consecutive path params', () => {
+      expect(resourceBelongsToSingleParent('/a/{b}/{c}')).toBe(false);
     });
   });
 });

--- a/tools/spectral/ipa/rulesets/functions/utils/resourceEvaluation.js
+++ b/tools/spectral/ipa/rulesets/functions/utils/resourceEvaluation.js
@@ -207,32 +207,27 @@ export function getResourcePathItems(resourceCollectionPath, allPathItems) {
 /**
  * Checks whether a resource belongs to one parent resource.
  * For example, '/resource' returns false, '/resource/{id}/child' returns true.
+ * Instance paths are normalized to their collection path first, so
+ * '/parent/{parentId}/child/{childId}' returns true.
  *
  * @param {string} resourcePath a path for a resource
  * @returns {boolean}
  */
-function resourceBelongsToSingleParent(resourcePath) {
+export function resourceBelongsToSingleParent(resourcePath) {
   // Ignore /api/atlas/v2 and /api/atlas/v2/unauth
   const path = removePrefix(resourcePath);
   if (path === '') {
     return true;
   }
 
-  let resourcePathSections = path.split('/');
-  if (resourcePathSections[0] === '') {
-    resourcePathSections.shift();
+  const sections = path.split('/').filter((section) => section.length > 0);
+  // Normalize an instance path down to its collection path, so that
+  // '/parent/{parentId}/child/{childId}' is evaluated as '/parent/{parentId}/child'
+  if (sections.length > 0 && isPathParam(sections[sections.length - 1])) {
+    sections.pop();
   }
-  if (resourcePathSections.length < 2) {
-    return false;
-  }
-  if (isPathParam(resourcePathSections[resourcePathSections.length - 1])) {
-    resourcePathSections = resourcePathSections.slice(0, resourcePathSections.length - 2);
-  }
-  if (resourcePathSections.length === 1) {
-    return false;
-  }
-  const parentResourceSection = resourcePathSections[resourcePathSections.length - 2];
-  return isPathParam(parentResourceSection);
+  // The resource name is last, so the section before it holds the parent's id if there is a parent
+  return sections.length > 1 && isPathParam(sections[sections.length - 2]);
 }
 
 // TODO move prefixes to be rule arguments


### PR DESCRIPTION
## Proposed changes

`resourceBelongsToSingleParent` normalizes an instance path down to its collection path before checking whether the segment preceding the resource name is a path parameter, but the slice removed **two** segments instead of one. That left the array still ending in a path parameter and put a plain resource name in the `length - 2` slot, so the function returned `false` for every instance path:

| Input (after prefix strip) | Before | After |
| --- | --- | --- |
| `/groups/{groupId}/clusters/{clusterId}` | `false` | `true` |
| `/groups/{g}/clusters/{c}/processes/{p}` | `false` | `true` |
| `/groups/{groupId}` | throws `TypeError: Cannot read properties of undefined (reading 'startsWith')` | `false` |

The throw happened because the slice emptied the array, so `resourcePathSections[length - 2]` was `undefined` and `isPathParam` called `.startsWith` on it.

Changes:

- Drop one segment with `pop()` instead of two.
- Simplify the surrounding guards. The two length checks existed only to keep the indexing safe and are subsumed by a single bounds check on the final comparison. Splitting now filters empty segments, matching the idiom already used in `isRootLevelResource` and `longRunningOperations`.
- Export the function so it can be unit tested directly, and add cases for nested collections and instances, root-level rejection, non-parameterized parents, prefix-only paths, and consecutive path params.

**No change to rule output.** The only caller is `isSingletonResource`, which always passes a resource *collection* identifier — a path that by definition does not end in a path parameter — so the affected branch was never taken. This is a latent-correctness fix; the full `tools/spectral/ipa` suite passes unchanged (127 suites, 811 tests).

_Jira ticket:_ CLOUDP-438303

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works

### Changes to Spectral
- [x] I have read the [README](../tools/spectral/README.md) file for Spectral Updates
