### PR TITLE
fix: Go SDK validation uses the fresh FOAS instead of the stale committed spec

### DIFF
--- a/.github/workflows/required-spec-validations.yml
+++ b/.github/workflows/required-spec-validations.yml
@@ -58,6 +58,10 @@ jobs:
           id: go-sdk-validation
           run: |
             cp -rf "openapi-foas.yaml" "atlas-sdk-go/openapi/atlas-sdk.yaml"
+            # Point the SDK generation pipeline at the freshly built FOAS.
+            # Without this, generate.sh falls back to its default and
+            # validates the stale atlas-api.yaml committed in the SDK repo.
+            export OPENAPI_FILE_NAME="atlas-sdk.yaml"
             pushd atlas-sdk-go
             make -e openapi-pipeline
             popd


### PR DESCRIPTION
## Issue

The "Validate the FOAS can be used with the Go SDK" step copies the freshly built `openapi-foas.yaml` to `atlas-sdk-go/openapi/atlas-sdk.yaml` and runs `make -e openapi-pipeline`, but never exports `OPENAPI_FILE_NAME`. The SDK's `tools/scripts/generate.sh` falls back to its default `atlas-api.yaml` (see https://github.com/mongodb/atlas-sdk-go/blob/897c05e3381d7f0158ca3c7825c7835fbde8d8fe/tools/scripts/generate.sh#L14), so the pipeline transforms and validates the stale spec committed in the SDK repo, and the fresh FOAS is never read. This required check therefore passes even when the new spec would break SDK generation (false-pass gate).

Confirmed in CI logs (e.g. run https://github.com/mongodb/openapi/actions/runs/33871860221): the step prints `Running transformation based on atlas-api.yaml` and its env contains no `OPENAPI_FILE_NAME`.

## Fix

Export `OPENAPI_FILE_NAME="atlas-sdk.yaml"` in the step
## Verification

A Release Runner run on this branch should show `Running transformation based on atlas-sdk.yaml` in the "Run Required Validations" job log.