### PR TITLE
feat(ipa): IPA-112 excempt trailing abbreviations

### DIFF
--- a/tools/spectral/ipa/__tests__/IPA112FieldNamesAreCamelCase.test.js
+++ b/tools/spectral/ipa/__tests__/IPA112FieldNamesAreCamelCase.test.js
@@ -13,6 +13,13 @@ testRule('xgen-IPA-112-field-names-are-camel-case', [
               firstName: { type: 'string' },
               emailAddress: { type: 'string' },
               phoneNumber: { type: 'string' },
+              diskGB: { type: 'integer' },
+              memoryMB: { type: 'integer' },
+              storageKB: { type: 'integer' },
+              maxSizeGB: { type: 'integer' },
+              diskGBEnabled: { type: 'boolean' },
+              cpuGHz: { type: 'number' },
+              bandwidthMbps: { type: 'integer' },
             },
           },
         },
@@ -54,6 +61,49 @@ testRule('xgen-IPA-112-field-names-are-camel-case', [
       },
     },
     errors: [],
+  },
+  {
+    name: 'invalid examples - UoM abbreviations in invalid positions',
+    document: {
+      components: {
+        schemas: {
+          SchemaName: {
+            properties: {
+              GBSize: { type: 'integer' },
+              DISKGB: { type: 'integer' },
+              diskGBs: { type: 'integer' },
+              diskGBMB: { type: 'integer' },
+            },
+          },
+        },
+      },
+    },
+    errors: [
+      {
+        code: 'xgen-IPA-112-field-names-are-camel-case',
+        message: 'Property "GBSize" must use camelCase format.',
+        path: ['components', 'schemas', 'SchemaName', 'properties', 'GBSize'],
+        severity: DiagnosticSeverity.Error,
+      },
+      {
+        code: 'xgen-IPA-112-field-names-are-camel-case',
+        message: 'Property "DISKGB" must use camelCase format.',
+        path: ['components', 'schemas', 'SchemaName', 'properties', 'DISKGB'],
+        severity: DiagnosticSeverity.Error,
+      },
+      {
+        code: 'xgen-IPA-112-field-names-are-camel-case',
+        message: 'Property "diskGBs" must use camelCase format.',
+        path: ['components', 'schemas', 'SchemaName', 'properties', 'diskGBs'],
+        severity: DiagnosticSeverity.Error,
+      },
+      {
+        code: 'xgen-IPA-112-field-names-are-camel-case',
+        message: 'Property "diskGBMB" must use camelCase format.',
+        path: ['components', 'schemas', 'SchemaName', 'properties', 'diskGBMB'],
+        severity: DiagnosticSeverity.Error,
+      },
+    ],
   },
   {
     name: 'invalid examples',

--- a/tools/spectral/ipa/ipa-spectral.yaml
+++ b/tools/spectral/ipa/ipa-spectral.yaml
@@ -44,8 +44,6 @@ overrides:
       - '**#/components/schemas/ClusterDescription20240805/properties/mongoDBEmployeeAccessGrant' # unable to document exceptions, to be covered by CLOUDP-308286
       - '**#/components/schemas/LegacyAtlasCluster/properties/mongoDBEmployeeAccessGrant' # unable to document exceptions, to be covered by CLOUDP-308286
       - '**#/components/schemas/LegacyAtlasTenantClusterUpgradeRequest/properties/mongoDBEmployeeAccessGrant' # unable to document exceptions, to be covered by CLOUDP-308286
-      - '**#/components/schemas/AdvancedAutoScalingSettings/properties/diskGB' # unable to document exceptions, to be covered by CLOUDP-308286
-      - '**#/components/schemas/AutoScalingSettings/properties/diskGB' # same diskGB field as AdvancedAutoScalingSettings; to be covered by CLOUDP-308286
       - '**#/components/schemas/UserSecurity/properties/customerX509' # unable to document exceptions, to be covered by CLOUDP-308286
       - '**#/components/schemas/ApiAtlasClusterDescriptionPreview/properties/mongoDBEmployeeAccessGrant' # unable to document exceptions, to be covered by CLOUDP-308286
     rules:

--- a/tools/spectral/ipa/rulesets/functions/IPA112FieldNamesAreCamelCase.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA112FieldNamesAreCamelCase.js
@@ -2,6 +2,26 @@ import { casing } from '@stoplight/spectral-functions';
 import { evaluateAndCollectAdoptionStatus, handleInternalError } from './utils/collectionUtils.js';
 import { resolveObject } from './utils/componentUtils.js';
 
+// Units of measure abbreviations that are legitimately uppercase in camelCase field names.
+// e.g. diskGB, memoryMB, storageKB, cpuGHz.
+// The pattern matches a UoM suffix that is preceded by a lowercase letter or digit
+// (i.e. it follows a camelCase word) and is either at the end of the name or followed
+// by an uppercase letter (start of the next camelCase word).
+const UOM_ABBREVIATIONS = ['GB', 'MB', 'KB', 'TB', 'PB', 'GHz', 'MHz', 'KHz', 'Mbps', 'Kbps', 'Gbps', 'Tbps'];
+const UOM_PATTERN = new RegExp(
+  '(?<=[a-z0-9])(' + UOM_ABBREVIATIONS.join('|') + ')(?=[A-Z]|$)',
+  'g',
+);
+
+/**
+ * Normalise known UoM abbreviations so the camelCase check does not reject them.
+ * e.g. "diskGB" → "diskGb", "maxSizeGB" → "maxSizeGb".
+ * The original field name is preserved in the error message.
+ */
+function normaliseUoM(name) {
+  return name.replace(UOM_PATTERN, (m) => m[0] + m.slice(1).toLowerCase());
+}
+
 export default (input, options, { path, documentInventory, rule }) => {
   const ruleName = rule.name;
   const oas = documentInventory.unresolved;
@@ -19,7 +39,7 @@ export default (input, options, { path, documentInventory, rule }) => {
 
 function checkViolationsAndReturnErrors(input, path, ruleName) {
   try {
-    if (casing(input, { type: 'camel', disallowDigits: true })) {
+    if (casing(normaliseUoM(input), { type: 'camel', disallowDigits: true })) {
       const errorMessage = `Property "${input}" must use camelCase format.`;
       return [{ path, message: errorMessage }];
     }


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ [CLOUDP-442116](https://jira.mongodb.org/browse/CLOUDP-442116)

The `xgen-IPA-112-field-names-are-camel-case` rule incorrectly flagged field names that include units-of-measure (UoM) abbreviations such as `GB`, `MB`, `KB`, `TB`, `PB`, `GHz`, `MHz`, `KHz`, `Mbps`, `Kbps`, `Gbps`, `Tbps`. These abbreviations are legitimately uppercase in camelCase field names (e.g. `diskGB`, `memoryMB`, `cpuGHz`) but the underlying `casing()` function treated each uppercase letter as a separate word, causing false-positive violations.

The fix normalises known UoM abbreviations before the camelCase check by lowercasing their trailing letters (e.g. `diskGB` → `diskGb` for validation purposes only; the original name is preserved in any error message). The normalisation only applies when the abbreviation is preceded by a lowercase letter or digit and is followed by an uppercase letter or end-of-string — so invalid cases like `GBSize`, `DISKGB`, `diskGBs`, and `diskGBMB` still correctly fail.

As a result, the two per-field spectral overrides for `AdvancedAutoScalingSettings/properties/diskGB` and `AutoScalingSettings/properties/diskGB` in `ipa-spectral.yaml` are also removed, as they are no longer needed.

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works

### Changes to Spectral
- [x] I have read the [README](../tools/spectral/README.md) file for Spectral Updates

## Further comments

The normalisation is a pre-processing step only — the original field name is always used in the violation message. Known tradeoff: UoM abbreviations that coincide with other acronyms (e.g. `GB` = Great Britain, `MB` = Message Bus) will be incorrectly allowed. This is considered acceptable given the domain context of the Atlas API.