### PR TITLE
chore(ipa): CLOUDP-442116 - backport from MMS

### DIFF
--- a/tools/spectral/ipa/ipa-spectral.yaml
+++ b/tools/spectral/ipa/ipa-spectral.yaml
@@ -45,6 +45,7 @@ overrides:
       - '**#/components/schemas/LegacyAtlasCluster/properties/mongoDBEmployeeAccessGrant' # unable to document exceptions, to be covered by CLOUDP-308286
       - '**#/components/schemas/LegacyAtlasTenantClusterUpgradeRequest/properties/mongoDBEmployeeAccessGrant' # unable to document exceptions, to be covered by CLOUDP-308286
       - '**#/components/schemas/AdvancedAutoScalingSettings/properties/diskGB' # unable to document exceptions, to be covered by CLOUDP-308286
+      - '**#/components/schemas/AutoScalingSettings/properties/diskGB' # same diskGB field as AdvancedAutoScalingSettings; to be covered by CLOUDP-308286
       - '**#/components/schemas/UserSecurity/properties/customerX509' # unable to document exceptions, to be covered by CLOUDP-308286
       - '**#/components/schemas/ApiAtlasClusterDescriptionPreview/properties/mongoDBEmployeeAccessGrant' # unable to document exceptions, to be covered by CLOUDP-308286
     rules:


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ [CLOUDP-442116](https://jira.mongodb.org/browse/CLOUDP-442116)

Closes #1471

The OpenAPI Spec release failed because `AutoScalingSettings/properties/diskGB` was missing from the IPA spectral exceptions in this repo. The field triggers the `xgen-IPA-112-field-names-are-camel-case` rule violation (`diskGB` uses `GB` instead of camelCase) and needs an exception, the same as the already-exempted `AdvancedAutoScalingSettings/properties/diskGB` — it is the same `diskGB` field, just surfaced via a different schema.

This backports the missing exception from `$MMS_HOME/scripts/evergreen/openapi/.ipaspectral.yaml`, which already carries both entries.

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works

### Changes to Spectral
- [x] I have read the [README](../tools/spectral/README.md) file for Spectral Updates

## Further comments

No functional change to linting behaviour for existing specs — this only suppresses a false-positive violation on a pre-existing field that is already tracked for proper resolution under CLOUDP-308286.