### PR TITLE
chore: Include tools/foas in Dependabot automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,14 @@ updates:
     open-pull-requests-limit: 20
     commit-message:
       prefix: "chore"
+  - package-ecosystem: gomod
+    directory: "/tools/foas"
+    schedule:
+      interval: weekly
+      day: tuesday
+    open-pull-requests-limit: 20
+    commit-message:
+      prefix: "chore"
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
## Proposed changes

`tools/foas` was not included in Dependabot automation. This adds it.
