### PR TITLE
fix: remove dangling $refs after HiddenEnvsFilter deletes hidden schemas

### DIFF
--- a/tools/foas/openapi/filter/hidden_envs.go
+++ b/tools/foas/openapi/filter/hidden_envs.go
@@ -57,7 +57,80 @@ func (f *HiddenEnvsFilter) Apply() error {
 		return nil
 	}
 
-	return f.applyOnSchemas(f.oas.Components.Schemas)
+	if err := f.applyOnSchemas(f.oas.Components.Schemas); err != nil {
+		return err
+	}
+
+	f.removeDanglingSchemaRefs(f.oas.Components.Schemas)
+	return nil
+}
+
+// removeDanglingSchemaRefs removes properties whose $ref (bare or via allOf/anyOf/oneOf)
+// points to a schema deleted by HiddenEnvsFilter.
+func (*HiddenEnvsFilter) removeDanglingSchemaRefs(schemas openapi3.Schemas) {
+	for _, schema := range schemas {
+		if schema == nil || schema.Value == nil {
+			continue
+		}
+		for propName, prop := range schema.Value.Properties {
+			if isDanglingRef(prop, schemas) {
+				log.Printf("Removing property %q because its $ref points to a deleted schema", propName)
+				delete(schema.Value.Properties, propName)
+				continue
+			}
+			if prop == nil || prop.Value == nil {
+				continue
+			}
+			prop.Value.AllOf = filterDanglingRefs(prop.Value.AllOf, schemas)
+			prop.Value.AnyOf = filterDanglingRefs(prop.Value.AnyOf, schemas)
+			prop.Value.OneOf = filterDanglingRefs(prop.Value.OneOf, schemas)
+			if isPropertyEmpty(prop.Value) {
+				log.Printf("Removing property %q because its only type refs were deleted", propName)
+				delete(schema.Value.Properties, propName)
+			}
+		}
+	}
+}
+
+// isDanglingRef reports whether ref is an unresolved $ref to a deleted schema.
+func isDanglingRef(ref *openapi3.SchemaRef, schemas openapi3.Schemas) bool {
+	if ref == nil || ref.Value != nil {
+		return false
+	}
+	if ref.Ref == "" || !strings.HasPrefix(ref.Ref, "#/components/schemas/") {
+		return false
+	}
+	name := strings.TrimPrefix(ref.Ref, "#/components/schemas/")
+	_, exists := schemas[name]
+	return !exists
+}
+
+// filterDanglingRefs drops dangling $ref entries from a SchemaRefs slice.
+func filterDanglingRefs(refs openapi3.SchemaRefs, schemas openapi3.Schemas) openapi3.SchemaRefs {
+	if len(refs) == 0 {
+		return refs
+	}
+	out := refs[:0]
+	for _, ref := range refs {
+		if !isDanglingRef(ref, schemas) {
+			out = append(out, ref)
+		}
+	}
+	return out
+}
+
+// isPropertyEmpty reports whether a schema has no type definition left.
+func isPropertyEmpty(s *openapi3.Schema) bool {
+	if s == nil {
+		return true
+	}
+	if s.Type != nil && len(*s.Type) > 0 {
+		return false
+	}
+	if len(s.Properties) > 0 || s.Items != nil || s.AdditionalProperties.Schema != nil {
+		return false
+	}
+	return len(s.AllOf) == 0 && len(s.AnyOf) == 0 && len(s.OneOf) == 0
 }
 
 func (f *HiddenEnvsFilter) applyOnSchemas(schemas openapi3.Schemas) error {

--- a/tools/foas/openapi/filter/hidden_envs_test.go
+++ b/tools/foas/openapi/filter/hidden_envs_test.go
@@ -1197,3 +1197,108 @@ func getApplyOas() *openapi3.T {
 
 	return oas
 }
+
+func hiddenSchemaRef() *openapi3.SchemaRef {
+	return &openapi3.SchemaRef{Value: &openapi3.Schema{
+		Type: &openapi3.Types{"object"},
+		Extensions: map[string]any{
+			hiddenEnvsExtension: map[string]any{"envs": "stage,prod"},
+		},
+	}}
+}
+
+func strRef() *openapi3.SchemaRef {
+	return &openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{"string"}}}
+}
+
+func buildOAS(schemas openapi3.Schemas) *openapi3.T {
+	return &openapi3.T{
+		OpenAPI:    "3.0.1",
+		Info:       &openapi3.Info{Title: "test", Version: "1.0"},
+		Paths:      &openapi3.Paths{},
+		Components: &openapi3.Components{Schemas: schemas},
+	}
+}
+
+func applyForStage(t *testing.T, oas *openapi3.T) openapi3.Schemas {
+	t.Helper()
+	filter := &HiddenEnvsFilter{oas: oas, metadata: &Metadata{targetEnv: "stage"}}
+	require.NoError(t, filter.Apply())
+	return oas.Components.Schemas
+}
+
+// TestApply_DanglingRefs covers all positions where a $ref to a hidden schema
+// can appear and must be cleaned up.
+func TestApply_DanglingRefs(t *testing.T) {
+	type tcase struct {
+		name    string
+		schemas openapi3.Schemas
+		assert  func(s openapi3.Schemas)
+	}
+	hidden := "#/components/schemas/Hidden"
+	tests := []tcase{
+		{
+			name: "property/allOf wrapper without annotation (real-world: ApiSearchAutoScalingView)",
+			schemas: openapi3.Schemas{
+				"Hidden": hiddenSchemaRef(),
+				"Parent": {Value: &openapi3.Schema{
+					Type: &openapi3.Types{"object"},
+					Properties: openapi3.Schemas{
+						"gone": {Value: &openapi3.Schema{AllOf: openapi3.SchemaRefs{{Ref: hidden}}}},
+						"keep": strRef(),
+					},
+				}},
+			},
+			assert: func(s openapi3.Schemas) {
+				assert.NotContains(t, s, "Hidden")
+				assert.NotContains(t, s["Parent"].Value.Properties, "gone")
+				assert.Contains(t, s["Parent"].Value.Properties, "keep")
+			},
+		},
+		{
+			name: "property/allOf wrapper with annotation on property",
+			schemas: openapi3.Schemas{
+				"Hidden": hiddenSchemaRef(),
+				"Parent": {Value: &openapi3.Schema{
+					Type: &openapi3.Types{"object"},
+					Properties: openapi3.Schemas{
+						"gone": {Value: &openapi3.Schema{
+							AllOf:      openapi3.SchemaRefs{{Ref: hidden}},
+							Extensions: map[string]any{hiddenEnvsExtension: map[string]any{"envs": "stage,prod"}},
+						}},
+						"keep": strRef(),
+					},
+				}},
+			},
+			assert: func(s openapi3.Schemas) {
+				assert.NotContains(t, s, "Hidden")
+				assert.NotContains(t, s["Parent"].Value.Properties, "gone")
+				assert.Contains(t, s["Parent"].Value.Properties, "keep")
+			},
+		},
+		{
+			name: "property/bare $ref without annotation",
+			schemas: openapi3.Schemas{
+				"Hidden": hiddenSchemaRef(),
+				"Parent": {Value: &openapi3.Schema{
+					Type: &openapi3.Types{"object"},
+					Properties: openapi3.Schemas{
+						"gone": {Ref: hidden},
+						"keep": strRef(),
+					},
+				}},
+			},
+			assert: func(s openapi3.Schemas) {
+				assert.NotContains(t, s, "Hidden")
+				assert.NotContains(t, s["Parent"].Value.Properties, "gone")
+				assert.Contains(t, s["Parent"].Value.Properties, "keep")
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.assert(applyForStage(t, buildOAS(tc.schemas)))
+		})
+	}
+}


