### PR TITLE
feat(ipa): require long-running operations to expose an Operations endpoint

### DIFF
--- a/tools/spectral/ipa/__tests__/IPA132LrosMustExposeAnOperationsEndpoint.test.js
+++ b/tools/spectral/ipa/__tests__/IPA132LrosMustExposeAnOperationsEndpoint.test.js
@@ -1,0 +1,354 @@
+import testRule from './__helpers__/testRule';
+import { DiagnosticSeverity } from '@stoplight/types';
+
+const lroExtension = { 'x-xgen-long-running-operation': { legacy: false } };
+const legacyLroExtension = { 'x-xgen-long-running-operation': { legacy: true } };
+
+const lroPost = {
+  ...lroExtension,
+  responses: {
+    202: {
+      headers: {
+        Location: {
+          schema: { type: 'string', format: 'uri' },
+        },
+      },
+    },
+  },
+};
+
+const operationsEndpoints = {
+  '/api/atlas/v2/resourceName/operations': {
+    get: {},
+  },
+  '/api/atlas/v2/resourceName/operations/{operationId}': {
+    get: {},
+  },
+};
+
+testRule('xgen-IPA-132-lros-must-expose-an-operations-endpoint', [
+  {
+    name: 'valid collection-level long-running operation with Operations endpoints',
+    document: {
+      paths: {
+        '/api/atlas/v2/resourceName': {
+          post: lroPost,
+        },
+        ...operationsEndpoints,
+      },
+    },
+    errors: [],
+  },
+  {
+    name: 'valid instance-level long-running operation with instance Operations endpoints',
+    document: {
+      paths: {
+        '/api/atlas/v2/resourceName/{pathParam}': {
+          delete: lroPost,
+        },
+        '/api/atlas/v2/resourceName/{pathParam}/operations': {
+          get: {},
+        },
+        '/api/atlas/v2/resourceName/{pathParam}/operations/{operationId}': {
+          get: {},
+        },
+      },
+    },
+    errors: [],
+  },
+  {
+    name: 'valid instance-level long-running operation with Operations endpoints',
+    document: {
+      paths: {
+        '/api/atlas/v2/resourceName/{pathParam}': {
+          delete: lroPost,
+        },
+        '/api/atlas/v2/resourceName/{pathParam}/operations': {
+          get: {},
+        },
+        '/api/atlas/v2/resourceName/{pathParam}/operations/{operationId}': {
+          get: {},
+        },
+      },
+    },
+    errors: [],
+  },
+  {
+    name: 'invalid instance-level long-running operation with Operations endpoints only at the parent collection',
+    document: {
+      paths: {
+        '/api/atlas/v2/resourceName/{pathParam}': {
+          delete: lroPost,
+        },
+        ...operationsEndpoints,
+      },
+    },
+    errors: [
+      {
+        code: 'xgen-IPA-132-lros-must-expose-an-operations-endpoint',
+        message:
+          'The long-running operation must expose an Operations endpoint: define /api/atlas/v2/resourceName/{pathParam}/operations and /api/atlas/v2/resourceName/{pathParam}/operations/{operationId}, each with a get method.',
+        path: ['paths', '/api/atlas/v2/resourceName/{pathParam}', 'delete'],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
+  {
+    name: 'valid custom method long-running operation with Operations endpoints',
+    document: {
+      paths: {
+        '/api/atlas/v2/resourceName/{pathParam}:customMethod': {
+          post: lroPost,
+        },
+        '/api/atlas/v2/resourceName/{pathParam}/operations': {
+          get: {},
+        },
+        '/api/atlas/v2/resourceName/{pathParam}/operations/{operationId}': {
+          get: {},
+        },
+      },
+    },
+    errors: [],
+  },
+  {
+    name: 'valid untagged long-running operation with Operations endpoints',
+    document: {
+      paths: {
+        '/api/atlas/v2/resourceName': {
+          post: {
+            responses: {
+              202: {},
+            },
+          },
+        },
+        ...operationsEndpoints,
+      },
+    },
+    errors: [],
+  },
+  {
+    name: 'synchronous operations without a 202 response are ignored',
+    document: {
+      paths: {
+        '/api/atlas/v2/resourceName': {
+          post: {
+            responses: {
+              201: {},
+            },
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+  {
+    // The merge step derives the extension from the 202 and removes it otherwise, so a
+    // hand-authored extension without a 202 does not make an operation long-running
+    name: 'operations tagged without a 202 response are ignored',
+    document: {
+      paths: {
+        '/api/atlas/v2/resourceName': {
+          post: {
+            ...lroExtension,
+            responses: {
+              201: {},
+            },
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+  {
+    name: 'legacy long-running operations are ignored',
+    document: {
+      paths: {
+        '/api/atlas/v2/resourceName': {
+          post: {
+            ...legacyLroExtension,
+            responses: {
+              202: {},
+            },
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+  {
+    name: 'long-running operations on the shared legacy operationId list are ignored',
+    document: {
+      paths: {
+        '/api/atlas/v2/resourceName/{pathParam}': {
+          delete: {
+            operationId: 'deleteGroupCluster',
+            responses: {
+              202: {},
+            },
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+  {
+    name: 'invalid untagged long-running operation without Operations endpoints',
+    document: {
+      paths: {
+        '/api/atlas/v2/resourceName': {
+          post: {
+            responses: {
+              202: {},
+            },
+          },
+        },
+      },
+    },
+    errors: [
+      {
+        code: 'xgen-IPA-132-lros-must-expose-an-operations-endpoint',
+        message:
+          'The long-running operation must expose an Operations endpoint: define /api/atlas/v2/resourceName/operations and /api/atlas/v2/resourceName/operations/{operationId}, each with a get method.',
+        path: ['paths', '/api/atlas/v2/resourceName', 'post'],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
+  {
+    name: 'invalid long-running operation without Operations endpoints',
+    document: {
+      paths: {
+        '/api/atlas/v2/resourceName': {
+          post: lroPost,
+        },
+      },
+    },
+    errors: [
+      {
+        code: 'xgen-IPA-132-lros-must-expose-an-operations-endpoint',
+        message:
+          'The long-running operation must expose an Operations endpoint: define /api/atlas/v2/resourceName/operations and /api/atlas/v2/resourceName/operations/{operationId}, each with a get method.',
+        path: ['paths', '/api/atlas/v2/resourceName', 'post'],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
+  {
+    name: 'invalid long-running operation with an Operations collection that does not define get',
+    document: {
+      paths: {
+        '/api/atlas/v2/resourceName': {
+          post: lroPost,
+        },
+        '/api/atlas/v2/resourceName/operations': {
+          post: {},
+        },
+        '/api/atlas/v2/resourceName/operations/{operationId}': {
+          get: {},
+        },
+      },
+    },
+    errors: [
+      {
+        code: 'xgen-IPA-132-lros-must-expose-an-operations-endpoint',
+        message:
+          'The long-running operation must expose an Operations endpoint: define /api/atlas/v2/resourceName/operations and /api/atlas/v2/resourceName/operations/{operationId}, each with a get method.',
+        path: ['paths', '/api/atlas/v2/resourceName', 'post'],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
+  {
+    name: 'invalid long-running operation with a single Operation endpoint that does not define get',
+    document: {
+      paths: {
+        '/api/atlas/v2/resourceName': {
+          post: lroPost,
+        },
+        '/api/atlas/v2/resourceName/operations': {
+          get: {},
+        },
+        '/api/atlas/v2/resourceName/operations/{operationId}': {
+          delete: {},
+        },
+      },
+    },
+    errors: [
+      {
+        code: 'xgen-IPA-132-lros-must-expose-an-operations-endpoint',
+        message:
+          'The long-running operation must expose an Operations endpoint: define /api/atlas/v2/resourceName/operations and /api/atlas/v2/resourceName/operations/{operationId}, each with a get method.',
+        path: ['paths', '/api/atlas/v2/resourceName', 'post'],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
+  {
+    name: 'invalid long-running operation with only the Operations collection',
+    document: {
+      paths: {
+        '/api/atlas/v2/resourceName': {
+          post: lroPost,
+        },
+        '/api/atlas/v2/resourceName/operations': {
+          get: {},
+        },
+      },
+    },
+    errors: [
+      {
+        code: 'xgen-IPA-132-lros-must-expose-an-operations-endpoint',
+        message:
+          'The long-running operation must expose an Operations endpoint: define /api/atlas/v2/resourceName/operations and /api/atlas/v2/resourceName/operations/{operationId}, each with a get method.',
+        path: ['paths', '/api/atlas/v2/resourceName', 'post'],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
+  {
+    name: 'invalid long-running operations with exceptions',
+    document: {
+      paths: {
+        '/api/atlas/v2/resourceName': {
+          post: {
+            ...lroPost,
+            'x-xgen-IPA-exception': {
+              'xgen-IPA-132-lros-must-expose-an-operations-endpoint': 'reason',
+            },
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+  {
+    name: 'compliant long-running operations do not need an exception',
+    document: {
+      paths: {
+        '/api/atlas/v2/resourceName': {
+          post: {
+            ...lroPost,
+            'x-xgen-IPA-exception': {
+              'xgen-IPA-132-lros-must-expose-an-operations-endpoint': 'reason',
+            },
+          },
+        },
+        ...operationsEndpoints,
+      },
+    },
+    errors: [
+      {
+        code: 'xgen-IPA-132-lros-must-expose-an-operations-endpoint',
+        message: 'This component adopts the rule and does not need an exception. Please remove the exception.',
+        path: [
+          'paths',
+          '/api/atlas/v2/resourceName',
+          'post',
+          'x-xgen-IPA-exception',
+          'xgen-IPA-132-lros-must-expose-an-operations-endpoint',
+        ],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
+]);

--- a/tools/spectral/ipa/rulesets/IPA-132.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-132.yaml
@@ -18,6 +18,7 @@ functions:
   - IPA132LroInitiationMustReturn202AcceptedWithLocation
   - IPA132LroMustNotReturnSuccessStatusCodeOtherThan202
   - IPA132Lro202ResponseMustNotIncludeContent
+  - IPA132LrosMustExposeAnOperationsEndpoint
 
 aliases:
   OperationResponseSchema:
@@ -420,3 +421,34 @@ rules:
     given: $.paths[*][post,put,patch,delete]
     then:
       function: IPA132Lro202ResponseMustNotIncludeContent
+
+  xgen-IPA-132-lros-must-expose-an-operations-endpoint:
+    description: |
+      A long-running operation must expose an Operations endpoint through which clients poll the
+      operation status.
+
+      ##### Implementation details
+      Rule checks for the following conditions:
+
+        - Applies to mutating methods that declare a 202 response; the
+          `x-xgen-long-running-operation` extension is derived from the 202 during the merge
+          step, so the rule behaves identically on merged and per-service specs
+        - Legacy operations that predate IPA-132 are excluded from validation, whether marked
+          `legacy: true` during the merge step or matched by the shared legacy operationId list
+        - Both the Operations collection (`.../operations`) and the single Operation endpoint
+          (`.../operations/{operationId}`) must be defined, nested under the resource path of the
+          long-running operation
+        - Each endpoint must define the `get` method, i.e. List on the Operations collection and
+          Get on the single Operation; the Operations resource is read-only, so `get` is the only
+          method through which clients can poll status
+        - A mutation of a collection must expose the endpoints under the collection path
+          (`/resource/operations`), and a mutation of a single resource under the resource
+          instance path (`/resource/{resourceId}/operations`)
+        - Custom method suffixes are ignored when deriving the resource path
+        - Operations with `x-xgen-IPA-exception` for this rule are excluded from validation
+
+    message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-132-lros-must-expose-an-operations-endpoint'
+    severity: warn
+    given: $.paths[*][post,put,patch,delete]
+    then:
+      function: IPA132LrosMustExposeAnOperationsEndpoint

--- a/tools/spectral/ipa/rulesets/README.md
+++ b/tools/spectral/ipa/rulesets/README.md
@@ -1685,6 +1685,32 @@ Rule checks for the following conditions:
     schema, are allowed
   - Operations with `x-xgen-IPA-exception` for this rule are excluded from validation
 
+#### xgen-IPA-132-lros-must-expose-an-operations-endpoint
+
+ ![warn](https://img.shields.io/badge/warning-yellow) 
+A long-running operation must expose an Operations endpoint through which clients poll the
+operation status.
+
+##### Implementation details
+Rule checks for the following conditions:
+
+  - Applies to mutating methods that declare a 202 response; the
+    `x-xgen-long-running-operation` extension is derived from the 202 during the merge
+    step, so the rule behaves identically on merged and per-service specs
+  - Legacy operations that predate IPA-132 are excluded from validation, whether marked
+    `legacy: true` during the merge step or matched by the shared legacy operationId list
+  - Both the Operations collection (`.../operations`) and the single Operation endpoint
+    (`.../operations/{operationId}`) must be defined, nested under the resource path of the
+    long-running operation
+  - Each endpoint must define the `get` method, i.e. List on the Operations collection and
+    Get on the single Operation; the Operations resource is read-only, so `get` is the only
+    method through which clients can poll status
+  - A mutation of a collection must expose the endpoints under the collection path
+    (`/resource/operations`), and a mutation of a single resource under the resource
+    instance path (`/resource/{resourceId}/operations`)
+  - Custom method suffixes are ignored when deriving the resource path
+  - Operations with `x-xgen-IPA-exception` for this rule are excluded from validation
+
 
 
 

--- a/tools/spectral/ipa/rulesets/functions/IPA132LrosMustExposeAnOperationsEndpoint.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA132LrosMustExposeAnOperationsEndpoint.js
@@ -1,0 +1,57 @@
+import { evaluateAndCollectAdoptionStatus, handleInternalError } from './utils/collectionUtils.js';
+import { isCustomMethodIdentifier, stripCustomMethodName } from './utils/resourceEvaluation.js';
+import { isNonLegacyLongRunningOperation, isSingleOperationPath } from './utils/longRunningOperations.js';
+
+/**
+ * Checks that a long-running operation defined by IPA-132 exposes an Operations endpoint: both the
+ * Operations collection and the single Operation endpoint must be defined, each with the get method
+ * clients poll for status, and nested under the resource that spawns the operations. A mutation of a
+ * collection must expose them under the collection path, a mutation of a single resource under the
+ * resource instance path.
+ *
+ * @param {object} input - The operation object of a mutating method
+ * @param {object} _ - Unused
+ * @param {object} context - The context object containing the path, documentInventory and rule
+ */
+export default (input, _, { path, documentInventory, rule }) => {
+  const ruleName = rule.name;
+  const oas = documentInventory.resolved;
+
+  if (!isNonLegacyLongRunningOperation(input)) {
+    return;
+  }
+
+  const errors = checkViolationsAndReturnErrors(path[1], oas, path, ruleName);
+  return evaluateAndCollectAdoptionStatus(errors, ruleName, input, path);
+};
+
+function checkViolationsAndReturnErrors(resourcePath, oas, path, ruleName) {
+  try {
+    const basePath = isCustomMethodIdentifier(resourcePath) ? stripCustomMethodName(resourcePath) : resourcePath;
+
+    const operationsCollectionPath = `${basePath}/operations`;
+    if (definesGet(oas, operationsCollectionPath) && hasReadableSingleOperationChild(oas, operationsCollectionPath)) {
+      return [];
+    }
+
+    return [
+      {
+        path,
+        message: `The long-running operation must expose an Operations endpoint: define ${basePath}/operations and ${basePath}/operations/{operationId}, each with a get method.`,
+      },
+    ];
+  } catch (e) {
+    return handleInternalError(ruleName, path, e);
+  }
+}
+
+function hasReadableSingleOperationChild(oas, operationsCollectionPath) {
+  return Object.keys(oas.paths).some(
+    (pathKey) =>
+      pathKey.startsWith(`${operationsCollectionPath}/{`) && isSingleOperationPath(pathKey) && definesGet(oas, pathKey)
+  );
+}
+
+function definesGet(oas, pathKey) {
+  return Boolean(oas.paths[pathKey]?.get);
+}


### PR DESCRIPTION
## Proposed changes

This PR adds the last IPA-132 rule: a long-running operation must expose the Operations endpoint clients poll for status.

_Jira ticket:_ CLOUDP-435359

### Rule added

At `warn` severity, given `$.paths[*][post,put,patch,delete]`:

| Rule | Checks |
| --- | --- |
| `xgen-IPA-132-lros-must-expose-an-operations-endpoint` | Both the Operations collection (`.../operations`) and the single Operation endpoint (`.../operations/{operationId}`) are defined under the resource path of the long-running operation |

Resource path resolution: custom method suffixes are stripped before deriving the resource path. A mutation of a collection must expose the endpoints under the collection path (`/resource/operations`), and a mutation of a single resource under the resource instance path (`/resource/{resourceId}/operations`).

### How long-running operations are selected

Through the shared `isNonLegacyLongRunningOperation` helper introduced in #1448 — selection is on the declared 202 response, with legacy operations excluded both by the `legacy: true` marking and by the shared legacy operationId list. No new selection logic.

### Testing

Valid cases for the collection-level, instance-level and custom-method shapes; invalid cases for a missing Operations endpoint, for a collection defined without the single Operation endpoint, and for an instance-level operation whose Operations endpoints sit only at the parent collection; violation-with-exception (suppressed) and compliant-with-exception (flagged as unnecessary); selection cases covering untagged operations declaring a 202 (valid and violating), synchronous operations, operations tagged without a 202, and legacy exclusion via both the `legacy: true` marking and the shared operationId list.

Full suite: 131 suites / 861 tests pass. Prettier clean.

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