### PR DESCRIPTION
https://jira.mongodb.org/browse/CLOUDP-443394

## What

When `HiddenEnvsFilter` deletes a schema from `components/schemas`, properties in other schemas that reference it can be left with a dangling `$ref`. The next step that loads the spec calls `ResolveRefsIn`, which crashes with `map key "<SchemaName>" not found`.

Two property shapes are affected:
1. **Bare `$ref`** — `{"\": "#/components/schemas/Hidden"}` with no annotation. After `json.Unmarshal`, `Value == nil`; the existing filter skips it.
2. **`allOf` wrapper** — `{"allOf": [{"\": "..."}]}` with no `x-xgen-hidden-env` on the property itself. After the ref is pruned the property becomes empty and is left behind.

**Root cause in MMS PR #184045:** `ApiSearchAutoScalingView` was annotated `x-xgen-hidden-env: stage,prod` at the class level, but the `autoScaling` field on `ApiSearchDeploymentRequestView` was added without the same annotation. Fixed in MMS by PR #185021 (backported to `v20260909` by PR #185860). This PR makes `foascli` resilient to the same class of mistake.

## Fix

Added `removeDanglingSchemaRefs` called after `applyOnSchemas`. It scans component schema properties and removes any that are a dangling bare `$ref` or an `allOf`/`anyOf`/`oneOf` wrapper that became empty after its refs were pruned.

## Testing

Table-driven test `TestApply_DanglingRefs` covers the three real-world property shapes found in the MMS OAS:
1. `allOf` wrapper without annotation on the property (the original bug)
2. `allOf` wrapper with `x-xgen-hidden-env` on the property (existing behaviour preserved)
3. Bare `$ref` without annotation